### PR TITLE
feat(FE-002): login + signup with security hardening

### DIFF
--- a/app/(auth)/login/login-form.tsx
+++ b/app/(auth)/login/login-form.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+
+export function LoginForm(): React.ReactElement {
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  async function onSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+    setError(null);
+    setPending(true);
+
+    const form = event.currentTarget;
+    const data = new FormData(form);
+
+    try {
+      const res = await fetch("/api/auth/login", {
+        method: "POST",
+        body: data,
+        headers: { Accept: "application/json" },
+      });
+
+      if (res.ok) {
+        window.location.assign("/");
+        return;
+      }
+
+      let message = "Email or password incorrect.";
+      try {
+        const body: unknown = await res.json();
+        if (
+          body &&
+          typeof body === "object" &&
+          "error" in body &&
+          typeof (body as { error: unknown }).error === "string"
+        ) {
+          message = (body as { error: string }).error;
+        }
+      } catch {
+        // ignore JSON parse error, fall back to default
+      }
+      setError(message);
+    } catch {
+      setError("Network error. Try again.");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <form className="space-y-lg" onSubmit={onSubmit} noValidate>
+      <div className="space-y-xs">
+        <label
+          className="text-label-caps uppercase text-on-surface-variant"
+          htmlFor="email"
+        >
+          Email Address
+        </label>
+        <div className="relative">
+          <span className="material-symbols-outlined absolute left-md top-1/2 -translate-y-1/2 text-on-surface-variant text-[18px]">
+            mail
+          </span>
+          <input
+            className="w-full bg-surface-container-low border border-outline-variant focus:border-primary focus:outline-none px-md py-md pl-[44px] text-on-surface text-body-lg transition-all placeholder:text-surface-container-highest"
+            id="email"
+            name="email"
+            placeholder="name@example.com"
+            required
+            type="email"
+            autoComplete="email"
+            disabled={pending}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-xs">
+        <label
+          className="text-label-caps uppercase text-on-surface-variant"
+          htmlFor="password"
+        >
+          Password
+        </label>
+        <div className="relative">
+          <span className="material-symbols-outlined absolute left-md top-1/2 -translate-y-1/2 text-on-surface-variant text-[18px]">
+            lock
+          </span>
+          <input
+            className="w-full bg-surface-container-low border border-outline-variant focus:border-primary focus:outline-none px-md py-md pl-[44px] text-on-surface text-body-lg transition-all placeholder:text-surface-container-highest"
+            id="password"
+            name="password"
+            placeholder="••••••••"
+            required
+            minLength={8}
+            type="password"
+            autoComplete="current-password"
+            disabled={pending}
+          />
+        </div>
+      </div>
+
+      {error ? (
+        <p
+          aria-live="polite"
+          className="text-body-sm text-error border border-error/40 bg-error-container/20 px-md py-sm"
+        >
+          {error}
+        </p>
+      ) : null}
+
+      <div className="pt-md">
+        <button
+          className="w-full bg-primary-container text-on-primary-container hover:bg-primary py-md text-headline-md font-bold uppercase tracking-tight transition-all active:scale-[0.98] disabled:opacity-60"
+          type="submit"
+          disabled={pending}
+        >
+          {pending ? (
+            <span className="material-symbols-outlined animate-spin text-[20px] align-middle">
+              progress_activity
+            </span>
+          ) : (
+            "Sign In"
+          )}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,0 +1,69 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { getCurrentSession } from "@/lib/session";
+import { LoginForm } from "./login-form";
+
+interface LoginPageProps {
+  searchParams: Promise<{ registered?: string }>;
+}
+
+export default async function LoginPage({
+  searchParams,
+}: LoginPageProps): Promise<React.ReactElement> {
+  const { user } = await getCurrentSession();
+  if (user) {
+    redirect("/");
+  }
+
+  const params = await searchParams;
+  const registered = params.registered === "true";
+
+  return (
+    <main
+      className="flex min-h-screen items-center justify-center p-margin-mobile md:p-0"
+      style={{
+        background:
+          "radial-gradient(circle at 50% -20%, #292a2e 0%, #121317 70%)",
+      }}
+    >
+      <div className="w-full max-w-[440px] z-10">
+        <div className="mb-lg text-center">
+          <h1 className="text-headline-lg font-black text-on-background uppercase tracking-tighter">
+            TOURNAMENT PREDICTOR
+          </h1>
+          <p className="text-body-sm text-on-surface-variant mt-xs opacity-60">
+            Office Tournament Pool
+          </p>
+        </div>
+
+        <div className="bg-surface-container border border-outline-variant p-xl shadow-2xl">
+          {registered ? (
+            <p
+              aria-live="polite"
+              className="mb-lg text-body-sm text-on-secondary-container bg-secondary-container px-md py-sm"
+            >
+              Account created. Sign in below.
+            </p>
+          ) : null}
+
+          <LoginForm />
+
+          <div className="text-center pt-lg">
+            <Link
+              className="text-secondary text-label-caps uppercase hover:text-tertiary transition-colors border-b border-transparent hover:border-tertiary pb-1"
+              href="/signup"
+            >
+              Create an account
+            </Link>
+          </div>
+        </div>
+
+        <div className="mt-xl text-center">
+          <p className="text-data-mono uppercase text-on-surface-variant opacity-40">
+            © 2026 Tournament Predictor
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { getCurrentSession } from "@/lib/session";
+import { SignupForm } from "./signup-form";
+
+export default async function SignupPage(): Promise<React.ReactElement> {
+  const { user } = await getCurrentSession();
+  if (user) {
+    redirect("/");
+  }
+
+  return (
+    <main
+      className="min-h-screen flex items-center justify-center p-md"
+      style={{
+        background:
+          "radial-gradient(circle at 50% -20%, #292a2e 0%, #121317 70%)",
+      }}
+    >
+      <div className="w-full max-w-[600px]">
+        <div className="flex flex-col items-center mb-xl">
+          <h1 className="text-headline-lg font-black text-on-background uppercase tracking-tighter mb-xs">
+            TOURNAMENT PREDICTOR
+          </h1>
+        </div>
+
+        <div className="bg-surface-container border border-outline-variant rounded-lg p-lg shadow-2xl relative overflow-hidden">
+          <div className="absolute top-0 left-0 w-full h-[2px] bg-gradient-to-r from-transparent via-primary to-transparent opacity-50" />
+
+          <SignupForm />
+
+          <div className="mt-lg pt-lg border-t border-outline-variant/20 text-center">
+            <p className="text-body-sm text-on-surface-variant">
+              Already part of the league?{" "}
+              <Link className="text-tertiary hover:underline" href="/login">
+                Login here
+              </Link>
+            </p>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/(auth)/signup/signup-form.tsx
+++ b/app/(auth)/signup/signup-form.tsx
@@ -1,0 +1,322 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { DEPARTMENTS, displayDepartment } from "@/lib/data/departments";
+import { TEAMS } from "@/lib/data/teams";
+
+export function SignupForm(): React.ReactElement {
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  async function onSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+    setError(null);
+
+    const form = event.currentTarget;
+    const data = new FormData(form);
+
+    const password = data.get("password");
+    const rePassword = data.get("rePassword");
+    if (
+      typeof password === "string" &&
+      typeof rePassword === "string" &&
+      password !== rePassword
+    ) {
+      setError("Passwords do not match.");
+      return;
+    }
+    if (typeof password === "string" && password.length < 8) {
+      setError("Invalid password");
+      return;
+    }
+
+    const winner = data.get("winner");
+    const secretWinner = data.get("secretWinner");
+    if (
+      typeof winner === "string" &&
+      typeof secretWinner === "string" &&
+      winner === secretWinner
+    ) {
+      setError("Winner and secret winner must differ.");
+      return;
+    }
+
+    setPending(true);
+    try {
+      const res = await fetch("/api/user", {
+        method: "POST",
+        body: data,
+        headers: { Accept: "application/json" },
+      });
+
+      if (res.ok) {
+        window.location.assign("/login?registered=true");
+        return;
+      }
+
+      let message = "Could not create account.";
+      try {
+        const body: unknown = await res.json();
+        if (
+          body &&
+          typeof body === "object" &&
+          "error" in body &&
+          typeof (body as { error: unknown }).error === "string"
+        ) {
+          message = (body as { error: string }).error;
+        }
+      } catch {
+        // ignore parse failure
+      }
+      setError(message);
+    } catch {
+      setError("Network error. Try again.");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <form className="space-y-lg" onSubmit={onSubmit} noValidate>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-md">
+        <div className="space-y-xs">
+          <label
+            className="text-label-caps uppercase text-on-surface-variant block"
+            htmlFor="firstName"
+          >
+            First Name
+          </label>
+          <input
+            className="w-full bg-surface-container-lowest border border-outline-variant rounded text-body-lg p-md text-on-surface focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary transition-all placeholder:opacity-30"
+            id="firstName"
+            name="firstName"
+            placeholder="John"
+            required
+            type="text"
+            autoComplete="given-name"
+            disabled={pending}
+          />
+        </div>
+        <div className="space-y-xs">
+          <label
+            className="text-label-caps uppercase text-on-surface-variant block"
+            htmlFor="lastName"
+          >
+            Last Name
+          </label>
+          <input
+            className="w-full bg-surface-container-lowest border border-outline-variant rounded text-body-lg p-md text-on-surface focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary transition-all placeholder:opacity-30"
+            id="lastName"
+            name="lastName"
+            placeholder="Doe"
+            required
+            type="text"
+            autoComplete="family-name"
+            disabled={pending}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-xs">
+        <label
+          className="text-label-caps uppercase text-on-surface-variant block"
+          htmlFor="username"
+        >
+          Username
+        </label>
+        <div className="relative">
+          <span className="absolute left-md top-1/2 -translate-y-1/2 material-symbols-outlined text-on-surface-variant text-[18px]">
+            person
+          </span>
+          <input
+            className="w-full bg-surface-container-lowest border border-outline-variant rounded text-body-lg p-md pl-[44px] text-on-surface focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary transition-all placeholder:opacity-30"
+            id="username"
+            name="username"
+            placeholder="striker_01"
+            required
+            type="text"
+            autoComplete="username"
+            disabled={pending}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-xs">
+        <label
+          className="text-label-caps uppercase text-on-surface-variant block"
+          htmlFor="email"
+        >
+          Email Address
+        </label>
+        <div className="relative">
+          <span className="absolute left-md top-1/2 -translate-y-1/2 material-symbols-outlined text-on-surface-variant text-[18px]">
+            mail
+          </span>
+          <input
+            className="w-full bg-surface-container-lowest border border-outline-variant rounded text-body-lg p-md pl-[44px] text-on-surface focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary transition-all placeholder:opacity-30"
+            id="email"
+            name="email"
+            placeholder="email@organization.com"
+            required
+            type="email"
+            autoComplete="email"
+            disabled={pending}
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-md">
+        <div className="space-y-xs">
+          <label
+            className="text-label-caps uppercase text-on-surface-variant block"
+            htmlFor="password"
+          >
+            Password
+          </label>
+          <div className="relative">
+            <span className="absolute left-md top-1/2 -translate-y-1/2 material-symbols-outlined text-on-surface-variant text-[18px]">
+              lock
+            </span>
+            <input
+              className="w-full bg-surface-container-lowest border border-outline-variant rounded text-body-lg p-md pl-[44px] text-on-surface focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary transition-all placeholder:opacity-30"
+              id="password"
+              name="password"
+              placeholder="••••••••"
+              required
+              minLength={8}
+              type="password"
+              autoComplete="new-password"
+              disabled={pending}
+            />
+          </div>
+        </div>
+        <div className="space-y-xs">
+          <label
+            className="text-label-caps uppercase text-on-surface-variant block"
+            htmlFor="rePassword"
+          >
+            Repeat Password
+          </label>
+          <div className="relative">
+            <span className="absolute left-md top-1/2 -translate-y-1/2 material-symbols-outlined text-on-surface-variant text-[18px]">
+              lock
+            </span>
+            <input
+              className="w-full bg-surface-container-lowest border border-outline-variant rounded text-body-lg p-md pl-[44px] text-on-surface focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary transition-all placeholder:opacity-30"
+              id="rePassword"
+              name="rePassword"
+              placeholder="••••••••"
+              required
+              minLength={8}
+              type="password"
+              autoComplete="new-password"
+              disabled={pending}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-xs">
+        <label
+          className="text-label-caps uppercase text-on-surface-variant block"
+          htmlFor="department"
+        >
+          Department
+        </label>
+        <select
+          className="w-full bg-surface-container-lowest border border-outline-variant rounded text-body-lg p-md text-on-surface focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary transition-all appearance-none"
+          id="department"
+          name="department"
+          required
+          defaultValue=""
+          disabled={pending}
+        >
+          <option disabled value="">
+            Select location...
+          </option>
+          {DEPARTMENTS.map((d) => (
+            <option key={d} value={d}>
+              {displayDepartment(d)}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-md pt-md border-t border-outline-variant/30">
+        <div className="space-y-xs">
+          <label
+            className="text-label-caps uppercase text-on-surface-variant block"
+            htmlFor="winner"
+          >
+            Tournament Winner
+          </label>
+          <select
+            className="w-full bg-surface-container-lowest border border-outline-variant rounded text-body-lg p-md text-on-surface focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary transition-all"
+            id="winner"
+            name="winner"
+            required
+            defaultValue=""
+            disabled={pending}
+          >
+            <option disabled value="">
+              Select Team
+            </option>
+            {TEAMS.map((t) => (
+              <option key={t.code} value={t.code}>
+                {t.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="space-y-xs">
+          <label
+            className="text-label-caps uppercase text-on-surface-variant block"
+            htmlFor="secretWinner"
+          >
+            Secret Winner
+          </label>
+          <select
+            className="w-full bg-surface-container-lowest border border-outline-variant rounded text-body-lg p-md text-on-surface focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary transition-all"
+            id="secretWinner"
+            name="secretWinner"
+            required
+            defaultValue=""
+            disabled={pending}
+          >
+            <option disabled value="">
+              Select Team
+            </option>
+            {TEAMS.map((t) => (
+              <option key={t.code} value={t.code}>
+                {t.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {error ? (
+        <p
+          aria-live="polite"
+          className="text-body-sm text-error border border-error/40 bg-error-container/20 px-md py-sm"
+        >
+          {error}
+        </p>
+      ) : null}
+
+      <button
+        className="w-full bg-primary-container text-on-primary-container hover:bg-primary py-lg text-label-caps uppercase tracking-widest font-bold transition-all active:scale-[0.98] mt-lg disabled:opacity-60"
+        type="submit"
+        disabled={pending}
+      >
+        {pending ? (
+          <span className="material-symbols-outlined animate-spin text-[18px] align-middle">
+            progress_activity
+          </span>
+        ) : (
+          "Register"
+        )}
+      </button>
+    </form>
+  );
+}

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,0 +1,93 @@
+import { cookies } from "next/headers";
+import { Argon2id } from "oslo/password";
+import { lucia } from "@/lib/auth";
+import { getUserByEmail } from "@/lib/user";
+import { loginSchema } from "@/lib/validation/auth";
+import { checkRateLimit, getClientIp } from "@/lib/rate-limit";
+
+const argon2id = new Argon2id({
+  memorySize: 19456,
+  iterations: 2,
+  tagLength: 32,
+  parallelism: 1,
+});
+
+const DUMMY_HASH =
+  "$argon2id$v=19$m=19456,t=2,p=1$ZHVtbXlzYWx0ZHVtbXlzYWx0$" +
+  "ZHVtbXloYXNoZHVtbXloYXNoZHVtbXloYXNoZHVtbXloYXNoMQ";
+
+const GENERIC_ERROR = "Email or password incorrect.";
+
+function jsonError(message: string, status: number): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function wantsJson(request: Request): boolean {
+  const accept = request.headers.get("accept") ?? "";
+  return accept.includes("application/json");
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const ip = getClientIp(request.headers);
+  const limit = checkRateLimit(ip, "login");
+  if (!limit.ok) {
+    return new Response(
+      JSON.stringify({ error: "Too many requests, try again later." }),
+      {
+        status: 429,
+        headers: {
+          "Content-Type": "application/json",
+          ...(limit.retryAfter
+            ? { "Retry-After": String(limit.retryAfter) }
+            : {}),
+        },
+      },
+    );
+  }
+
+  const formData = await request.formData();
+  const raw = {
+    email: formData.get("email"),
+    password: formData.get("password"),
+  };
+
+  const parsed = loginSchema.safeParse(raw);
+  if (!parsed.success) {
+    const first = parsed.error.issues[0];
+    const message = first?.message ?? "Invalid input";
+    return jsonError(message, 400);
+  }
+
+  const { email, password } = parsed.data;
+  const existing = await getUserByEmail(email);
+
+  if (!existing) {
+    await argon2id.verify(DUMMY_HASH, password);
+    return jsonError(GENERIC_ERROR, 400);
+  }
+
+  const valid = await argon2id.verify(existing.password, password);
+  if (!valid) {
+    return jsonError(GENERIC_ERROR, 400);
+  }
+
+  const session = await lucia.createSession(String(existing.id), {});
+  const sessionCookie = lucia.createSessionCookie(session.id);
+  const cookieStore = await cookies();
+  cookieStore.set(
+    sessionCookie.name,
+    sessionCookie.value,
+    sessionCookie.attributes,
+  );
+
+  if (wantsJson(request)) {
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  return new Response(null, { status: 302, headers: { Location: "/" } });
+}

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,0 +1,23 @@
+import { cookies } from "next/headers";
+import { lucia } from "@/lib/auth";
+import { getCurrentSession } from "@/lib/session";
+
+export async function POST(): Promise<Response> {
+  const { session } = await getCurrentSession();
+  if (session) {
+    await lucia.invalidateSession(session.id);
+  }
+
+  const blank = lucia.createBlankSessionCookie();
+  const cookieStore = await cookies();
+  cookieStore.set(blank.name, blank.value, blank.attributes);
+
+  return new Response(null, { status: 302, headers: { Location: "/login" } });
+}
+
+export function GET(): Response {
+  return new Response(null, {
+    status: 405,
+    headers: { Allow: "POST" },
+  });
+}

--- a/app/api/user/route.ts
+++ b/app/api/user/route.ts
@@ -1,0 +1,120 @@
+import { Argon2id } from "oslo/password";
+import { createUser, getUserByEmail } from "@/lib/user";
+import { signupSchema } from "@/lib/validation/auth";
+import { checkRateLimit, getClientIp } from "@/lib/rate-limit";
+
+const argon2id = new Argon2id({
+  memorySize: 19456,
+  iterations: 2,
+  tagLength: 32,
+  parallelism: 1,
+});
+
+function jsonError(message: string, status: number): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function wantsJson(request: Request): boolean {
+  const accept = request.headers.get("accept") ?? "";
+  return accept.includes("application/json");
+}
+
+const REQUIRED_FIELDS = [
+  "email",
+  "password",
+  "rePassword",
+  "firstName",
+  "lastName",
+  "username",
+  "department",
+  "winner",
+  "secretWinner",
+] as const;
+
+export async function POST(request: Request): Promise<Response> {
+  const ip = getClientIp(request.headers);
+  const limit = checkRateLimit(ip, "signup");
+  if (!limit.ok) {
+    return new Response(
+      JSON.stringify({ error: "Too many requests, try again later." }),
+      {
+        status: 429,
+        headers: {
+          "Content-Type": "application/json",
+          ...(limit.retryAfter
+            ? { "Retry-After": String(limit.retryAfter) }
+            : {}),
+        },
+      },
+    );
+  }
+
+  const formData = await request.formData();
+
+  const missing: string[] = [];
+  for (const field of REQUIRED_FIELDS) {
+    const v = formData.get(field);
+    if (typeof v !== "string" || v.length === 0) {
+      missing.push(field);
+    }
+  }
+  if (missing.length > 0) {
+    return jsonError(
+      `Missing required fields: ${missing.join(", ")}`,
+      400,
+    );
+  }
+
+  const raw = {
+    email: formData.get("email"),
+    password: formData.get("password"),
+    rePassword: formData.get("rePassword"),
+    firstName: formData.get("firstName"),
+    lastName: formData.get("lastName"),
+    username: formData.get("username"),
+    department: formData.get("department"),
+    winner: formData.get("winner"),
+    secretWinner: formData.get("secretWinner"),
+  };
+
+  const parsed = signupSchema.safeParse(raw);
+  if (!parsed.success) {
+    const first = parsed.error.issues[0];
+    const message = first?.message ?? "Invalid input";
+    return jsonError(message, 400);
+  }
+
+  const data = parsed.data;
+
+  const existing = await getUserByEmail(data.email);
+  if (existing) {
+    return jsonError("This email is already registered.", 400);
+  }
+
+  const passwordHash = await argon2id.hash(data.password);
+
+  await createUser({
+    email: data.email,
+    password: passwordHash,
+    firstName: data.firstName,
+    lastName: data.lastName,
+    username: data.username,
+    department: data.department,
+    winner: data.winner,
+    secretWinner: data.secretWinner,
+  });
+
+  if (wantsJson(request)) {
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  return new Response(null, {
+    status: 302,
+    headers: { Location: "/login?registered=true" },
+  });
+}

--- a/lib/data/teams.ts
+++ b/lib/data/teams.ts
@@ -1,0 +1,34 @@
+export const TEAMS = [
+  { code: "ALB", name: "Albanien" },
+  { code: "BEL", name: "Belgien" },
+  { code: "DEU", name: "Deutschland" },
+  { code: "DNK", name: "Dänemark" },
+  { code: "ENG", name: "England" },
+  { code: "FRA", name: "Frankreich" },
+  { code: "GEO", name: "Georgien" },
+  { code: "ITA", name: "Italien" },
+  { code: "HRV", name: "Kroatien" },
+  { code: "NLD", name: "Niederlande" },
+  { code: "AUT", name: "Österreich" },
+  { code: "POL", name: "Polen" },
+  { code: "PRT", name: "Portugal" },
+  { code: "ROU", name: "Rumänien" },
+  { code: "SCO", name: "Schottland" },
+  { code: "CHE", name: "Schweiz" },
+  { code: "SRB", name: "Serbien" },
+  { code: "SVK", name: "Slowakei" },
+  { code: "SVN", name: "Slowenien" },
+  { code: "ESP", name: "Spanien" },
+  { code: "CZE", name: "Tschechien" },
+  { code: "TUR", name: "Türkei" },
+  { code: "UKR", name: "Ukraine" },
+  { code: "HUN", name: "Ungarn" },
+] as const;
+
+export type TeamCode = (typeof TEAMS)[number]["code"];
+
+export const TEAM_CODES: readonly TeamCode[] = TEAMS.map((t) => t.code);
+
+export function isTeamCode(value: string): value is TeamCode {
+  return (TEAM_CODES as readonly string[]).includes(value);
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,12 +1,32 @@
-import Database from "better-sqlite3";
-import { drizzle } from "drizzle-orm/better-sqlite3";
+import Database, { type Database as DatabaseType } from "better-sqlite3";
+import { drizzle, type BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import * as schema from "@/db/schema";
 
-const dbPath = process.env.DATABASE_URL ?? "../shared/db/database.db";
+type Schema = typeof schema;
+type Db = BetterSQLite3Database<Schema>;
 
-const sqlite = new Database(dbPath);
-sqlite.pragma("journal_mode = WAL");
-sqlite.pragma("foreign_keys = ON");
+let _sqlite: DatabaseType | null = null;
+let _db: Db | null = null;
 
-export const db = drizzle(sqlite, { schema });
+function open(): Db {
+  if (_db) return _db;
+  const dbPath = process.env.DATABASE_URL ?? "../shared/db/database.db";
+  _sqlite = new Database(dbPath);
+  _sqlite.pragma("journal_mode = WAL");
+  _sqlite.pragma("foreign_keys = ON");
+  _db = drizzle(_sqlite, { schema });
+  return _db;
+}
+
+export const db = new Proxy({} as Db, {
+  get(_target, prop, receiver) {
+    const instance = open();
+    const value = Reflect.get(instance as object, prop, receiver);
+    if (typeof value === "function") {
+      return value.bind(instance);
+    }
+    return value;
+  },
+});
+
 export default db;

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,44 @@
+const WINDOW_MS = 10 * 60 * 1000;
+const MAX_ATTEMPTS = 5;
+
+type Entry = { count: number; resetAt: number };
+
+const buckets = new Map<string, Entry>();
+
+export interface RateLimitResult {
+  ok: boolean;
+  retryAfter?: number;
+}
+
+export function checkRateLimit(ip: string, bucket: string): RateLimitResult {
+  const key = `${bucket}:${ip}`;
+  const now = Date.now();
+  const entry = buckets.get(key);
+
+  if (!entry || entry.resetAt <= now) {
+    buckets.set(key, { count: 1, resetAt: now + WINDOW_MS });
+    return { ok: true };
+  }
+
+  if (entry.count >= MAX_ATTEMPTS) {
+    return { ok: false, retryAfter: Math.ceil((entry.resetAt - now) / 1000) };
+  }
+
+  entry.count += 1;
+  return { ok: true };
+}
+
+export function resetRateLimit(ip: string, bucket: string): void {
+  buckets.delete(`${bucket}:${ip}`);
+}
+
+export function getClientIp(headers: Headers): string {
+  const xff = headers.get("x-forwarded-for");
+  if (xff) {
+    const first = xff.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  const real = headers.get("x-real-ip");
+  if (real) return real.trim();
+  return "unknown";
+}

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -1,0 +1,28 @@
+import { cookies } from "next/headers";
+import { cache } from "react";
+import type { Session, User } from "lucia";
+import { lucia } from "@/lib/auth";
+
+export const getCurrentSession = cache(
+  async (): Promise<{ user: User; session: Session } | { user: null; session: null }> => {
+    const cookieStore = await cookies();
+    const sessionId = cookieStore.get(lucia.sessionCookieName)?.value ?? null;
+    if (!sessionId) {
+      return { user: null, session: null };
+    }
+    const result = await lucia.validateSession(sessionId);
+    try {
+      if (result.session && result.session.fresh) {
+        const fresh = lucia.createSessionCookie(result.session.id);
+        cookieStore.set(fresh.name, fresh.value, fresh.attributes);
+      }
+      if (!result.session) {
+        const blank = lucia.createBlankSessionCookie();
+        cookieStore.set(blank.name, blank.value, blank.attributes);
+      }
+    } catch {
+      // cookies().set() throws inside Server Components — ignore.
+    }
+    return result;
+  },
+);

--- a/lib/user.ts
+++ b/lib/user.ts
@@ -1,0 +1,24 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { user } from "@/db/schema";
+
+export type DatabaseUser = typeof user.$inferSelect;
+export type NewUser = typeof user.$inferInsert;
+
+export async function getUserByEmail(
+  email: string,
+): Promise<DatabaseUser | undefined> {
+  return db.query.user.findFirst({ where: eq(user.email, email) });
+}
+
+export async function createUser(newUser: NewUser): Promise<number> {
+  const inserted = await db
+    .insert(user)
+    .values(newUser)
+    .returning({ id: user.id });
+  const created = inserted[0];
+  if (!created) {
+    throw new Error("Failed to create user");
+  }
+  return created.id;
+}

--- a/lib/validation/auth.ts
+++ b/lib/validation/auth.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+import { DEPARTMENTS } from "@/lib/data/departments";
+import { TEAM_CODES } from "@/lib/data/teams";
+
+export const loginSchema = z.object({
+  email: z.string().email({ message: "Invalid email" }),
+  password: z.string().min(8, { message: "Invalid password" }),
+});
+
+export type LoginInput = z.infer<typeof loginSchema>;
+
+export const signupSchema = z
+  .object({
+    firstName: z.string().min(1, { message: "firstName" }),
+    lastName: z.string().min(1, { message: "lastName" }),
+    username: z.string().min(1, { message: "username" }),
+    email: z.string().email({ message: "Invalid email" }),
+    password: z.string().min(8, { message: "Invalid password" }),
+    rePassword: z.string().min(8, { message: "Invalid password" }),
+    department: z.enum(DEPARTMENTS, { message: "department" }),
+    winner: z.enum(TEAM_CODES as unknown as [string, ...string[]], {
+      message: "winner",
+    }),
+    secretWinner: z.enum(TEAM_CODES as unknown as [string, ...string[]], {
+      message: "secretWinner",
+    }),
+  })
+  .refine((data) => data.password === data.rePassword, {
+    message: "Passwords do not match.",
+    path: ["rePassword"],
+  })
+  .refine((data) => data.winner !== data.secretWinner, {
+    message: "Winner and secret winner must differ.",
+    path: ["secretWinner"],
+  });
+
+export type SignupInput = z.infer<typeof signupSchema>;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "next": "15.0.4",
     "oslo": "^1.2.1",
     "react": "19.0.0",
-    "react-dom": "19.0.0"
+    "react-dom": "19.0.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       react-dom:
         specifier: 19.0.0
         version: 19.0.0(react@19.0.0)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4.0.0
@@ -2773,6 +2776,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
@@ -5404,3 +5410,5 @@ snapshots:
   wrappy@1.0.2: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@4.4.3: {}


### PR DESCRIPTION
## Summary
- Implements [FE-002](https://github.com/football-betting/workspace/blob/main/tickets/backlog/review/FE-002_login-signup.md): login + signup pages, three API handlers (login, logout, user/signup), Zod validation, in-memory rate-limiter, and the full security hardening list (PW≥8, generic errors with timing parity, explicit Argon2id params, POST-only logout, rate-limit 5/10min/IP).
- One in-scope FE-001 file modification: `lib/db.ts` switched to a lazy Proxy so `next build`'s page-data collection doesn't open SQLite at build time. API-compatible. Rationale in the commit message.

## What's in
- `app/(auth)/login/page.tsx` + `login-form.tsx` (Client)
- `app/(auth)/signup/page.tsx` + `signup-form.tsx` (Client)
- `app/api/auth/login/route.ts` — generic-error parity (dummy-hash verify on user-not-found)
- `app/api/auth/logout/route.ts` — POST 302, GET 405 `Allow: POST`
- `app/api/user/route.ts` — Argon2id (m=19456, t=2, p=1, tagLength 32), Zod schemas, `winner !== secretWinner`, duplicate-email rejection
- `lib/validation/auth.ts`, `lib/rate-limit.ts`, `lib/data/teams.ts`, `lib/user.ts`, `lib/session.ts`
- `lib/db.ts` lazy Proxy (in-scope, see commit message)
- `zod ^4.4.3`

## Reviewer verdict
APPROVE WITH MINOR NOTES (full transcript on the ticket). Auth-boundary deep check passed:
- Disclosure parity ✅ (user-not-found path runs identical Argon2id verify; ~2ms timing delta)
- Cookie flags ✅ (Lucia defaults `httpOnly`/`sameSite=lax`; `secure` in prod)
- CSRF coverage ✅ (middleware matcher covers `/api/*`)
- Rate-limit correctness ✅ (5 allowed, 6th 429 + Retry-After, per-bucket per-IP)
- Argon2id params ✅
- Password never logged or returned

Non-blocking notes:
1. Rate-limiter has no eviction sweep — fine for single-instance, flag for the shared-limiter follow-up
2. `Maintz` typo lives on in `displayDepartment` (FE-001 decision, deferred per spec §16 tech-debt)
3. No automated tests yet (AC didn't require; FE-010 will add them)

## Quality gates
- `pnpm exec tsc --noEmit` — clean
- `pnpm build` — successful (9 static + 3 dynamic routes)
- Icon greps (`<svg`, `dangerouslySetInnerHTML`, forbidden libs) — all 0 matches
- `any` / `as any` / `@ts-ignore` audit — none

## Test plan
- [ ] `pnpm dev` → `/login` renders; submit garbage → "Email or password incorrect." (same wording for unknown email AND wrong password)
- [ ] `/signup` form has Repeat Password; `winner = secretWinner` inline error; password <8 → 400 "Invalid password"
- [ ] After successful signup → `/login?registered=true` with success banner
- [ ] 6 rapid login attempts from one IP → 6th returns 429 with `Retry-After`
- [ ] `curl -X GET http://localhost:3000/api/auth/logout` → 405 `Allow: POST`
- [ ] Cookie inspection: `Set-Cookie` from login has `HttpOnly`, `SameSite=Lax`, `Secure` (only when `NODE_ENV=production`)