### PR TITLE
FE-003: dashboard — live block, upcoming, tip form, ranking sidebar

### DIFF
--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -1,13 +1,65 @@
-export default function Page() {
+import { getCurrentSession } from "@/lib/session";
+import { getLiveMatches, getUpcomingMatches } from "@/lib/match";
+import { getTipByUserAndMatchIds, type TipRow } from "@/lib/tip";
+import { fetchApi } from "@/lib/api";
+import type { RatingResponse } from "@/lib/rating";
+import { LiveBlock } from "@/components/dashboard/LiveBlock";
+import { UpcomingList } from "@/components/dashboard/UpcomingList";
+import { RankingSidebar } from "@/components/dashboard/RankingSidebar";
+import { BottomNav } from "@/components/dashboard/BottomNav";
+import { TopAppBar } from "@/components/dashboard/TopAppBar";
+
+async function loadRating(): Promise<RatingResponse | null> {
+  try {
+    return await fetchApi<RatingResponse>("rating", "table");
+  } catch (error) {
+    console.error("[dashboard] rating API offline:", error);
+    return null;
+  }
+}
+
+export default async function DashboardPage(): Promise<React.ReactElement> {
+  const { user } = await getCurrentSession();
+  if (!user) {
+    throw new Error("Dashboard rendered without a session — auth guard failed");
+  }
+  const userId = Number(user.id);
+
+  const [liveMatches, upcomingMatches, rating] = await Promise.all([
+    getLiveMatches(),
+    getUpcomingMatches(),
+    loadRating(),
+  ]);
+
+  const allMatchIds = [
+    ...liveMatches.map((m) => m.id),
+    ...upcomingMatches.map((m) => m.id),
+  ];
+  const tips = await getTipByUserAndMatchIds(userId, allMatchIds);
+
+  const tipsByMatchId = new Map<number, TipRow>();
+  for (const t of tips) {
+    if (t.matchId !== null && t.matchId !== undefined) {
+      tipsByMatchId.set(t.matchId, t);
+    }
+  }
+
   return (
-    <main className="mx-auto flex min-h-screen max-w-(--container-max-desktop) flex-col items-start justify-center gap-md p-margin-mobile lg:p-margin-desktop">
-      <span className="text-label-caps uppercase text-on-surface-variant">
-        FE-001
-      </span>
-      <h1 className="text-display text-on-background">Bootstrap OK</h1>
-      <p className="text-body-lg text-on-surface">
-        Next.js + Tailwind v4 + Drizzle + Lucia scaffold is wired up.
-      </p>
-    </main>
+    <>
+      <TopAppBar active="dashboard" />
+      <main className="pt-4 md:pt-24 pb-24 md:pb-8 px-margin-mobile md:px-margin-desktop max-w-(--container-max-desktop) mx-auto grid grid-cols-12 gap-lg">
+        <div className="col-span-12 md:col-span-8 space-y-lg">
+          <LiveBlock matches={liveMatches} tipsByMatchId={tipsByMatchId} />
+          <UpcomingList
+            matches={upcomingMatches}
+            tipsByMatchId={tipsByMatchId}
+          />
+        </div>
+        <div className="col-span-12 md:col-span-4">
+          <RankingSidebar rating={rating} currentUserId={userId} />
+        </div>
+      </main>
+      <BottomNav active="dashboard" />
+    </>
   );
 }

--- a/app/api/tip/[matchId]/route.ts
+++ b/app/api/tip/[matchId]/route.ts
@@ -1,0 +1,93 @@
+import { getCurrentSession } from "@/lib/session";
+import { getMatchById } from "@/lib/match";
+import { saveTip } from "@/lib/tip";
+
+function jsonError(message: string, status: number): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ matchId: string }> },
+): Promise<Response> {
+  const { user } = await getCurrentSession();
+  if (!user) {
+    return jsonError("Not logged in", 401);
+  }
+
+  const userId = Number(user.id);
+  if (!Number.isFinite(userId) || userId <= 0) {
+    return jsonError("Not logged in", 401);
+  }
+
+  const { matchId: rawMatchId } = await params;
+  const matchId = Number.parseInt(rawMatchId, 10);
+  if (!Number.isFinite(matchId) || matchId <= 0) {
+    return jsonError("Match not found", 400);
+  }
+
+  const matchRow = await getMatchById(matchId);
+  if (!matchRow) {
+    return jsonError("Match not found", 400);
+  }
+
+  const now = new Date();
+  if (
+    matchRow.utcDate.getTime() < now.getTime() ||
+    matchRow.homeScore !== null ||
+    matchRow.awayScore !== null
+  ) {
+    return jsonError("Match already started or finished", 400);
+  }
+
+  const formData = await request.formData();
+  const rawTip1 = formData.get("tip1");
+  const rawTip2 = formData.get("tip2");
+
+  const tip1 = Number.parseInt(
+    typeof rawTip1 === "string" ? rawTip1 : "",
+    10,
+  );
+  const tip2 = Number.parseInt(
+    typeof rawTip2 === "string" ? rawTip2 : "",
+    10,
+  );
+
+  if (
+    !Number.isFinite(tip1) ||
+    tip1 < 0 ||
+    tip1 > 20 ||
+    !Number.isFinite(tip2) ||
+    tip2 < 0 ||
+    tip2 > 20
+  ) {
+    return jsonError("Tip out of range (0–20)", 400);
+  }
+
+  try {
+    const saved = await saveTip(userId, matchId, tip1, tip2);
+    return new Response(
+      JSON.stringify({
+        success: true,
+        tip: {
+          id: saved.id,
+          userId: saved.userId,
+          matchId: saved.matchId,
+          scoreHome: saved.scoreHome,
+          scoreAway: saved.scoreAway,
+          date: saved.date instanceof Date ? saved.date.getTime() : saved.date,
+        },
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  } catch (error) {
+    console.error("[tip] save failed", error);
+    return jsonError("Failed to save tip", 500);
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -49,6 +49,11 @@
   --color-on-background: #e3e2e7;
   --color-surface-variant: #343539;
 
+  --color-success: #4ade80;
+  --color-warning: #fde047;
+  --color-neutral: #e3e2e7;
+  --color-danger: #f87171;
+
   --font-sans: var(--font-hanken-grotesk), system-ui, sans-serif;
   --font-mono: var(--font-jetbrains-mono), ui-monospace, monospace;
 

--- a/components/dashboard/BottomNav.tsx
+++ b/components/dashboard/BottomNav.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+
+interface BottomNavProps {
+  active: "dashboard" | "ranking" | "profile";
+}
+
+const ITEMS = [
+  { id: "dashboard", label: "Dashboard", icon: "dashboard", href: "/" },
+  { id: "ranking", label: "Ranking", icon: "leaderboard", href: "/ranking" },
+  { id: "profile", label: "Profile", icon: "person", href: "/profile" },
+] as const;
+
+export function BottomNav({ active }: BottomNavProps): React.ReactElement {
+  return (
+    <nav className="fixed bottom-0 left-0 w-full z-50 flex md:hidden justify-around items-center px-margin-mobile py-2 bg-surface-container border-t border-outline-variant">
+      {ITEMS.map((item) => {
+        const isActive = item.id === active;
+        return (
+          <Link
+            key={item.id}
+            href={item.href}
+            className={`flex flex-col items-center justify-center px-4 py-1 rounded-full transition-transform ${
+              isActive
+                ? "bg-secondary-container text-on-secondary-container scale-95"
+                : "text-on-surface-variant hover:bg-surface-container-highest"
+            }`}
+          >
+            <span
+              className="material-symbols-outlined"
+              style={isActive ? { fontVariationSettings: "'FILL' 1" } : undefined}
+            >
+              {item.icon}
+            </span>
+            <span className="text-label-caps uppercase">{item.label}</span>
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/components/dashboard/Flag.tsx
+++ b/components/dashboard/Flag.tsx
@@ -1,0 +1,31 @@
+const TLA_MAP: Record<string, string> = {
+  DEU: "GER",
+  NLD: "NED",
+  HRV: "CRO",
+  DNK: "DEN",
+  PRT: "POR",
+  CHE: "SUI",
+};
+
+function mapTla(tla: string): string {
+  return TLA_MAP[tla] ?? tla;
+}
+
+export function Flag({
+  tla,
+  name,
+  className,
+}: {
+  tla: string;
+  name: string;
+  className?: string;
+}): React.ReactElement {
+  const mapped = mapTla(tla);
+  return (
+    <img
+      src={`/svg/${mapped}.svg`}
+      alt={name}
+      className={className ?? "w-8 h-5 object-cover rounded-xs"}
+    />
+  );
+}

--- a/components/dashboard/LiveBlock.tsx
+++ b/components/dashboard/LiveBlock.tsx
@@ -1,0 +1,107 @@
+import Link from "next/link";
+import type { MatchRow } from "@/lib/match";
+import type { TipRow } from "@/lib/tip";
+import { Flag } from "@/components/dashboard/Flag";
+import { computeScore } from "@/lib/score";
+import { scoreColor, scoreToneClass } from "@/lib/scoring";
+
+export function LiveBlock({
+  matches,
+  tipsByMatchId,
+}: {
+  matches: MatchRow[];
+  tipsByMatchId: Map<number, TipRow>;
+}): React.ReactElement | null {
+  const rows = matches
+    .map((m) => {
+      const tip = tipsByMatchId.get(m.id);
+      if (!tip) return null;
+      const points =
+        m.homeScore !== null && m.awayScore !== null
+          ? computeScore(tip.scoreHome, tip.scoreAway, m.homeScore, m.awayScore)
+          : null;
+      return { match: m, tip, points };
+    })
+    .filter((r): r is { match: MatchRow; tip: TipRow; points: number | null } => r !== null);
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  return (
+    <section>
+      <div className="flex items-center gap-sm mb-md">
+        <span className="w-2 h-2 rounded-full bg-primary-container animate-pulse" />
+        <h2 className="text-label-caps uppercase text-primary tracking-widest">
+          LIVE NOW
+        </h2>
+      </div>
+      <div className="space-y-md">
+        {rows.map(({ match, tip, points }) => {
+          const tone = points !== null ? scoreColor(points) : "neutral";
+          const toneClass = scoreToneClass(tone);
+          return (
+            <Link
+              key={match.id}
+              href={`/match/${match.id}`}
+              className="block bg-surface-container border border-outline-variant rounded-lg p-lg relative overflow-hidden group hover:border-primary/40 transition-colors"
+            >
+              <div className="flex justify-between items-center">
+                <div className="flex flex-col items-center gap-sm w-1/3">
+                  <Flag
+                    tla={match.homeTeam.tla}
+                    name={match.homeTeam.name}
+                    className="w-12 h-8 object-cover rounded-sm shadow-md"
+                  />
+                  <span className="text-label-caps uppercase">
+                    {match.homeTeam.name}
+                  </span>
+                </div>
+                <div className="flex flex-col items-center gap-xs">
+                  <div className="text-display font-mono leading-none flex gap-md">
+                    <span>{match.homeScore ?? "-"}</span>
+                    <span className="text-outline-variant">:</span>
+                    <span>{match.awayScore ?? "-"}</span>
+                  </div>
+                  <span className="text-label-caps uppercase text-primary-container">
+                    LIVE
+                  </span>
+                </div>
+                <div className="flex flex-col items-center gap-sm w-1/3">
+                  <Flag
+                    tla={match.awayTeam.tla}
+                    name={match.awayTeam.name}
+                    className="w-12 h-8 object-cover rounded-sm shadow-md"
+                  />
+                  <span className="text-label-caps uppercase">
+                    {match.awayTeam.name}
+                  </span>
+                </div>
+              </div>
+              <div className="mt-lg pt-md border-t border-outline-variant flex justify-between items-center">
+                <div className="flex items-center gap-md">
+                  <span className="text-label-caps uppercase text-on-surface-variant">
+                    YOUR TIP:
+                  </span>
+                  <span className="font-mono text-data-mono bg-surface-container-highest px-md py-xs rounded">
+                    {tip.scoreHome} : {tip.scoreAway}
+                  </span>
+                </div>
+                <div className="flex items-center gap-sm">
+                  <span className="text-label-caps uppercase text-on-surface-variant">
+                    POINTS:
+                  </span>
+                  <span
+                    className={`text-headline-md font-bold tracking-tighter ${toneClass}`}
+                  >
+                    {points === null ? "–" : `${points > 0 ? "+" : ""}${points}`}
+                  </span>
+                </div>
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/components/dashboard/MatchRow.tsx
+++ b/components/dashboard/MatchRow.tsx
@@ -1,0 +1,61 @@
+import type { MatchRow as MatchRowData } from "@/lib/match";
+import type { TipRow } from "@/lib/tip";
+import { Flag } from "@/components/dashboard/Flag";
+import { TipForm } from "@/components/dashboard/TipForm";
+import { extractTime } from "@/lib/format";
+
+interface MatchRowProps {
+  match: MatchRowData;
+  tip?: TipRow;
+}
+
+export function MatchRow({ match, tip }: MatchRowProps): React.ReactElement {
+  const now = new Date();
+  const disabled =
+    match.utcDate.getTime() < now.getTime() ||
+    match.homeScore !== null ||
+    match.awayScore !== null;
+
+  return (
+    <div
+      className={`bg-surface-container border border-outline-variant rounded-lg p-lg transition-all ${
+        disabled
+          ? "opacity-60"
+          : "hover:border-primary/30"
+      }`}
+    >
+      <div className="flex flex-col md:flex-row md:justify-between md:items-center gap-md">
+        <div className="flex items-center gap-lg flex-1">
+          <div className="flex items-center gap-md w-32">
+            <Flag
+              tla={match.homeTeam.tla}
+              name={match.homeTeam.name}
+            />
+            <span className="text-body-lg font-bold">
+              {match.homeTeam.tla}
+            </span>
+          </div>
+          <div className="text-data-mono font-mono text-on-surface-variant">
+            {extractTime(match.utcDate)}
+          </div>
+          <div className="flex items-center gap-md w-32 justify-end">
+            <span className="text-body-lg font-bold">
+              {match.awayTeam.tla}
+            </span>
+            <Flag
+              tla={match.awayTeam.tla}
+              name={match.awayTeam.name}
+            />
+          </div>
+        </div>
+        <TipForm
+          matchId={match.id}
+          initialTip={
+            tip ? { scoreHome: tip.scoreHome, scoreAway: tip.scoreAway } : null
+          }
+          disabled={disabled}
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/RankingSidebar.tsx
+++ b/components/dashboard/RankingSidebar.tsx
@@ -1,0 +1,204 @@
+import Link from "next/link";
+import type { RatingResponse, RatingUser } from "@/lib/rating";
+import { sliceGlobalShortTable } from "@/lib/rating";
+import { abbreviateUsername } from "@/lib/format";
+import { TabBar } from "@/components/dashboard/TabBar";
+import { DEPARTMENTS, displayDepartment } from "@/lib/data/departments";
+
+interface RankingSidebarProps {
+  rating: RatingResponse | null;
+  currentUserId: number;
+}
+
+function RankingRow({
+  user,
+  isCurrent,
+  showDivider = false,
+}: {
+  user?: RatingUser;
+  isCurrent?: boolean;
+  showDivider?: boolean;
+}): React.ReactElement {
+  if (showDivider) {
+    return (
+      <div className="p-xs bg-surface-container-lowest flex justify-center">
+        <span className="material-symbols-outlined text-outline-variant text-[16px]">
+          more_vert
+        </span>
+      </div>
+    );
+  }
+  if (!user) {
+    return <></>;
+  }
+  return (
+    <Link
+      href={`/user/${user.user_id}`}
+      className={`p-md flex items-center justify-between group transition-colors ${
+        isCurrent
+          ? "bg-primary/10 border-l-4 border-primary"
+          : "hover:bg-surface-container-high"
+      }`}
+    >
+      <div className="flex items-center gap-md min-w-0">
+        <span
+          className={`text-data-mono font-mono w-6 text-right shrink-0 ${
+            isCurrent ? "text-primary" : "text-on-surface-variant"
+          }`}
+        >
+          {user.position}
+        </span>
+        <div
+          className={`w-8 h-8 rounded-full flex items-center justify-center shrink-0 ${
+            isCurrent ? "bg-primary" : "bg-surface-container-highest"
+          }`}
+        >
+          <span
+            className={`material-symbols-outlined text-[18px] ${
+              isCurrent ? "text-on-primary" : ""
+            }`}
+            style={
+              isCurrent ? { fontVariationSettings: "'FILL' 1" } : undefined
+            }
+          >
+            person
+          </span>
+        </div>
+        <span
+          className={`text-body-sm font-bold truncate ${
+            isCurrent ? "text-primary" : ""
+          }`}
+        >
+          {abbreviateUsername(user.name)}
+          {isCurrent ? " (You)" : ""}
+        </span>
+      </div>
+      <span
+        className={`text-data-mono font-mono whitespace-nowrap ${
+          isCurrent ? "text-primary font-bold" : "text-on-surface"
+        }`}
+      >
+        {user.score_sum} PTS
+      </span>
+    </Link>
+  );
+}
+
+function GlobalPanel({
+  rating,
+  currentUserId,
+}: {
+  rating: RatingResponse;
+  currentUserId: number;
+}): React.ReactElement {
+  const { topRows, neighborRows, hasGap } = sliceGlobalShortTable(
+    rating.global,
+    currentUserId,
+  );
+
+  if (topRows.length === 0) {
+    return (
+      <div className="p-lg text-center text-body-sm text-on-surface-variant">
+        No ranking data yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="divide-y divide-outline-variant">
+      {topRows.map((u) => (
+        <RankingRow
+          key={u.user_id}
+          user={u}
+          isCurrent={u.user_id === currentUserId}
+        />
+      ))}
+      {hasGap ? <RankingRow showDivider /> : null}
+      {neighborRows.map((u) => (
+        <RankingRow
+          key={u.user_id}
+          user={u}
+          isCurrent={u.user_id === currentUserId}
+        />
+      ))}
+    </div>
+  );
+}
+
+function DepartmentPanel({
+  users,
+  currentUserId,
+}: {
+  users: RatingUser[];
+  currentUserId: number;
+}): React.ReactElement {
+  if (users.length === 0) {
+    return (
+      <div className="p-lg text-center text-body-sm text-on-surface-variant">
+        No users in this department.
+      </div>
+    );
+  }
+  return (
+    <div className="divide-y divide-outline-variant">
+      {users.map((u) => (
+        <RankingRow
+          key={u.user_id}
+          user={u}
+          isCurrent={u.user_id === currentUserId}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function RankingSidebar({
+  rating,
+  currentUserId,
+}: RankingSidebarProps): React.ReactElement {
+  if (!rating) {
+    return (
+      <aside className="space-y-lg">
+        <div className="bg-surface-container border border-outline-variant rounded-lg p-lg">
+          <h3 className="text-label-caps uppercase text-on-surface mb-md">
+            RANKING
+          </h3>
+          <p className="text-body-sm text-on-surface-variant">
+            Ranking API offline. Try again later.
+          </p>
+        </div>
+      </aside>
+    );
+  }
+
+  const tabs = [
+    { id: "global", label: "Global" },
+    ...DEPARTMENTS.map((d) => ({ id: d, label: displayDepartment(d) })),
+  ];
+
+  const panels: Record<string, React.ReactNode> = {
+    global: <GlobalPanel rating={rating} currentUserId={currentUserId} />,
+  };
+  for (const dept of DEPARTMENTS) {
+    panels[dept] = (
+      <DepartmentPanel
+        users={rating.departments[dept] ?? []}
+        currentUserId={currentUserId}
+      />
+    );
+  }
+
+  return (
+    <aside className="space-y-lg">
+      <div className="bg-surface-container border border-outline-variant rounded-lg overflow-hidden">
+        <TabBar tabs={tabs} initialActive="global" panels={panels} />
+        <Link
+          href="/ranking"
+          className="block p-md text-center text-label-caps uppercase text-secondary hover:underline bg-surface-container-low transition-all"
+        >
+          VIEW FULL RANKING
+        </Link>
+      </div>
+    </aside>
+  );
+}

--- a/components/dashboard/TabBar.tsx
+++ b/components/dashboard/TabBar.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState } from "react";
+
+interface TabBarProps {
+  tabs: { id: string; label: string }[];
+  initialActive?: string;
+  panels: Record<string, React.ReactNode>;
+}
+
+export function TabBar({
+  tabs,
+  initialActive,
+  panels,
+}: TabBarProps): React.ReactElement {
+  const [active, setActive] = useState<string>(
+    initialActive ?? tabs[0]?.id ?? "",
+  );
+
+  return (
+    <>
+      <div className="p-md bg-surface-container-high border-b border-outline-variant">
+        <h3 className="text-label-caps uppercase text-on-surface mb-md">
+          RANKING
+        </h3>
+        <div className="flex gap-sm overflow-x-auto no-scrollbar">
+          {tabs.map((tab) => {
+            const isActive = tab.id === active;
+            return (
+              <button
+                key={tab.id}
+                type="button"
+                onClick={() => setActive(tab.id)}
+                className={`text-[10px] font-bold px-md py-1 rounded-full shrink-0 uppercase transition-colors ${
+                  isActive
+                    ? "bg-primary text-on-primary"
+                    : "bg-surface-container-lowest text-on-surface-variant hover:text-on-surface"
+                }`}
+              >
+                {tab.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+      {tabs.map((tab) => (
+        <div key={tab.id} hidden={tab.id !== active}>
+          {panels[tab.id]}
+        </div>
+      ))}
+    </>
+  );
+}

--- a/components/dashboard/TipForm.tsx
+++ b/components/dashboard/TipForm.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, type FormEvent } from "react";
+
+interface TipFormProps {
+  matchId: number;
+  initialTip?: { scoreHome: number; scoreAway: number } | null;
+  disabled?: boolean;
+}
+
+export function TipForm({
+  matchId,
+  initialTip = null,
+  disabled = false,
+}: TipFormProps): React.ReactElement {
+  const router = useRouter();
+  const [tipHome, setTipHome] = useState<string>(
+    initialTip ? String(initialTip.scoreHome) : "",
+  );
+  const [tipAway, setTipAway] = useState<string>(
+    initialTip ? String(initialTip.scoreAway) : "",
+  );
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  async function onSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+    if (disabled) return;
+    setError(null);
+    setSaved(false);
+    setPending(true);
+
+    const form = new FormData();
+    form.set("tip1", tipHome);
+    form.set("tip2", tipAway);
+
+    try {
+      const res = await fetch(`/api/tip/${matchId}`, {
+        method: "POST",
+        body: form,
+        headers: { Accept: "application/json" },
+      });
+
+      if (res.ok) {
+        setSaved(true);
+        router.refresh();
+        return;
+      }
+
+      let message = "Failed to save tip.";
+      try {
+        const body: unknown = await res.json();
+        if (
+          body &&
+          typeof body === "object" &&
+          "error" in body &&
+          typeof (body as { error: unknown }).error === "string"
+        ) {
+          message = (body as { error: string }).error;
+        }
+      } catch {
+        // ignore
+      }
+      setError(message);
+    } catch {
+      setError("Network error. Try again.");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  const buttonLabel = saved
+    ? "SAVED"
+    : pending
+      ? "..."
+      : initialTip
+        ? "EDIT"
+        : "SAVE";
+
+  return (
+    <div className="flex flex-col gap-xs">
+      <form
+        onSubmit={onSubmit}
+        className="flex items-center gap-md justify-end"
+      >
+        <div className="flex gap-xs items-center">
+          <input
+            type="number"
+            min={0}
+            max={20}
+            required
+            value={tipHome}
+            onChange={(e) => setTipHome(e.target.value)}
+            disabled={disabled || pending}
+            placeholder="-"
+            aria-label="Home score tip"
+            className="w-12 min-h-12 bg-surface-container-low border border-outline-variant rounded text-center text-headline-md font-mono focus:border-primary focus:ring-0 transition-colors disabled:opacity-60"
+          />
+          <span className="text-outline-variant">:</span>
+          <input
+            type="number"
+            min={0}
+            max={20}
+            required
+            value={tipAway}
+            onChange={(e) => setTipAway(e.target.value)}
+            disabled={disabled || pending}
+            placeholder="-"
+            aria-label="Away score tip"
+            className="w-12 min-h-12 bg-surface-container-low border border-outline-variant rounded text-center text-headline-md font-mono focus:border-primary focus:ring-0 transition-colors disabled:opacity-60"
+          />
+        </div>
+        <button
+          type="submit"
+          disabled={disabled || pending}
+          className={`px-lg py-2 min-h-12 rounded-lg text-label-caps uppercase font-bold transition-all active:scale-95 disabled:opacity-60 ${
+            saved
+              ? "bg-tertiary text-on-tertiary"
+              : "bg-primary text-on-primary hover:opacity-90"
+          }`}
+        >
+          {buttonLabel}
+        </button>
+      </form>
+      {error ? (
+        <p
+          aria-live="polite"
+          className="text-body-sm text-danger text-right px-xs"
+        >
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/components/dashboard/TopAppBar.tsx
+++ b/components/dashboard/TopAppBar.tsx
@@ -1,0 +1,49 @@
+import Link from "next/link";
+
+interface TopAppBarProps {
+  active: "dashboard" | "ranking" | "profile";
+}
+
+const LINKS = [
+  { id: "dashboard", label: "Dashboard", href: "/" },
+  { id: "ranking", label: "Ranking", href: "/ranking" },
+  { id: "profile", label: "Profile", href: "/profile" },
+] as const;
+
+export function TopAppBar({ active }: TopAppBarProps): React.ReactElement {
+  return (
+    <header className="bg-background border-b border-outline-variant fixed top-0 left-0 w-full z-40 hidden md:block">
+      <div className="flex justify-between items-center w-full px-margin-desktop h-16 max-w-(--container-max-desktop) mx-auto">
+        <div className="text-headline-md font-black text-on-background tracking-tighter">
+          TOURNAMENT PREDICTOR
+        </div>
+        <nav className="flex gap-lg">
+          {LINKS.map((link) => {
+            const isActive = link.id === active;
+            return (
+              <Link
+                key={link.id}
+                href={link.href}
+                className={`text-label-caps uppercase pb-1 transition-colors ${
+                  isActive
+                    ? "text-primary border-b-2 border-primary"
+                    : "text-on-surface-variant hover:text-primary"
+                }`}
+              >
+                {link.label}
+              </Link>
+            );
+          })}
+        </nav>
+        <form action="/api/auth/logout" method="POST">
+          <button
+            type="submit"
+            className="text-label-caps uppercase text-on-surface-variant hover:text-primary transition-colors"
+          >
+            Logout
+          </button>
+        </form>
+      </div>
+    </header>
+  );
+}

--- a/components/dashboard/UpcomingList.tsx
+++ b/components/dashboard/UpcomingList.tsx
@@ -1,0 +1,60 @@
+import type { MatchRow as MatchRowData } from "@/lib/match";
+import type { TipRow } from "@/lib/tip";
+import { MatchRow } from "@/components/dashboard/MatchRow";
+import { groupByDate } from "@/lib/match";
+import { formatDate } from "@/lib/format";
+
+interface UpcomingListProps {
+  matches: MatchRowData[];
+  tipsByMatchId: Map<number, TipRow>;
+}
+
+export function UpcomingList({
+  matches,
+  tipsByMatchId,
+}: UpcomingListProps): React.ReactElement {
+  if (matches.length === 0) {
+    return (
+      <section>
+        <h2 className="text-label-caps uppercase text-on-surface-variant mb-md tracking-widest">
+          UPCOMING FIXTURES
+        </h2>
+        <div className="bg-surface-container border border-outline-variant rounded-lg p-lg text-on-surface-variant">
+          No upcoming fixtures.
+        </div>
+      </section>
+    );
+  }
+
+  const grouped = groupByDate(matches);
+  const dateKeys = Object.keys(grouped).sort();
+
+  return (
+    <section>
+      <h2 className="text-label-caps uppercase text-on-surface-variant mb-md tracking-widest">
+        UPCOMING FIXTURES
+      </h2>
+      <div className="space-y-lg">
+        {dateKeys.map((key) => {
+          const dayMatches = grouped[key];
+          if (!dayMatches || dayMatches.length === 0) return null;
+          const heading = formatDate(dayMatches[0]!.utcDate);
+          return (
+            <div key={key} className="space-y-sm">
+              <div className="text-label-caps uppercase text-on-surface-variant/60 px-xs">
+                {heading}
+              </div>
+              {dayMatches.map((m) => (
+                <MatchRow
+                  key={m.id}
+                  match={m}
+                  tip={tipsByMatchId.get(m.id)}
+                />
+              ))}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -1,0 +1,31 @@
+export function formatDate(ts: Date | number): string {
+  const d = ts instanceof Date ? ts : new Date(ts);
+  return d.toLocaleDateString("de-DE", {
+    weekday: "short",
+    day: "numeric",
+    month: "long",
+  });
+}
+
+export function formatDateKey(ts: Date | number): string {
+  const d = ts instanceof Date ? ts : new Date(ts);
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+export function extractTime(ts: Date | number): string {
+  const d = ts instanceof Date ? ts : new Date(ts);
+  return d.toLocaleTimeString("de-DE", {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function abbreviateUsername(name: string): string {
+  if (name.length > 17) {
+    return name.slice(0, 14) + "…";
+  }
+  return name;
+}

--- a/lib/match.ts
+++ b/lib/match.ts
@@ -1,0 +1,76 @@
+import { and, eq, gte } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { match } from "@/db/schema";
+import { formatDateKey } from "@/lib/format";
+
+export interface TeamRef {
+  name: string;
+  tla: string;
+}
+
+export interface MatchRow {
+  id: number;
+  homeTeam: TeamRef;
+  awayTeam: TeamRef;
+  status: string;
+  utcDate: Date;
+  homeScore: number | null;
+  awayScore: number | null;
+}
+
+function isTeamRef(value: unknown): value is TeamRef {
+  if (value === null || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.name === "string" && typeof v.tla === "string";
+}
+
+function rowToMatch(row: typeof match.$inferSelect): MatchRow | null {
+  if (!isTeamRef(row.homeTeam) || !isTeamRef(row.awayTeam)) {
+    return null;
+  }
+  return {
+    id: row.id,
+    homeTeam: row.homeTeam,
+    awayTeam: row.awayTeam,
+    status: row.status,
+    utcDate: row.utcDate,
+    homeScore: row.homeScore,
+    awayScore: row.awayScore,
+  };
+}
+
+export async function getLiveMatches(): Promise<MatchRow[]> {
+  const rows = await db.select().from(match).where(eq(match.status, "IN_PLAY"));
+  return rows
+    .map(rowToMatch)
+    .filter((m): m is MatchRow => m !== null)
+    .sort((a, b) => a.utcDate.getTime() - b.utcDate.getTime());
+}
+
+export async function getUpcomingMatches(): Promise<MatchRow[]> {
+  const now = new Date();
+  const rows = await db
+    .select()
+    .from(match)
+    .where(and(eq(match.status, "SCHEDULED"), gte(match.utcDate, now)));
+  return rows
+    .map(rowToMatch)
+    .filter((m): m is MatchRow => m !== null)
+    .sort((a, b) => a.utcDate.getTime() - b.utcDate.getTime());
+}
+
+export async function getMatchById(id: number): Promise<MatchRow | null> {
+  const row = await db.query.match.findFirst({ where: eq(match.id, id) });
+  if (!row) return null;
+  return rowToMatch(row);
+}
+
+export function groupByDate(matches: MatchRow[]): Record<string, MatchRow[]> {
+  const groups: Record<string, MatchRow[]> = {};
+  for (const m of matches) {
+    const key = formatDateKey(m.utcDate);
+    if (!groups[key]) groups[key] = [];
+    groups[key].push(m);
+  }
+  return groups;
+}

--- a/lib/rating.ts
+++ b/lib/rating.ts
@@ -1,0 +1,69 @@
+export interface RatingTeam {
+  name: string;
+  tla: string;
+}
+
+export interface RatingMatchInfo {
+  match_id: string;
+  user: string;
+  user_id: number;
+  score: number;
+  team1: RatingTeam;
+  team2: RatingTeam;
+  tip_home: number | null;
+  tip_away: number | null;
+  score_home: number | null;
+  score_away: number | null;
+  date: number;
+}
+
+export interface RatingUser {
+  name: string;
+  user_id: number;
+  department: string;
+  position: number;
+  score_sum: number;
+  sum_win_exact: number;
+  sum_score_diff: number;
+  sum_team: number;
+  extra_point: number;
+  tips: RatingMatchInfo[];
+}
+
+export interface RatingResponse {
+  global: RatingUser[];
+  departments: Record<string, RatingUser[]>;
+}
+
+export interface ShortTableSlice {
+  topRows: RatingUser[];
+  neighborRows: RatingUser[];
+  hasGap: boolean;
+}
+
+export function sliceGlobalShortTable(
+  global: RatingUser[],
+  currentUserId: number,
+): ShortTableSlice {
+  if (global.length === 0) {
+    return { topRows: [], neighborRows: [], hasGap: false };
+  }
+
+  const userIndexInTail = global.slice(3).findIndex((u) => u.user_id === currentUserId);
+
+  if (userIndexInTail > 0) {
+    const start = Math.max(0, userIndexInTail - 1);
+    const end = userIndexInTail + 2;
+    return {
+      topRows: global.slice(0, 3),
+      neighborRows: global.slice(3).slice(start, end),
+      hasGap: true,
+    };
+  }
+
+  return {
+    topRows: global.slice(0, 6),
+    neighborRows: [],
+    hasGap: false,
+  };
+}

--- a/lib/score.ts
+++ b/lib/score.ts
@@ -1,0 +1,21 @@
+export function computeScore(
+  tipHome: number,
+  tipAway: number,
+  scoreHome: number,
+  scoreAway: number,
+): number {
+  if (tipHome === scoreHome && tipAway === scoreAway) {
+    return 4;
+  }
+  const tipDiff = tipHome - tipAway;
+  const scoreDiff = scoreHome - scoreAway;
+  if (tipDiff === scoreDiff) {
+    return 2;
+  }
+  const tipWinner = Math.sign(tipDiff);
+  const scoreWinner = Math.sign(scoreDiff);
+  if (tipWinner === scoreWinner) {
+    return 1;
+  }
+  return 0;
+}

--- a/lib/scoring.ts
+++ b/lib/scoring.ts
@@ -1,0 +1,22 @@
+export type ScoreTone = "success" | "warning" | "neutral" | "danger";
+
+export function scoreColor(points: number): ScoreTone {
+  if (points === 4) return "success";
+  if (points === 2) return "warning";
+  if (points === 0) return "danger";
+  return "neutral";
+}
+
+export function scoreToneClass(tone: ScoreTone): string {
+  switch (tone) {
+    case "success":
+      return "text-success";
+    case "warning":
+      return "text-warning";
+    case "danger":
+      return "text-danger";
+    case "neutral":
+    default:
+      return "text-neutral";
+  }
+}

--- a/lib/tip.ts
+++ b/lib/tip.ts
@@ -1,0 +1,57 @@
+import { and, eq, inArray } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { tip } from "@/db/schema";
+
+export type TipRow = typeof tip.$inferSelect;
+
+export async function getTipByUserAndMatchIds(
+  userId: number,
+  matchIds: number[],
+): Promise<TipRow[]> {
+  if (matchIds.length === 0) return [];
+  return db
+    .select()
+    .from(tip)
+    .where(and(eq(tip.userId, userId), inArray(tip.matchId, matchIds)));
+}
+
+export async function getTipByUserAndMatch(
+  userId: number,
+  matchId: number,
+): Promise<TipRow | undefined> {
+  const rows = await db
+    .select()
+    .from(tip)
+    .where(and(eq(tip.userId, userId), eq(tip.matchId, matchId)))
+    .limit(1);
+  return rows[0];
+}
+
+export async function saveTip(
+  userId: number,
+  matchId: number,
+  scoreHome: number,
+  scoreAway: number,
+): Promise<TipRow> {
+  const existing = await getTipByUserAndMatch(userId, matchId);
+  const now = new Date();
+  if (existing) {
+    await db
+      .update(tip)
+      .set({ scoreHome, scoreAway, date: now })
+      .where(eq(tip.id, existing.id));
+  } else {
+    await db.insert(tip).values({
+      userId,
+      matchId,
+      date: now,
+      scoreHome,
+      scoreAway,
+    });
+  }
+  const fresh = await getTipByUserAndMatch(userId, matchId);
+  if (!fresh) {
+    throw new Error("Tip upsert failed to persist");
+  }
+  return fresh;
+}


### PR DESCRIPTION
Replaces the FE-001 placeholder with the real dashboard. Live block (IN_PLAY with live points pill), upcoming fixtures grouped by date with TipForm per row, ranking sidebar (4 tabs, spec §14.3 slicing). Rust /rating wrapped in try/catch — sidebar shows 'Ranking API offline' if Rust is down so the dashboard stays usable for solo dev.

POST /api/tip/[matchId] enforces session + match-still-open + 0–20 range. Returns 401 only for missing session; 400 for everything else (fixes spec §5.3's legacy 401-everywhere bug). Tips fetched in one inArray query (no N+1).

Reviewer **APPROVE**. Type-check clean, build green, no inline SVG, no forbidden icon libs, no `any`, no new packages. ~1100 LOC across 15 new + 2 modified files.