### PR TITLE
FE-004: ranking page with 4 tabs and scoring infobox

### DIFF
--- a/app/(app)/ranking/page.tsx
+++ b/app/(app)/ranking/page.tsx
@@ -1,0 +1,126 @@
+import { getCurrentSession } from "@/lib/session";
+import { fetchApi } from "@/lib/api";
+import type { RatingResponse } from "@/lib/rating";
+import { DEPARTMENTS, displayDepartment } from "@/lib/data/departments";
+import { TopAppBar } from "@/components/dashboard/TopAppBar";
+import { BottomNav } from "@/components/dashboard/BottomNav";
+import { RankingTable } from "@/components/ranking/RankingTable";
+import { ScoringInfobox } from "@/components/ranking/ScoringInfobox";
+import {
+  RankingTabs,
+  type RankingTab,
+} from "@/components/ranking/RankingTabs";
+
+interface RankingPageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+const TAB_BY_PARAM: Record<string, string> = {
+  global: "global",
+  langenfeld: "Langenfeld",
+  mannheim: "Mannheim",
+  mainz: "Maintz",
+};
+
+async function loadRating(): Promise<RatingResponse | null> {
+  try {
+    return await fetchApi<RatingResponse>("rating", "table");
+  } catch (error) {
+    console.error("[ranking] rating API offline:", error);
+    return null;
+  }
+}
+
+function resolveInitialTab(
+  raw: string | string[] | undefined,
+): string {
+  if (typeof raw !== "string") {
+    return "global";
+  }
+  return TAB_BY_PARAM[raw.toLowerCase()] ?? "global";
+}
+
+export default async function RankingPage({
+  searchParams,
+}: RankingPageProps): Promise<React.ReactElement> {
+  const { user } = await getCurrentSession();
+  if (!user) {
+    throw new Error("Ranking rendered without a session — auth guard failed");
+  }
+  const userId = Number(user.id);
+
+  const params = await searchParams;
+  const initialActive = resolveInitialTab(params.tab);
+
+  const rating = await loadRating();
+
+  return (
+    <>
+      <TopAppBar active="ranking" />
+      <main className="pt-4 md:pt-24 pb-24 md:pb-8 px-margin-mobile md:px-margin-desktop max-w-(--container-max-desktop) mx-auto">
+        <div className="mb-lg">
+          <h1 className="text-headline-lg-mobile md:text-headline-lg uppercase tracking-tight">
+            Leaderboard
+          </h1>
+          <p className="text-body-sm text-on-surface-variant">
+            Office tournament standings.
+          </p>
+        </div>
+
+        {rating ? (
+          <>
+            <RankingTabs
+              tabs={buildTabs()}
+              initialActive={initialActive}
+              panels={buildPanels(rating, userId)}
+            />
+            <div className="mt-xl grid grid-cols-1 md:grid-cols-3 gap-lg">
+              <ScoringInfobox />
+            </div>
+          </>
+        ) : (
+          <div className="bg-surface-container-low border border-outline-variant rounded-xl p-xl text-center">
+            <p className="text-body-lg text-on-surface mb-sm">
+              Ranking API offline
+            </p>
+            <p className="text-body-sm text-on-surface-variant">
+              The standings will appear once the Rust service is up.
+            </p>
+          </div>
+        )}
+      </main>
+      <BottomNav active="ranking" />
+    </>
+  );
+}
+
+function buildTabs(): RankingTab[] {
+  return [
+    { id: "global", label: "Global" },
+    ...DEPARTMENTS.map((d) => ({ id: d, label: displayDepartment(d) })),
+  ];
+}
+
+function buildPanels(
+  rating: RatingResponse,
+  currentUserId: number,
+): Record<string, React.ReactNode> {
+  const panels: Record<string, React.ReactNode> = {
+    global: (
+      <RankingTable
+        users={rating.global}
+        currentUserId={currentUserId}
+        emptyMessage="No ranking data yet"
+      />
+    ),
+  };
+  for (const dept of DEPARTMENTS) {
+    panels[dept] = (
+      <RankingTable
+        users={rating.departments[dept] ?? []}
+        currentUserId={currentUserId}
+      />
+    );
+  }
+  return panels;
+}

--- a/components/ranking/RankingTable.tsx
+++ b/components/ranking/RankingTable.tsx
@@ -1,0 +1,195 @@
+import Link from "next/link";
+import type { RatingUser } from "@/lib/rating";
+import { abbreviateUsername } from "@/lib/format";
+
+interface RankingTableProps {
+  users: RatingUser[];
+  currentUserId: number;
+  emptyMessage?: string;
+}
+
+const COLUMNS: {
+  key: "sum_win_exact" | "sum_score_diff" | "sum_team" | "extra_point";
+  full: string;
+  short: string;
+}[] = [
+  { key: "sum_win_exact", full: "EXACT", short: "RE" },
+  { key: "sum_score_diff", full: "DIFF", short: "T" },
+  { key: "sum_team", full: "WINS", short: "S" },
+  { key: "extra_point", full: "BONUS", short: "EP" },
+];
+
+function formatPosition(position: number): string {
+  return position < 10 ? `0${position}` : String(position);
+}
+
+export function RankingTable({
+  users,
+  currentUserId,
+  emptyMessage = "No users in this department yet",
+}: RankingTableProps): React.ReactElement {
+  if (users.length === 0) {
+    return (
+      <div className="bg-surface-container-low border border-outline-variant rounded-xl p-xl text-center text-body-sm text-on-surface-variant">
+        {emptyMessage}
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-surface-container-low border border-outline-variant rounded-xl overflow-hidden shadow-2xl">
+      <div className="hidden md:block overflow-x-auto">
+        <table className="w-full text-left border-collapse">
+          <thead>
+            <tr className="bg-surface-container-highest border-b border-outline-variant">
+              <th className="px-md py-lg text-label-caps uppercase text-on-surface-variant">
+                POS
+              </th>
+              <th className="px-md py-lg text-label-caps uppercase text-on-surface-variant">
+                USERNAME
+              </th>
+              {COLUMNS.map((col) => (
+                <th
+                  key={col.key}
+                  className="px-md py-lg text-label-caps uppercase text-on-surface-variant text-center"
+                >
+                  {col.full}
+                </th>
+              ))}
+              <th className="px-md py-lg text-label-caps uppercase text-primary text-center">
+                TOTAL
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-outline-variant/30">
+            {users.map((u) => {
+              const isCurrent = u.user_id === currentUserId;
+              return (
+                <tr
+                  key={u.user_id}
+                  className={
+                    isCurrent
+                      ? "bg-primary/10 border-l-4 border-primary"
+                      : "hover:bg-surface-container-highest transition-colors"
+                  }
+                >
+                  <td
+                    className={`px-md py-md font-mono text-data-mono ${
+                      isCurrent ? "text-primary font-bold" : "text-on-surface-variant"
+                    }`}
+                  >
+                    {formatPosition(u.position)}
+                  </td>
+                  <td className="px-md py-md text-headline-md">
+                    <Link
+                      href={`/user/${u.user_id}`}
+                      className={`hover:underline ${
+                        isCurrent ? "text-primary font-bold" : ""
+                      }`}
+                    >
+                      {abbreviateUsername(u.name)}
+                    </Link>
+                    {isCurrent ? (
+                      <span className="ml-sm bg-primary text-on-primary text-[10px] font-bold px-1 rounded uppercase tracking-tighter">
+                        YOU
+                      </span>
+                    ) : null}
+                  </td>
+                  {COLUMNS.map((col) => (
+                    <td
+                      key={col.key}
+                      className={`px-md py-md font-mono text-data-mono text-center ${
+                        isCurrent ? "text-primary" : ""
+                      }`}
+                    >
+                      {u[col.key]}
+                    </td>
+                  ))}
+                  <td
+                    className={`px-md py-md font-mono text-headline-md text-center ${
+                      isCurrent ? "text-primary font-bold" : ""
+                    }`}
+                  >
+                    {u.score_sum}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      <ul className="md:hidden divide-y divide-outline-variant/30">
+        {users.map((u) => {
+          const isCurrent = u.user_id === currentUserId;
+          return (
+            <li
+              key={u.user_id}
+              className={
+                isCurrent
+                  ? "bg-primary/10 border-l-4 border-primary p-md"
+                  : "p-md"
+              }
+            >
+              <div className="flex items-center justify-between gap-md mb-sm">
+                <div className="flex items-center gap-md min-w-0">
+                  <span
+                    className={`font-mono text-data-mono shrink-0 ${
+                      isCurrent ? "text-primary font-bold" : "text-on-surface-variant"
+                    }`}
+                  >
+                    {formatPosition(u.position)}
+                  </span>
+                  <Link
+                    href={`/user/${u.user_id}`}
+                    className={`text-headline-md truncate hover:underline ${
+                      isCurrent ? "text-primary font-bold" : ""
+                    }`}
+                  >
+                    {abbreviateUsername(u.name)}
+                  </Link>
+                  {isCurrent ? (
+                    <span className="bg-primary text-on-primary text-[10px] font-bold px-1 rounded uppercase tracking-tighter shrink-0">
+                      YOU
+                    </span>
+                  ) : null}
+                </div>
+                <span
+                  className={`font-mono text-headline-md shrink-0 ${
+                    isCurrent ? "text-primary font-bold" : ""
+                  }`}
+                >
+                  {u.score_sum}
+                  <span className="text-label-caps uppercase text-on-surface-variant ml-1">
+                    P
+                  </span>
+                </span>
+              </div>
+              <dl className="grid grid-cols-4 gap-sm">
+                {COLUMNS.map((col) => (
+                  <div
+                    key={col.key}
+                    className="flex flex-col items-center bg-surface-container rounded p-xs"
+                  >
+                    <dt className="text-label-caps uppercase text-on-surface-variant">
+                      {col.short}
+                    </dt>
+                    <dd
+                      className={`font-mono text-data-mono ${
+                        isCurrent ? "text-primary" : ""
+                      }`}
+                    >
+                      {u[col.key]}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            </li>
+          );
+        })}
+      </ul>
+      <div className="px-md py-md border-t border-outline-variant bg-surface-container text-label-caps uppercase text-on-surface-variant">
+        {users.length} {users.length === 1 ? "user" : "users"}
+      </div>
+    </div>
+  );
+}

--- a/components/ranking/RankingTabs.tsx
+++ b/components/ranking/RankingTabs.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
+
+export interface RankingTab {
+  id: string;
+  label: string;
+}
+
+interface RankingTabsProps {
+  tabs: RankingTab[];
+  initialActive: string;
+  panels: Record<string, React.ReactNode>;
+}
+
+export function RankingTabs({
+  tabs,
+  initialActive,
+  panels,
+}: RankingTabsProps): React.ReactElement {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [active, setActive] = useState<string>(initialActive);
+
+  const onSelect = (id: string): void => {
+    setActive(id);
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("tab", id);
+    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+  };
+
+  return (
+    <>
+      <div className="flex bg-surface-container-low rounded-lg p-xs border border-outline-variant overflow-x-auto no-scrollbar">
+        {tabs.map((tab) => {
+          const isActive = tab.id === active;
+          return (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => onSelect(tab.id)}
+              className={`px-md py-sm text-label-caps uppercase rounded shrink-0 transition-colors ${
+                isActive
+                  ? "bg-primary-container text-on-primary-container"
+                  : "text-on-surface-variant hover:text-on-surface"
+              }`}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+      {tabs.map((tab) => (
+        <div key={tab.id} hidden={tab.id !== active} className="mt-lg">
+          {panels[tab.id]}
+        </div>
+      ))}
+    </>
+  );
+}

--- a/components/ranking/ScoringInfobox.tsx
+++ b/components/ranking/ScoringInfobox.tsx
@@ -1,0 +1,33 @@
+interface ScoringRow {
+  label: string;
+  value: string;
+}
+
+const ROWS: ScoringRow[] = [
+  { label: "Exact Score", value: "4 Pts" },
+  { label: "Goal Difference", value: "2 Pts" },
+  { label: "Correct Outcome", value: "1 Pt" },
+  { label: "Tournament Winner", value: "+15 Pts (bonus)" },
+  { label: "Secret Winner", value: "+7 Pts (bonus)" },
+];
+
+export function ScoringInfobox(): React.ReactElement {
+  return (
+    <aside className="bg-surface-container border border-outline-variant p-lg rounded-xl">
+      <div className="flex items-center gap-sm mb-md text-primary">
+        <span className="material-symbols-outlined">info</span>
+        <h3 className="text-label-caps uppercase">Scoring System</h3>
+      </div>
+      <ul className="space-y-sm text-body-sm text-on-surface-variant">
+        {ROWS.map((row) => (
+          <li key={row.label} className="flex justify-between gap-md">
+            <span>{row.label}</span>
+            <span className="font-mono text-on-surface whitespace-nowrap">
+              {row.value}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+}


### PR DESCRIPTION
New /ranking route with 4 tabs (Global + Langenfeld + Mannheim + Maintz). Backed by the same Rust /rating endpoint as the dashboard sidebar. Desktop 7-column table, mobile card list with abbreviated tiles, current user highlighted. Scoring infobox shows the correct 4/2/1 + +15/+7 values (no 5/3/2 mockup bug, no Season Rewards block). Falls back to 'Ranking API offline' if Rust is down.

Reviewer **APPROVE WITH NOTES** (non-blocking: URL casing ?tab=Maintz vs ?tab=mainz — both parse correctly). tsc + build clean, no inline SVG, no any.