### PR TITLE
FE-005: match detail page with header + predictions table

### DIFF
--- a/app/(app)/match/[id]/page.tsx
+++ b/app/(app)/match/[id]/page.tsx
@@ -1,0 +1,172 @@
+import { notFound } from "next/navigation";
+import { getCurrentSession } from "@/lib/session";
+import { getMatchById } from "@/lib/match";
+import { fetchApi } from "@/lib/api";
+import { TopAppBar } from "@/components/dashboard/TopAppBar";
+import { BottomNav } from "@/components/dashboard/BottomNav";
+import { MatchHeader } from "@/components/match/MatchHeader";
+import {
+  PredictionsTable,
+  type PredictionRow,
+} from "@/components/match/PredictionsTable";
+
+interface MatchPageProps {
+  params: Promise<{ id: string }>;
+}
+
+interface RawTip {
+  user: unknown;
+  user_id: unknown;
+  score: unknown;
+  tip_home: unknown;
+  tip_away: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}
+
+function parseTips(raw: unknown): PredictionRow[] | null {
+  let list: unknown = raw;
+  if (isRecord(list)) {
+    const data = list.data;
+    if (isRecord(data) && Array.isArray(data.tips)) {
+      list = data.tips;
+    } else if (Array.isArray(list.tips)) {
+      list = list.tips;
+    }
+  }
+  if (!Array.isArray(list)) return null;
+
+  const rows: PredictionRow[] = [];
+  for (const item of list) {
+    if (!isRecord(item)) continue;
+    const t = item as unknown as RawTip;
+    const userId =
+      typeof t.user_id === "number"
+        ? t.user_id
+        : typeof t.user_id === "string"
+          ? Number(t.user_id)
+          : NaN;
+    if (!Number.isFinite(userId)) continue;
+    const username = typeof t.user === "string" ? t.user : "";
+    const score = typeof t.score === "number" ? t.score : 0;
+    if (t.tip_home === undefined || t.tip_home === null) {
+      continue;
+    }
+    if (t.tip_away === undefined || t.tip_away === null) {
+      continue;
+    }
+    const tipHome =
+      typeof t.tip_home === "number"
+        ? t.tip_home
+        : typeof t.tip_home === "string"
+          ? Number(t.tip_home)
+          : null;
+    const tipAway =
+      typeof t.tip_away === "number"
+        ? t.tip_away
+        : typeof t.tip_away === "string"
+          ? Number(t.tip_away)
+          : null;
+    if (tipHome === null || tipAway === null) continue;
+    if (!Number.isFinite(tipHome) || !Number.isFinite(tipAway)) continue;
+    rows.push({
+      userId,
+      username,
+      scoreHome: tipHome,
+      scoreAway: tipAway,
+      score,
+    });
+  }
+  return rows;
+}
+
+type PredictionsLoad =
+  | { status: "ok"; rows: PredictionRow[] }
+  | { status: "offline" };
+
+async function loadPredictions(matchId: number): Promise<PredictionsLoad> {
+  try {
+    const raw = await fetchApi<unknown>(`game/${matchId}`);
+    const rows = parseTips(raw);
+    if (rows === null) {
+      return { status: "offline" };
+    }
+    rows.sort((a, b) => b.score - a.score);
+    return { status: "ok", rows };
+  } catch (error) {
+    console.error("[match] predictions API offline:", error);
+    return { status: "offline" };
+  }
+}
+
+export default async function MatchDetailPage({
+  params,
+}: MatchPageProps): Promise<React.ReactElement> {
+  const { user } = await getCurrentSession();
+  if (!user) {
+    throw new Error(
+      "Match detail rendered without a session — auth guard failed",
+    );
+  }
+  const userId = Number(user.id);
+
+  const { id: rawId } = await params;
+  if (!/^[1-9]\d*$/.test(rawId)) {
+    notFound();
+  }
+  const matchId = Number(rawId);
+  if (!Number.isSafeInteger(matchId)) {
+    notFound();
+  }
+
+  const match = await getMatchById(matchId);
+  if (!match) {
+    notFound();
+  }
+
+  const predictions = await loadPredictions(matchId);
+  const status = match.status;
+  const isScheduled = status !== "IN_PLAY" && status !== "FINISHED";
+
+  return (
+    <>
+      <TopAppBar active="dashboard" />
+      <main className="pt-4 md:pt-24 pb-24 md:pb-8 px-margin-mobile md:px-margin-desktop max-w-(--container-max-desktop) mx-auto">
+        <MatchHeader match={match} liveMinute={null} />
+
+        <section>
+          <div className="flex justify-between items-end mb-md">
+            <h3 className="text-headline-md uppercase">User Predictions</h3>
+            <div className="text-label-caps uppercase text-on-surface-variant hidden md:block">
+              Sorted by Points Scored
+            </div>
+          </div>
+
+          {predictions.status === "offline" ? (
+            <div className="bg-surface-container-low border border-outline-variant rounded-xl p-xl text-center">
+              <p className="text-body-lg text-on-surface mb-sm">
+                Predictions service offline
+              </p>
+              <p className="text-body-sm text-on-surface-variant">
+                The user predictions will appear once the Rust service is up.
+              </p>
+            </div>
+          ) : (
+            <PredictionsTable
+              rows={predictions.rows}
+              currentUserId={userId}
+              emptyMessage={
+                isScheduled
+                  ? "No predictions yet"
+                  : "No predictions were submitted for this match"
+              }
+            />
+          )}
+        </section>
+      </main>
+      <BottomNav active="dashboard" />
+    </>
+  );
+}

--- a/components/match/MatchHeader.tsx
+++ b/components/match/MatchHeader.tsx
@@ -1,0 +1,162 @@
+import type { MatchRow } from "@/lib/match";
+import { Flag } from "@/components/dashboard/Flag";
+import { extractTime, formatDate } from "@/lib/format";
+
+interface MatchHeaderProps {
+  match: MatchRow;
+  liveMinute?: number | null;
+}
+
+type Status = "LIVE" | "FINISHED" | "SCHEDULED";
+
+function resolveStatus(raw: string): Status {
+  if (raw === "IN_PLAY" || raw === "PAUSED") return "LIVE";
+  if (raw === "FINISHED") return "FINISHED";
+  return "SCHEDULED";
+}
+
+function hasFinalScore(match: MatchRow): boolean {
+  return match.homeScore !== null && match.awayScore !== null;
+}
+
+export function MatchHeader({
+  match,
+  liveMinute,
+}: MatchHeaderProps): React.ReactElement {
+  const status = resolveStatus(match.status);
+  const showScore = status !== "SCHEDULED" && hasFinalScore(match);
+
+  return (
+    <section className="mb-xl">
+      <div className="bg-surface-container border border-outline-variant rounded-lg overflow-hidden relative">
+        <div className="absolute inset-0 pointer-events-none bg-[radial-gradient(ellipse_at_top,_var(--color-primary-container)_0%,_transparent_55%)] opacity-10" />
+        <div className="relative z-10 p-lg md:p-xl flex flex-col items-center">
+          <StatusBadge status={status} liveMinute={liveMinute} />
+          <div className="flex items-center justify-between w-full max-w-4xl gap-md md:gap-lg mt-md">
+            <TeamBlock
+              tla={match.homeTeam.tla}
+              name={match.homeTeam.name}
+            />
+            <div className="flex flex-col items-center min-w-0">
+              {showScore ? (
+                <div className="text-headline-lg md:text-display font-mono leading-none flex gap-sm md:gap-md text-primary">
+                  <span>{match.homeScore}</span>
+                  <span className="text-on-surface-variant">:</span>
+                  <span>{match.awayScore}</span>
+                </div>
+              ) : status === "SCHEDULED" ? (
+                <div className="text-headline-md md:text-headline-lg font-mono text-on-surface-variant uppercase tracking-tighter">
+                  vs
+                </div>
+              ) : (
+                <div className="text-headline-lg md:text-display font-mono leading-none flex gap-sm md:gap-md text-primary">
+                  <span>?</span>
+                  <span className="text-on-surface-variant">:</span>
+                  <span>?</span>
+                </div>
+              )}
+              <StatusSublabel
+                status={status}
+                liveMinute={liveMinute}
+                kickoff={match.utcDate}
+              />
+            </div>
+            <TeamBlock
+              tla={match.awayTeam.tla}
+              name={match.awayTeam.name}
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function TeamBlock({
+  tla,
+  name,
+}: {
+  tla: string;
+  name: string;
+}): React.ReactElement {
+  return (
+    <div className="flex flex-col items-center flex-1 min-w-0 gap-sm">
+      <Flag
+        tla={tla}
+        name={name}
+        className="w-16 h-10 md:w-20 md:h-12 object-cover rounded-sm shadow-md border border-outline-variant"
+      />
+      <h2 className="text-body-lg md:text-headline-md uppercase text-center font-bold truncate w-full">
+        {name}
+      </h2>
+    </div>
+  );
+}
+
+function StatusBadge({
+  status,
+  liveMinute,
+}: {
+  status: Status;
+  liveMinute?: number | null;
+}): React.ReactElement {
+  if (status === "LIVE") {
+    return (
+      <div className="flex items-center gap-sm bg-error-container/40 border border-error/40 px-md py-1 rounded-full">
+        <span className="w-2 h-2 rounded-full bg-primary-container animate-pulse" />
+        <span className="text-label-caps uppercase text-primary">LIVE</span>
+        {typeof liveMinute === "number" ? (
+          <span className="text-label-caps font-mono text-primary">
+            {liveMinute}&apos;
+          </span>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (status === "FINISHED") {
+    return (
+      <span className="bg-surface-container-highest text-on-surface px-md py-1 rounded text-label-caps uppercase border border-outline-variant">
+        FULL TIME
+      </span>
+    );
+  }
+
+  return (
+    <span className="bg-surface-container-low text-on-surface-variant px-md py-1 rounded text-label-caps uppercase border border-outline-variant">
+      SCHEDULED
+    </span>
+  );
+}
+
+function StatusSublabel({
+  status,
+  liveMinute,
+  kickoff,
+}: {
+  status: Status;
+  liveMinute?: number | null;
+  kickoff: Date;
+}): React.ReactElement | null {
+  if (status === "LIVE") {
+    return (
+      <div className="text-label-caps uppercase text-on-surface-variant mt-xs">
+        {typeof liveMinute === "number" ? `${liveMinute}'` : "Live"}
+      </div>
+    );
+  }
+
+  if (status === "FINISHED") {
+    return (
+      <div className="text-label-caps uppercase text-on-surface-variant mt-xs">
+        FULL TIME
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-label-caps uppercase text-on-surface-variant mt-xs font-mono">
+      {formatDate(kickoff)} &middot; {extractTime(kickoff)}
+    </div>
+  );
+}

--- a/components/match/PredictionsTable.tsx
+++ b/components/match/PredictionsTable.tsx
@@ -1,0 +1,235 @@
+import Link from "next/link";
+import { abbreviateUsername } from "@/lib/format";
+import { scoreColor, type ScoreTone } from "@/lib/scoring";
+
+export interface PredictionRow {
+  userId: number;
+  username: string;
+  scoreHome: number | null;
+  scoreAway: number | null;
+  score: number;
+}
+
+interface PredictionsTableProps {
+  rows: PredictionRow[];
+  currentUserId: number;
+  emptyMessage: string;
+}
+
+function formatRank(rank: number): string {
+  return rank < 10 ? `0${rank}` : String(rank);
+}
+
+function initials(username: string): string {
+  const trimmed = username.trim();
+  if (trimmed.length === 0) return "?";
+  const parts = trimmed.split(/\s+/);
+  if (parts.length >= 2) {
+    return (parts[0][0] + parts[1][0]).toUpperCase();
+  }
+  return trimmed.slice(0, 2).toUpperCase();
+}
+
+function hashHue(value: string): number {
+  let hash = 0;
+  for (let i = 0; i < value.length; i++) {
+    hash = (hash * 31 + value.charCodeAt(i)) >>> 0;
+  }
+  return hash % 360;
+}
+
+function avatarStyle(username: string): React.CSSProperties {
+  const hue = hashHue(username);
+  return {
+    backgroundColor: `hsl(${hue} 55% 28%)`,
+    color: `hsl(${hue} 90% 88%)`,
+  };
+}
+
+function pillClass(tone: ScoreTone): string {
+  switch (tone) {
+    case "success":
+      return "bg-[#1b5e20] text-white border border-green-400/30";
+    case "warning":
+      return "bg-[#fbc02d]/20 text-[#fbc02d] border border-[#fbc02d]/40";
+    case "danger":
+      return "bg-error-container/30 text-error border border-error/40";
+    case "neutral":
+    default:
+      return "bg-surface-container-highest text-on-surface-variant border border-outline-variant";
+  }
+}
+
+function formatPoints(score: number): string {
+  return score > 0 ? `+${score}` : String(score);
+}
+
+function formatPrediction(home: number | null, away: number | null): string {
+  const h = home === null ? "-" : String(home);
+  const a = away === null ? "-" : String(away);
+  return `${h} — ${a}`;
+}
+
+export function PredictionsTable({
+  rows,
+  currentUserId,
+  emptyMessage,
+}: PredictionsTableProps): React.ReactElement {
+  if (rows.length === 0) {
+    return (
+      <div className="bg-surface-container-low border border-outline-variant rounded-xl p-xl text-center text-body-sm text-on-surface-variant">
+        {emptyMessage}
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-surface-container border border-outline-variant rounded-lg overflow-hidden">
+      <div className="hidden md:block overflow-x-auto">
+        <table className="w-full text-left border-collapse">
+          <thead>
+            <tr className="bg-surface-container-high border-b border-outline-variant">
+              <th className="px-lg py-md text-label-caps uppercase text-on-surface-variant">
+                RANK
+              </th>
+              <th className="px-lg py-md text-label-caps uppercase text-on-surface-variant">
+                USER
+              </th>
+              <th className="px-lg py-md text-label-caps uppercase text-on-surface-variant text-center">
+                PREDICTION
+              </th>
+              <th className="px-lg py-md text-label-caps uppercase text-on-surface-variant text-right">
+                POINTS
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-outline-variant">
+            {rows.map((row, index) => {
+              const isCurrent = row.userId === currentUserId;
+              const tone = scoreColor(row.score);
+              return (
+                <tr
+                  key={row.userId}
+                  className={
+                    isCurrent
+                      ? "bg-primary/10 border-l-4 border-primary"
+                      : "hover:bg-surface-container-high transition-colors"
+                  }
+                >
+                  <td
+                    className={`px-lg py-md font-mono text-data-mono ${
+                      isCurrent ? "text-primary font-bold" : ""
+                    }`}
+                  >
+                    {formatRank(index + 1)}
+                  </td>
+                  <td className="px-lg py-md">
+                    <Link
+                      href={`/user/${row.userId}`}
+                      className="flex items-center gap-md hover:underline"
+                    >
+                      <span
+                        className="w-8 h-8 rounded-full flex items-center justify-center font-bold text-xs shrink-0"
+                        style={avatarStyle(row.username)}
+                      >
+                        {initials(row.username)}
+                      </span>
+                      <span
+                        className={
+                          isCurrent
+                            ? "text-primary font-bold"
+                            : "font-bold text-on-surface"
+                        }
+                      >
+                        {abbreviateUsername(row.username)}
+                      </span>
+                      {isCurrent ? (
+                        <span className="bg-primary text-on-primary text-[10px] font-bold px-1 rounded uppercase tracking-tighter">
+                          YOU
+                        </span>
+                      ) : null}
+                    </Link>
+                  </td>
+                  <td className="px-lg py-md text-center font-mono text-headline-md tracking-widest">
+                    {formatPrediction(row.scoreHome, row.scoreAway)}
+                  </td>
+                  <td className="px-lg py-md text-right">
+                    <span
+                      className={`px-4 py-1 rounded-full font-mono text-data-mono inline-block ${pillClass(
+                        tone,
+                      )}`}
+                    >
+                      {formatPoints(row.score)}
+                    </span>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <ul className="md:hidden divide-y divide-outline-variant">
+        {rows.map((row, index) => {
+          const isCurrent = row.userId === currentUserId;
+          const tone = scoreColor(row.score);
+          return (
+            <li
+              key={row.userId}
+              className={
+                isCurrent
+                  ? "bg-primary/10 border-l-4 border-primary p-md"
+                  : "p-md"
+              }
+            >
+              <Link
+                href={`/user/${row.userId}`}
+                className="flex items-center justify-between gap-md"
+              >
+                <div className="flex items-center gap-md min-w-0">
+                  <span
+                    className={`font-mono text-data-mono shrink-0 ${
+                      isCurrent ? "text-primary font-bold" : "text-on-surface-variant"
+                    }`}
+                  >
+                    {formatRank(index + 1)}
+                  </span>
+                  <span
+                    className="w-8 h-8 rounded-full flex items-center justify-center font-bold text-xs shrink-0"
+                    style={avatarStyle(row.username)}
+                  >
+                    {initials(row.username)}
+                  </span>
+                  <div className="flex flex-col min-w-0">
+                    <span
+                      className={`truncate font-bold ${
+                        isCurrent ? "text-primary" : "text-on-surface"
+                      }`}
+                    >
+                      {abbreviateUsername(row.username)}
+                      {isCurrent ? (
+                        <span className="ml-sm bg-primary text-on-primary text-[10px] font-bold px-1 rounded uppercase tracking-tighter">
+                          YOU
+                        </span>
+                      ) : null}
+                    </span>
+                    <span className="font-mono text-data-mono text-on-surface-variant">
+                      {formatPrediction(row.scoreHome, row.scoreAway)}
+                    </span>
+                  </div>
+                </div>
+                <span
+                  className={`px-3 py-1 rounded-full font-mono text-data-mono shrink-0 ${pillClass(
+                    tone,
+                  )}`}
+                >
+                  {formatPoints(row.score)}
+                </span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
New /match/[id] route. Status badges (LIVE pulsing / FULL TIME / SCHEDULED), German-locale kickoff sublabel, predictions table sorted by score DESC, current user highlighted with YOU pill, deterministic HSL avatar from username hash. Live-minute is wired through MatchHeader as a prop but never fabricated — Rust API doesn't yet expose it.

Rust response shape: bare array (not wrapped). Parser tolerates bare-array, wrapped {tips}, and {data:{tips}} variants for forward compatibility.

Reviewer **APPROVE WITH NOTES** (cosmetic only: em-dash vs hyphen, FULL TIME duplication, two hard-coded hex colors in pillClass). tsc + build clean, no inline SVG, no any.

**Out-of-scope finding** (will get its own hotfix): seed password 'test123' (7 chars) collides with FE-002 min(8) validation — seeded users currently can't log in.