### PR TITLE
fix(seed): use 8-char password 'test1234' for demo users

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,18 @@ pnpm db:reset      # wipe + migrate + seed (FE-007)
 pnpm dev           # http://localhost:3000
 ```
 
+Seed users (all share password `test1234`):
+
+| Email | Username | Department |
+|---|---|---|
+| `me@dev.local` | TestUser | Langenfeld |
+| `ada@dev.local` | AdaLovelace | Maintz |
+| `alan@dev.local` | AlanTuring | Maintz |
+| `marie@dev.local` | MarieCurie | Mannheim |
+| `nikola@dev.local` | NikolaTesla | Mannheim |
+| `rosa@dev.local` | RosaParks | Mannheim |
+| `albert@dev.local` | AlbertEinstein | Langenfeld |
+| `isaac@dev.local` | IsaacNewton | Langenfeld |
+
 See [docs in the workspace repo](https://github.com/football-betting/workspace)
 for the full functional spec and ticket backlog.

--- a/scripts/demo_data.ts
+++ b/scripts/demo_data.ts
@@ -316,7 +316,7 @@ async function main(): Promise<void> {
   });
   const passwordHashes = new Map<string, string>();
   for (const u of USERS) {
-    const hash = await argon2id.hash("test123");
+    const hash = await argon2id.hash("test1234");
     passwordHashes.set(u.email, hash);
     console.log(`  hashed ${u.email}`);
   }


### PR DESCRIPTION
FE-002 loginSchema requires password.min(8); FE-007 seed used 'test123' (7 chars), so seeded users couldn't log in. Bumped seed password to 'test1234' and documented the seed roster + password in README.