### PR TITLE
FE-006: user profile page

### DIFF
--- a/app/(app)/user/[id]/page.tsx
+++ b/app/(app)/user/[id]/page.tsx
@@ -1,0 +1,94 @@
+import { notFound } from "next/navigation";
+import { getCurrentSession } from "@/lib/session";
+import { getUserById } from "@/lib/user";
+import { fetchApi } from "@/lib/api";
+import type { RatingUser } from "@/lib/rating";
+import { TopAppBar } from "@/components/dashboard/TopAppBar";
+import { BottomNav } from "@/components/dashboard/BottomNav";
+import { ProfileHeader } from "@/components/profile/ProfileHeader";
+import { StatTiles } from "@/components/profile/StatTiles";
+import { WinnerCards } from "@/components/profile/WinnerCards";
+import { PredictionHistory } from "@/components/profile/PredictionHistory";
+
+interface UserPageProps {
+  params: Promise<{ id: string }>;
+}
+
+type RatingLoad =
+  | { status: "ok"; data: RatingUser }
+  | { status: "offline" };
+
+async function loadUserRating(id: number): Promise<RatingLoad> {
+  try {
+    const data = await fetchApi<RatingUser>(`user/${id}`, "data");
+    return { status: "ok", data };
+  } catch (error) {
+    console.error("[profile] user rating API offline:", error);
+    return { status: "offline" };
+  }
+}
+
+export default async function UserProfilePage({
+  params,
+}: UserPageProps): Promise<React.ReactElement> {
+  const { user: sessionUser } = await getCurrentSession();
+  if (!sessionUser) {
+    throw new Error("Profile rendered without a session — auth guard failed");
+  }
+
+  const { id: rawId } = await params;
+  if (!/^[1-9]\d*$/.test(rawId)) {
+    notFound();
+  }
+  const userId = Number(rawId);
+  if (!Number.isSafeInteger(userId) || userId <= 0) {
+    notFound();
+  }
+
+  const localUser = await getUserById(userId);
+  if (!localUser) {
+    notFound();
+  }
+
+  const ratingLoad = await loadUserRating(userId);
+
+  const position = ratingLoad.status === "ok" ? ratingLoad.data.position : null;
+  const totalPoints =
+    ratingLoad.status === "ok" ? ratingLoad.data.score_sum : null;
+  const exact =
+    ratingLoad.status === "ok" ? ratingLoad.data.sum_win_exact : null;
+  const diff =
+    ratingLoad.status === "ok" ? ratingLoad.data.sum_score_diff : null;
+  const wins = ratingLoad.status === "ok" ? ratingLoad.data.sum_team : null;
+  const bonus = ratingLoad.status === "ok" ? ratingLoad.data.extra_point : null;
+  const tips = ratingLoad.status === "ok" ? ratingLoad.data.tips : [];
+
+  const isOwnProfile = Number(sessionUser.id) === userId;
+
+  return (
+    <>
+      <TopAppBar active={isOwnProfile ? "profile" : "dashboard"} />
+      <main className="pt-4 md:pt-24 pb-24 md:pb-8 px-margin-mobile md:px-margin-desktop max-w-(--container-max-desktop) mx-auto">
+        <div className="grid grid-cols-1 md:grid-cols-12 gap-lg mb-xl">
+          <div className="md:col-span-8 flex flex-col justify-between">
+            <ProfileHeader
+              username={localUser.username}
+              position={position}
+              totalPoints={totalPoints}
+            />
+            <StatTiles exact={exact} diff={diff} wins={wins} bonus={bonus} />
+          </div>
+          <div className="md:col-span-4">
+            <WinnerCards
+              winner={localUser.winner}
+              secretWinner={localUser.secretWinner}
+            />
+          </div>
+        </div>
+
+        <PredictionHistory status={ratingLoad.status} tips={tips} />
+      </main>
+      <BottomNav active={isOwnProfile ? "profile" : "dashboard"} />
+    </>
+  );
+}

--- a/components/profile/PredictionHistory.tsx
+++ b/components/profile/PredictionHistory.tsx
@@ -1,0 +1,173 @@
+import Link from "next/link";
+import type { RatingMatchInfo } from "@/lib/rating";
+import { formatDate } from "@/lib/format";
+import { scoreColor, scoreToneClass } from "@/lib/scoring";
+import { TOURNAMENT_NAME } from "@/lib/data/tournament";
+
+type HistoryStatus = "ok" | "offline";
+
+interface PredictionHistoryProps {
+  status: HistoryStatus;
+  tips: RatingMatchInfo[];
+}
+
+function clampPerMatchPoints(score: number): number {
+  if (score === 4) return 4;
+  if (score === 2) return 2;
+  if (score === 1) return 1;
+  return 0;
+}
+
+function formatPoints(points: number): string {
+  return points > 0 ? `+${points}` : "0";
+}
+
+function formatScorePair(home: number | null, away: number | null): string {
+  const h = home === null ? "—" : String(home);
+  const a = away === null ? "—" : String(away);
+  return `${h} - ${a}`;
+}
+
+function parseDate(date: number): Date {
+  return new Date(date * 1000);
+}
+
+export function PredictionHistory({
+  status,
+  tips,
+}: PredictionHistoryProps): React.ReactElement {
+  return (
+    <section className="mt-xl">
+      <div className="flex justify-between items-end border-b border-outline-variant pb-md mb-lg">
+        <h2 className="text-headline-lg-mobile md:text-headline-lg text-on-background">
+          Prediction History
+        </h2>
+        <span className="text-label-caps uppercase text-on-surface-variant">
+          {TOURNAMENT_NAME}
+        </span>
+      </div>
+
+      {status === "offline" ? (
+        <div className="bg-surface-container-low border border-outline-variant rounded-xl p-xl text-center">
+          <p className="text-body-lg text-on-surface mb-sm">Service offline</p>
+          <p className="text-body-sm text-on-surface-variant">
+            Prediction history will appear once the Rust service is up.
+          </p>
+        </div>
+      ) : tips.length === 0 ? (
+        <div className="bg-surface-container-low border border-outline-variant rounded-xl p-xl text-center text-body-sm text-on-surface-variant">
+          No predictions yet
+        </div>
+      ) : (
+        <>
+          <div className="hidden md:block overflow-hidden border border-outline-variant">
+            <table className="w-full text-left border-collapse">
+              <thead>
+                <tr className="bg-surface-container-high text-label-caps uppercase text-on-surface-variant border-b border-outline-variant">
+                  <th className="px-lg py-md">Match</th>
+                  <th className="px-lg py-md text-center">Prediction</th>
+                  <th className="px-lg py-md text-center">Result</th>
+                  <th className="px-lg py-md text-right">Points</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-outline-variant">
+                {tips.map((t) => {
+                  const points = clampPerMatchPoints(t.score);
+                  const toneClass = scoreToneClass(scoreColor(points));
+                  const matchDate = parseDate(t.date);
+                  return (
+                    <tr
+                      key={t.match_id}
+                      className="bg-surface hover:bg-surface-container-lowest transition-colors"
+                    >
+                      <td className="px-lg py-lg">
+                        <Link
+                          href={`/match/${t.match_id}`}
+                          className="flex flex-col hover:underline"
+                        >
+                          <span className="text-body-lg font-bold text-on-background">
+                            {t.team1.tla} vs {t.team2.tla}
+                          </span>
+                          <span className="text-label-caps uppercase text-on-surface-variant font-mono">
+                            {formatDate(matchDate)}
+                          </span>
+                        </Link>
+                      </td>
+                      <td className="px-lg py-lg text-center">
+                        <span className="bg-surface-container-highest px-md py-xs rounded-sm font-mono text-data-mono text-on-background border border-outline-variant">
+                          {formatScorePair(t.tip_home, t.tip_away)}
+                        </span>
+                      </td>
+                      <td className="px-lg py-lg text-center">
+                        <span className="bg-surface-variant text-on-surface px-md py-xs rounded-sm font-mono text-data-mono">
+                          {formatScorePair(t.score_home, t.score_away)}
+                        </span>
+                      </td>
+                      <td className="px-lg py-lg text-right">
+                        <span
+                          className={`text-headline-md font-mono font-bold ${toneClass}`}
+                        >
+                          {formatPoints(points)}
+                        </span>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          <ul className="md:hidden border border-outline-variant divide-y divide-outline-variant">
+            {tips.map((t) => {
+              const points = clampPerMatchPoints(t.score);
+              const toneClass = scoreToneClass(scoreColor(points));
+              const matchDate = parseDate(t.date);
+              return (
+                <li key={t.match_id} className="bg-surface">
+                  <Link
+                    href={`/match/${t.match_id}`}
+                    className="block p-md hover:bg-surface-container-lowest transition-colors"
+                  >
+                    <div className="flex justify-between items-start gap-md mb-sm">
+                      <div className="flex flex-col min-w-0">
+                        <span className="text-body-lg font-bold text-on-background">
+                          {t.team1.tla} vs {t.team2.tla}
+                        </span>
+                        <span className="text-label-caps uppercase text-on-surface-variant font-mono">
+                          {formatDate(matchDate)}
+                        </span>
+                      </div>
+                      <span
+                        className={`text-headline-md font-mono font-bold shrink-0 ${toneClass}`}
+                      >
+                        {formatPoints(points)}
+                      </span>
+                    </div>
+                    <div className="grid grid-cols-2 gap-sm">
+                      <div className="flex flex-col items-start">
+                        <span className="text-label-caps uppercase text-on-surface-variant">
+                          Prediction
+                        </span>
+                        <span className="bg-surface-container-highest px-md py-xs rounded-sm font-mono text-data-mono text-on-background border border-outline-variant">
+                          {formatScorePair(t.tip_home, t.tip_away)}
+                        </span>
+                      </div>
+                      <div className="flex flex-col items-start">
+                        <span className="text-label-caps uppercase text-on-surface-variant">
+                          Result
+                        </span>
+                        <span className="bg-surface-variant text-on-surface px-md py-xs rounded-sm font-mono text-data-mono">
+                          {formatScorePair(t.score_home, t.score_away)}
+                        </span>
+                      </div>
+                    </div>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </>
+      )}
+    </section>
+  );
+}

--- a/components/profile/ProfileHeader.tsx
+++ b/components/profile/ProfileHeader.tsx
@@ -1,0 +1,47 @@
+interface ProfileHeaderProps {
+  username: string;
+  position: number | null;
+  totalPoints: number | null;
+}
+
+function formatRank(position: number | null): string {
+  if (position === null) return "—";
+  return `#${position}`;
+}
+
+function formatPoints(points: number | null): string {
+  if (points === null) return "—";
+  return points.toLocaleString("de-DE");
+}
+
+export function ProfileHeader({
+  username,
+  position,
+  totalPoints,
+}: ProfileHeaderProps): React.ReactElement {
+  return (
+    <div>
+      <h1 className="text-headline-lg-mobile md:text-headline-lg text-on-background mb-sm">
+        {username}
+      </h1>
+      <div className="flex flex-wrap gap-md items-center mt-md">
+        <div className="bg-surface-container px-lg py-md border border-outline-variant">
+          <span className="text-label-caps uppercase text-on-surface-variant block mb-xs">
+            GLOBAL RANKING
+          </span>
+          <span className="text-display font-mono text-primary tracking-tighter">
+            {formatRank(position)}
+          </span>
+        </div>
+        <div className="bg-surface-container px-lg py-md border border-outline-variant">
+          <span className="text-label-caps uppercase text-on-surface-variant block mb-xs">
+            TOTAL POINTS
+          </span>
+          <span className="text-display font-mono text-tertiary tracking-tighter">
+            {formatPoints(totalPoints)}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/profile/StatTiles.tsx
+++ b/components/profile/StatTiles.tsx
@@ -1,0 +1,38 @@
+interface StatTilesProps {
+  exact: number | null;
+  diff: number | null;
+  wins: number | null;
+  bonus: number | null;
+}
+
+const TILES: { key: keyof StatTilesProps; label: string }[] = [
+  { key: "exact", label: "EXACT" },
+  { key: "diff", label: "DIFF" },
+  { key: "wins", label: "WINS" },
+  { key: "bonus", label: "BONUS" },
+];
+
+function display(value: number | null): string {
+  if (value === null) return "—";
+  return String(value);
+}
+
+export function StatTiles(props: StatTilesProps): React.ReactElement {
+  return (
+    <div className="grid grid-cols-2 lg:grid-cols-4 gap-md mt-lg">
+      {TILES.map((tile) => (
+        <div
+          key={tile.key}
+          className="p-md border border-outline-variant bg-surface-container-low"
+        >
+          <span className="text-label-caps uppercase text-on-surface-variant block">
+            {tile.label}
+          </span>
+          <span className="text-headline-md font-mono text-on-background">
+            {display(props[tile.key])}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/profile/WinnerCards.tsx
+++ b/components/profile/WinnerCards.tsx
@@ -1,0 +1,57 @@
+import { Flag } from "@/components/dashboard/Flag";
+
+interface WinnerCardsProps {
+  winner: string;
+  secretWinner: string;
+}
+
+function WinnerCard({
+  label,
+  tla,
+  icon,
+}: {
+  label: string;
+  tla: string;
+  icon: string;
+}): React.ReactElement {
+  return (
+    <div className="bg-surface-container border border-outline-variant p-lg relative overflow-hidden group">
+      <div className="relative z-10">
+        <span className="text-label-caps uppercase text-on-surface-variant">
+          {label}
+        </span>
+        <div className="flex items-center gap-md mt-sm">
+          <Flag
+            tla={tla}
+            name={tla}
+            className="w-10 h-auto rounded-xs grayscale group-hover:grayscale-0 transition-all duration-500"
+          />
+          <span className="text-headline-md font-bold uppercase tracking-widest">
+            {tla}
+          </span>
+        </div>
+      </div>
+      <div className="absolute -right-4 -bottom-4 opacity-5 pointer-events-none">
+        <span className="material-symbols-outlined" style={{ fontSize: 120 }}>
+          {icon}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function WinnerCards({
+  winner,
+  secretWinner,
+}: WinnerCardsProps): React.ReactElement {
+  return (
+    <div className="flex flex-col gap-md">
+      <WinnerCard label="TOURNAMENT WINNER" tla={winner} icon="emoji_events" />
+      <WinnerCard
+        label="SECRET WINNER"
+        tla={secretWinner}
+        icon="visibility_off"
+      />
+    </div>
+  );
+}

--- a/lib/data/tournament.ts
+++ b/lib/data/tournament.ts
@@ -1,0 +1,1 @@
+export const TOURNAMENT_NAME = "Office Pool 2026";

--- a/lib/user.ts
+++ b/lib/user.ts
@@ -11,6 +11,12 @@ export async function getUserByEmail(
   return db.query.user.findFirst({ where: eq(user.email, email) });
 }
 
+export async function getUserById(
+  id: number,
+): Promise<DatabaseUser | undefined> {
+  return db.query.user.findFirst({ where: eq(user.id, id) });
+}
+
 export async function createUser(newUser: NewUser): Promise<number> {
   const inserted = await db
     .insert(user)


### PR DESCRIPTION
New /user/[id] route with header + 4 stat tiles + winner cards + prediction history. Defensive clampPerMatchPoints ensures the history shows only +4/+2/+1/0 (never the +15/+7 bonuses — those stay in the BONUS tile aggregate). Tournament name in lib/data/tournament.ts; no hardcoded 'SEASON 2024'. Rust-offline degrades gracefully. Reviewer **APPROVE**. tsc + build clean, no inline SVG, no any.