### PR TITLE
FE-008: match-import API with x-api-key auth (frontend half)

### DIFF
--- a/app/api/match/import/route.ts
+++ b/app/api/match/import/route.ts
@@ -1,0 +1,124 @@
+import { timingSafeEqual } from "node:crypto";
+import { db } from "@/lib/db";
+import { match } from "@/db/schema";
+import { matchImportSchema } from "@/lib/validation/match-import";
+
+const JSON_HEADERS = { "Content-Type": "application/json" } as const;
+
+function jsonResponse(body: unknown, status: number, extra?: HeadersInit): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...JSON_HEADERS, ...(extra ?? {}) },
+  });
+}
+
+function unauthorized(): Response {
+  return jsonResponse({ error: "invalid api key" }, 401);
+}
+
+function methodNotAllowed(): Response {
+  return new Response(JSON.stringify({ error: "method not allowed" }), {
+    status: 405,
+    headers: { ...JSON_HEADERS, Allow: "POST" },
+  });
+}
+
+function verifyApiKey(request: Request): Response | null {
+  const configured = process.env.MATCH_IMPORT_API_KEY ?? "";
+  if (configured.length === 0) {
+    console.error("[match/import] MATCH_IMPORT_API_KEY is not configured");
+    return jsonResponse({ error: "server misconfigured" }, 500);
+  }
+
+  const provided = request.headers.get("x-api-key") ?? "";
+  const expected = Buffer.from(configured);
+  const got = Buffer.from(provided);
+
+  if (got.length !== expected.length) {
+    return unauthorized();
+  }
+  if (!timingSafeEqual(got, expected)) {
+    return unauthorized();
+  }
+  return null;
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const authError = verifyApiKey(request);
+  if (authError) return authError;
+
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return jsonResponse(
+      { error: "invalid payload", issues: [{ message: "invalid JSON" }] },
+      400,
+    );
+  }
+
+  const parsed = matchImportSchema.safeParse(raw);
+  if (!parsed.success) {
+    return jsonResponse(
+      { error: "invalid payload", issues: parsed.error.issues },
+      400,
+    );
+  }
+
+  const data = parsed.data;
+  const utcDate = new Date(data.utcDate * 1000);
+
+  const values = {
+    id: data.id,
+    homeTeam: data.homeTeam,
+    awayTeam: data.awayTeam,
+    status: data.status,
+    utcDate,
+    score: data.score ?? null,
+    homeScore: data.homeScore ?? null,
+    awayScore: data.awayScore ?? null,
+  };
+
+  try {
+    await db
+      .insert(match)
+      .values(values)
+      .onConflictDoUpdate({
+        target: match.id,
+        set: {
+          homeTeam: values.homeTeam,
+          awayTeam: values.awayTeam,
+          status: values.status,
+          utcDate: values.utcDate,
+          score: values.score,
+          homeScore: values.homeScore,
+          awayScore: values.awayScore,
+        },
+      });
+  } catch (error) {
+    console.error("[match/import] upsert failed", error);
+    return jsonResponse({ error: "upsert failed" }, 500);
+  }
+
+  return jsonResponse({ ok: true, id: data.id }, 200);
+}
+
+export function GET(): Response {
+  return methodNotAllowed();
+}
+
+export function HEAD(): Response {
+  return methodNotAllowed();
+}
+
+export function PUT(): Response {
+  return methodNotAllowed();
+}
+
+export function DELETE(): Response {
+  return methodNotAllowed();
+}
+
+export function PATCH(): Response {
+  return methodNotAllowed();
+}

--- a/lib/validation/match-import.ts
+++ b/lib/validation/match-import.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+export const MATCH_STATUSES = [
+  "SCHEDULED",
+  "IN_PLAY",
+  "PAUSED",
+  "FINISHED",
+  "POSTPONED",
+  "CANCELLED",
+  "SUSPENDED",
+] as const;
+
+const teamSchema = z.object({
+  name: z.string().min(1),
+  tla: z.string().min(2).max(5),
+  crest: z.string().optional(),
+});
+
+export const matchImportSchema = z.object({
+  id: z.number().int().positive(),
+  homeTeam: teamSchema,
+  awayTeam: teamSchema,
+  status: z.enum(MATCH_STATUSES),
+  utcDate: z.number().int(),
+  score: z.unknown().optional(),
+  homeScore: z.number().int().nullable().optional(),
+  awayScore: z.number().int().nullable().optional(),
+});
+
+export type MatchImportInput = z.infer<typeof matchImportSchema>;

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,6 +2,10 @@ import { NextResponse, type NextRequest } from "next/server";
 import { verifyRequestOrigin } from "lucia";
 
 export function middleware(request: NextRequest): NextResponse {
+  if (request.nextUrl.pathname === "/api/match/import") {
+    return NextResponse.next();
+  }
+
   if (request.method !== "GET") {
     const originHeader = request.headers.get("Origin");
     const hostHeader =


### PR DESCRIPTION
Frontend half only. The macht-api Rust changes are tracked as XR-001 in the workspace.

POST /api/match/import with constant-time x-api-key compare (node:crypto.timingSafeEqual), Zod-validated payload, Drizzle onConflictDoUpdate. Identical 401 shape for both wrong-key branches. CSRF middleware skipped for this route only via exact-match pass-through; every other non-GET still goes through verifyRequestOrigin (smoke-verified).

Reviewer **APPROVE**. tsc + build clean.