### PR TITLE
FE-010: vitest + playwright suite against FE-007 seed

### DIFF
--- a/.env.test.example
+++ b/.env.test.example
@@ -1,0 +1,3 @@
+DATABASE_URL=../shared/db/test.db
+RUST_API_URL=http://localhost:8080
+MATCH_IMPORT_API_KEY=devkey-test

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ yarn-error.log*
 .env
 .env*.local
 .env.production
+.env.test
 
 # Typescript
 *.tsbuildinfo

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -1,9 +1,10 @@
 export function formatDate(ts: Date | number): string {
   const d = ts instanceof Date ? ts : new Date(ts);
   return d.toLocaleDateString("de-DE", {
-    weekday: "short",
+    weekday: "long",
     day: "numeric",
     month: "long",
+    year: "numeric",
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,12 @@
     "db:seed": "tsx scripts/demo_data.ts",
     "db:seed:test": "DATABASE_URL=../shared/db/test.db tsx scripts/demo_data.ts",
     "db:reset": "tsx scripts/reset.ts",
-    "db:fresh": "tsx scripts/reset.ts"
+    "db:fresh": "tsx scripts/reset.ts",
+    "test": "vitest run",
+    "test:unit": "vitest run tests/unit",
+    "test:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed"
   },
   "dependencies": {
     "@lucia-auth/adapter-drizzle": "^1.1.0",
@@ -28,17 +33,20 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4.0.0",
     "@types/better-sqlite3": "^7.6.12",
     "@types/node": "^22.10.2",
     "@types/react": "^19.0.1",
     "@types/react-dom": "^19.0.2",
+    "@vitest/coverage-v8": "^4.1.7",
     "drizzle-kit": "^0.28.1",
     "eslint": "^9",
     "eslint-config-next": "15.0.4",
     "postcss": "^8.4.49",
     "tailwindcss": "^4.0.0",
     "tsx": "^4.19.2",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "vitest": "^4.1.7"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  globalSetup: "./tests/e2e/setup.ts",
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: "list",
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "pnpm dev",
+    url: "http://localhost:3000/login",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: {
+      DATABASE_URL: "../shared/db/test.db",
+      RUST_API_URL: process.env.RUST_API_URL ?? "http://localhost:8080",
+      MATCH_IMPORT_API_KEY: "devkey-test",
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 3.2.2
       next:
         specifier: 15.0.4
-        version: 15.0.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 15.0.4(@playwright/test@1.60.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       oslo:
         specifier: ^1.2.1
         version: 1.2.1
@@ -36,6 +36,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@tailwindcss/postcss':
         specifier: ^4.0.0
         version: 4.3.0
@@ -51,6 +54,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.0.2
         version: 19.2.3(@types/react@19.2.15)
+      '@vitest/coverage-v8':
+        specifier: ^4.1.7
+        version: 4.1.7(vitest@4.1.7)
       drizzle-kit:
         specifier: ^0.28.1
         version: 0.28.1
@@ -72,12 +78,36 @@ importers:
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.0.14(@types/node@22.19.19)(esbuild@0.19.12)(jiti@2.7.0)(tsx@4.22.3))
 
 packages:
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -1003,11 +1033,120 @@ packages:
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
+  '@oxc-project/types@0.132.0':
+    resolution: {integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@rolldown/binding-android-arm64@1.0.2':
+    resolution: {integrity: sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.2':
+    resolution: {integrity: sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.2':
+    resolution: {integrity: sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.2':
+    resolution: {integrity: sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
+    resolution: {integrity: sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.2':
+    resolution: {integrity: sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.2':
+    resolution: {integrity: sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.2':
+    resolution: {integrity: sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.2':
+    resolution: {integrity: sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.2':
+    resolution: {integrity: sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.2':
+    resolution: {integrity: sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.2':
+    resolution: {integrity: sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.2':
+    resolution: {integrity: sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.2':
+    resolution: {integrity: sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.2':
+    resolution: {integrity: sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
   '@rushstack/eslint-patch@1.16.1':
     resolution: {integrity: sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
@@ -1115,6 +1254,12 @@ packages:
 
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
@@ -1315,6 +1460,44 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/coverage-v8@4.1.7':
+    resolution: {integrity: sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==}
+    peerDependencies:
+      '@vitest/browser': 4.1.7
+      vitest: 4.1.7
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@4.1.7':
+    resolution: {integrity: sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==}
+
+  '@vitest/mocker@4.1.7':
+    resolution: {integrity: sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.7':
+    resolution: {integrity: sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==}
+
+  '@vitest/runner@4.1.7':
+    resolution: {integrity: sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==}
+
+  '@vitest/snapshot@4.1.7':
+    resolution: {integrity: sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==}
+
+  '@vitest/spy@4.1.7':
+    resolution: {integrity: sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==}
+
+  '@vitest/utils@4.1.7':
+    resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1371,8 +1554,15 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
+
+  ast-v8-to-istanbul@1.0.2:
+    resolution: {integrity: sha512-dKmJxJsGItLmc5CYZKuEjuG6GnBs6PG4gohMhyFOWKaNQoYCuRZJDECaBlHmcG0lv2wc2E0uU8lESmBEumC3DQ==}
 
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
@@ -1450,6 +1640,10 @@ packages:
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -1476,6 +1670,9 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1669,6 +1866,9 @@ packages:
     resolution: {integrity: sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
@@ -1825,6 +2025,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -1832,6 +2035,10 @@ packages:
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1889,6 +2096,11 @@ packages:
 
   fs-monkey@1.1.0:
     resolution: {integrity: sha512-QMUezzXWII9EV5aTFXW1UBVUO77wYPpjqIF8/AviUCThNeSYZykpoTixUeaNNBwmCev0AMDWMAni+f8Hxb1IFw==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1976,6 +2188,9 @@ packages:
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -2118,6 +2333,18 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
@@ -2125,6 +2352,9 @@ packages:
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2256,6 +2486,13 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -2373,6 +2610,9 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -2411,6 +2651,9 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2421,6 +2664,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -2501,6 +2754,11 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rolldown@1.0.2:
+    resolution: {integrity: sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -2571,6 +2829,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
 
@@ -2593,6 +2854,12 @@ packages:
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -2675,9 +2942,20 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.2:
+    resolution: {integrity: sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -2744,6 +3022,90 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  vite@8.0.14:
+    resolution: {integrity: sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.7:
+    resolution: {integrity: sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.7
+      '@vitest/browser-preview': 4.1.7
+      '@vitest/browser-webdriverio': 4.1.7
+      '@vitest/coverage-istanbul': 4.1.7
+      '@vitest/coverage-v8': 4.1.7
+      '@vitest/ui': 4.1.7
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -2765,6 +3127,11 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
@@ -2782,6 +3149,21 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@drizzle-team/brocli@0.10.2': {}
 
@@ -3387,9 +3769,68 @@ snapshots:
 
   '@oslojs/encoding@1.1.0': {}
 
+  '@oxc-project/types@0.132.0': {}
+
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
+  '@rolldown/binding-android-arm64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.2':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.2':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.2':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.2':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.16.1': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@swc/counter@0.1.3': {}
 
@@ -3479,6 +3920,13 @@ snapshots:
   '@types/better-sqlite3@7.6.13':
     dependencies:
       '@types/node': 22.19.19
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
 
@@ -3659,6 +4107,61 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
+  '@vitest/coverage-v8@4.1.7(vitest@4.1.7)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.7
+      ast-v8-to-istanbul: 1.0.2
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.1
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.0.14(@types/node@22.19.19)(esbuild@0.19.12)(jiti@2.7.0)(tsx@4.22.3))
+
+  '@vitest/expect@4.1.7':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.7(vite@8.0.14(@types/node@22.19.19)(esbuild@0.19.12)(jiti@2.7.0)(tsx@4.22.3))':
+    dependencies:
+      '@vitest/spy': 4.1.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.14(@types/node@22.19.19)(esbuild@0.19.12)(jiti@2.7.0)(tsx@4.22.3)
+
+  '@vitest/pretty-format@4.1.7':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.7':
+    dependencies:
+      '@vitest/utils': 4.1.7
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.7':
+    dependencies:
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/utils': 4.1.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.7': {}
+
+  '@vitest/utils@4.1.7':
+    dependencies:
+      '@vitest/pretty-format': 4.1.7
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -3747,7 +4250,15 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
+
+  ast-v8-to-istanbul@1.0.2:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   async-function@1.0.0: {}
 
@@ -3825,6 +4336,8 @@ snapshots:
 
   caniuse-lite@1.0.30001793: {}
 
+  chai@6.2.2: {}
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -3853,6 +4366,8 @@ snapshots:
     optional: true
 
   concat-map@0.0.1: {}
+
+  convert-source-map@2.0.0: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -4028,6 +4543,8 @@ snapshots:
       internal-slot: 1.1.0
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
+
+  es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.2:
     dependencies:
@@ -4335,9 +4852,15 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
 
   expand-template@2.0.3: {}
+
+  expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -4390,6 +4913,9 @@ snapshots:
   fs-constants@1.0.0: {}
 
   fs-monkey@1.1.0:
+    optional: true
+
+  fsevents@2.3.2:
     optional: true
 
   fsevents@2.3.3:
@@ -4480,6 +5006,8 @@ snapshots:
   hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
+
+  html-escaper@2.0.2: {}
 
   ieee754@1.2.1: {}
 
@@ -4623,6 +5151,19 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   iterator.prototype@1.1.5:
     dependencies:
       define-data-property: 1.1.4
@@ -4633,6 +5174,8 @@ snapshots:
       set-function-name: 2.0.2
 
   jiti@2.7.0: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -4740,6 +5283,16 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magicast@0.5.3:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.1
+
   math-intrinsics@1.1.0: {}
 
   memfs-browser@3.5.10302:
@@ -4783,7 +5336,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@15.0.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  next@15.0.4(@playwright/test@1.60.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       '@next/env': 15.0.4
       '@swc/counter': 0.1.3
@@ -4803,6 +5356,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.0.4
       '@next/swc-win32-arm64-msvc': 15.0.4
       '@next/swc-win32-x64-msvc': 15.0.4
+      '@playwright/test': 1.60.0
       sharp: 0.33.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -4861,6 +5415,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
 
+  obug@2.1.1: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -4903,11 +5459,21 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 
@@ -5011,6 +5577,27 @@ snapshots:
       supports-preserve-symlinks-flag: 1.0.0
 
   reusify@1.1.0: {}
+
+  rolldown@1.0.2:
+    dependencies:
+      '@oxc-project/types': 0.132.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.2
+      '@rolldown/binding-darwin-arm64': 1.0.2
+      '@rolldown/binding-darwin-x64': 1.0.2
+      '@rolldown/binding-freebsd-x64': 1.0.2
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.2
+      '@rolldown/binding-linux-arm64-gnu': 1.0.2
+      '@rolldown/binding-linux-arm64-musl': 1.0.2
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.2
+      '@rolldown/binding-linux-s390x-gnu': 1.0.2
+      '@rolldown/binding-linux-x64-gnu': 1.0.2
+      '@rolldown/binding-linux-x64-musl': 1.0.2
+      '@rolldown/binding-openharmony-arm64': 1.0.2
+      '@rolldown/binding-wasm32-wasi': 1.0.2
+      '@rolldown/binding-win32-arm64-msvc': 1.0.2
+      '@rolldown/binding-win32-x64-msvc': 1.0.2
 
   run-parallel@1.2.0:
     dependencies:
@@ -5126,6 +5713,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   simple-concat@1.0.1: {}
 
   simple-get@4.0.1:
@@ -5149,6 +5738,10 @@ snapshots:
   source-map@0.6.1: {}
 
   stable-hash@0.0.5: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -5247,10 +5840,16 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.2: {}
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -5360,6 +5959,48 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  vite@8.0.14(@types/node@22.19.19)(esbuild@0.19.12)(jiti@2.7.0)(tsx@4.22.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 22.19.19
+      esbuild: 0.19.12
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      tsx: 4.22.3
+
+  vitest@4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.0.14(@types/node@22.19.19)(esbuild@0.19.12)(jiti@2.7.0)(tsx@4.22.3)):
+    dependencies:
+      '@vitest/expect': 4.1.7
+      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@22.19.19)(esbuild@0.19.12)(jiti@2.7.0)(tsx@4.22.3))
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.14(@types/node@22.19.19)(esbuild@0.19.12)(jiti@2.7.0)(tsx@4.22.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.19
+      '@vitest/coverage-v8': 4.1.7(vitest@4.1.7)
+    transitivePeerDependencies:
+      - msw
+
   which-boxed-primitive@1.1.1:
     dependencies:
       is-bigint: 1.1.0
@@ -5404,6 +6045,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/tests/e2e/auth-disclosure.spec.ts
+++ b/tests/e2e/auth-disclosure.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test, type APIResponse } from "@playwright/test";
+
+async function attemptLogin(
+  request: import("@playwright/test").APIRequestContext,
+  email: string,
+  password: string,
+): Promise<{ status: number; body: { error?: string } }> {
+  const form = new URLSearchParams();
+  form.set("email", email);
+  form.set("password", password);
+  const res: APIResponse = await request.post(
+    "http://localhost:3000/api/auth/login",
+    {
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+        Origin: "http://localhost:3000",
+      },
+      data: form.toString(),
+    },
+  );
+  const body = (await res.json().catch(() => ({}))) as { error?: string };
+  return { status: res.status(), body };
+}
+
+test.describe("auth disclosure", () => {
+  test("unknown email and wrong password produce the same response as a known email with a wrong password", async ({
+    request,
+  }) => {
+    const unknown = await attemptLogin(
+      request,
+      `unknown-${Date.now()}@dev.local`,
+      "wrong-password-99",
+    );
+    const known = await attemptLogin(
+      request,
+      "me@dev.local",
+      "wrong-password-99",
+    );
+
+    expect(unknown.status).toBe(known.status);
+    expect(unknown.body.error).toBe(known.body.error);
+    expect(known.body.error).toBe("Email or password incorrect.");
+  });
+});

--- a/tests/e2e/auth-flow.spec.ts
+++ b/tests/e2e/auth-flow.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("auth happy path", () => {
+  test("signup redirects to /login?registered=true and shows success banner", async ({
+    page,
+  }) => {
+    const unique = `e2e-signup-${Date.now()}@dev.local`;
+    await page.goto("/signup");
+
+    await page.fill("#firstName", "E2E");
+    await page.fill("#lastName", "Tester");
+    await page.fill("#username", `e2e_${Date.now()}`);
+    await page.fill("#email", unique);
+    await page.fill("#password", "test1234");
+    await page.fill("#rePassword", "test1234");
+    await page.selectOption("#department", "Langenfeld");
+    await page.selectOption("#winner", "DEU");
+    await page.selectOption("#secretWinner", "ESP");
+
+    await page.click("button[type=submit]");
+
+    await page.waitForURL(/\/login\?registered=true$/);
+    await expect(
+      page.getByText("Account created. Sign in below."),
+    ).toBeVisible();
+  });
+
+  test("login lands on the dashboard, logout returns to /login, /  redirects to /login when signed out", async ({
+    page,
+  }) => {
+    await page.goto("/login");
+    await page.fill("#email", "me@dev.local");
+    await page.fill("#password", "test1234");
+    await page.click("button[type=submit]");
+    await page.waitForURL("http://localhost:3000/");
+
+    await expect(page).toHaveURL("http://localhost:3000/");
+
+    const logout = page.getByRole("button", { name: "Logout" }).first();
+    await logout.click();
+    await page.waitForURL(/\/login(\?|$)/);
+
+    await page.goto("/");
+    await page.waitForURL(/\/login(\?|$)/);
+  });
+});

--- a/tests/e2e/dashboard.spec.ts
+++ b/tests/e2e/dashboard.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "@playwright/test";
+
+async function login(page: import("@playwright/test").Page): Promise<void> {
+  await page.goto("/login");
+  await page.fill("#email", "me@dev.local");
+  await page.fill("#password", "test1234");
+  await page.click("button[type=submit]");
+  await page.waitForURL("http://localhost:3000/");
+}
+
+test.describe("dashboard buckets", () => {
+  test("live block lists both IN_PLAY matches", async ({ page }) => {
+    await login(page);
+
+    const liveSection = page
+      .locator("section", { hasText: "LIVE NOW" })
+      .first();
+    await expect(liveSection).toBeVisible();
+    const liveRows = liveSection.locator("a[href^='/match/']");
+    await expect(liveRows).toHaveCount(2);
+  });
+
+  test("upcoming list shows the SCHEDULED fixtures grouped by date", async ({
+    page,
+  }) => {
+    await login(page);
+
+    const upcomingSection = page
+      .locator("section", { hasText: "UPCOMING FIXTURES" })
+      .first();
+    await expect(upcomingSection).toBeVisible();
+    const homeInputs = upcomingSection.getByLabel("Home score tip");
+    const count = await homeInputs.count();
+    expect(count).toBeGreaterThanOrEqual(6);
+  });
+});

--- a/tests/e2e/match-detail.spec.ts
+++ b/tests/e2e/match-detail.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "@playwright/test";
+
+async function login(page: import("@playwright/test").Page): Promise<void> {
+  await page.goto("/login");
+  await page.fill("#email", "me@dev.local");
+  await page.fill("#password", "test1234");
+  await page.click("button[type=submit]");
+  await page.waitForURL("http://localhost:3000/");
+}
+
+test.describe("match detail status badges", () => {
+  test("FINISHED match shows the FULL TIME badge", async ({ page }) => {
+    await login(page);
+    await page.goto("/match/1");
+    await expect(
+      page.getByText("FULL TIME", { exact: true }).first(),
+    ).toBeVisible();
+  });
+
+  test("IN_PLAY match shows the LIVE badge", async ({ page }) => {
+    await login(page);
+    await page.goto("/match/5");
+    await expect(page.getByText("LIVE", { exact: true }).first()).toBeVisible();
+  });
+
+  test("SCHEDULED match shows the SCHEDULED badge and the German kickoff date", async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto("/match/7");
+    await expect(
+      page.getByText("SCHEDULED", { exact: true }).first(),
+    ).toBeVisible();
+    const germanWeekday = page.locator("text=/Montag|Dienstag|Mittwoch|Donnerstag|Freitag|Samstag|Sonntag/");
+    await expect(germanWeekday.first()).toBeVisible();
+  });
+});

--- a/tests/e2e/profile.spec.ts
+++ b/tests/e2e/profile.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "@playwright/test";
+
+async function login(page: import("@playwright/test").Page): Promise<void> {
+  await page.goto("/login");
+  await page.fill("#email", "me@dev.local");
+  await page.fill("#password", "test1234");
+  await page.click("button[type=submit]");
+  await page.waitForURL("http://localhost:3000/");
+}
+
+test.describe("profile page", () => {
+  test("renders four stat tiles and a history table without tournament bonuses", async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto("/user/6");
+
+    for (const label of ["EXACT", "DIFF", "WINS", "BONUS"]) {
+      await expect(page.getByText(label, { exact: true }).first()).toBeVisible();
+    }
+
+    const offlineLine = page.getByText("Service offline");
+    const isOffline = await offlineLine
+      .first()
+      .isVisible()
+      .catch(() => false);
+
+    if (!isOffline) {
+      const historySection = page
+        .locator("section", { hasText: "Prediction History" })
+        .first();
+      const sectionText = (await historySection.innerText()) ?? "";
+      expect(sectionText).not.toMatch(/\+150/);
+      expect(sectionText).not.toMatch(/\+15\b/);
+      expect(sectionText).not.toMatch(/\+7\b/);
+      const offendingTokens = [
+        "GRUPPENPHASE",
+        "VIERTELFINALE",
+        "HALBFINALE",
+        "ACHTELFINALE",
+        "FINALE",
+      ];
+      for (const token of offendingTokens) {
+        expect(sectionText.toUpperCase()).not.toContain(token);
+      }
+    }
+  });
+});

--- a/tests/e2e/ranking.spec.ts
+++ b/tests/e2e/ranking.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "@playwright/test";
+
+async function login(page: import("@playwright/test").Page): Promise<void> {
+  await page.goto("/login");
+  await page.fill("#email", "me@dev.local");
+  await page.fill("#password", "test1234");
+  await page.click("button[type=submit]");
+  await page.waitForURL("http://localhost:3000/");
+}
+
+test.describe("ranking page", () => {
+  test("renders the four tabs and the scoring legend", async ({ page }) => {
+    await login(page);
+    await page.goto("/ranking");
+
+    for (const tab of ["Global", "Langenfeld", "Mannheim", "Mainz"]) {
+      await expect(
+        page.getByRole("button", { name: tab, exact: true }),
+      ).toBeVisible();
+    }
+
+    const offlineNotice = page.getByText("Ranking API offline");
+    const scoringInfobox = page.getByText("Scoring System");
+
+    const ranking = await scoringInfobox
+      .first()
+      .isVisible()
+      .catch(() => false);
+    const offline = await offlineNotice
+      .first()
+      .isVisible()
+      .catch(() => false);
+
+    expect(ranking || offline).toBe(true);
+
+    if (ranking) {
+      await expect(page.getByText("4 Pts")).toBeVisible();
+      await expect(page.getByText("2 Pts")).toBeVisible();
+      await expect(page.getByText("1 Pt")).toBeVisible();
+      await expect(page.getByText("+15 Pts (bonus)")).toBeVisible();
+      await expect(page.getByText("+7 Pts (bonus)")).toBeVisible();
+      const youPill = page.getByText("YOU", { exact: true }).first();
+      await expect(youPill).toBeVisible();
+    }
+  });
+});

--- a/tests/e2e/setup.ts
+++ b/tests/e2e/setup.ts
@@ -1,0 +1,41 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const FRONTEND_ROOT = path.resolve(HERE, "../..");
+const TEST_DB = path.resolve(FRONTEND_ROOT, "../shared/db/test.db");
+
+function removeDbFiles(): void {
+  for (const suffix of ["", "-shm", "-wal"]) {
+    const file = TEST_DB + suffix;
+    if (fs.existsSync(file)) {
+      fs.rmSync(file, { force: true });
+    }
+  }
+}
+
+function run(cmd: string, args: string[]): void {
+  const env = {
+    ...process.env,
+    DATABASE_URL: "../shared/db/test.db",
+  };
+  const result = spawnSync(cmd, args, {
+    stdio: "inherit",
+    env,
+    shell: false,
+    cwd: FRONTEND_ROOT,
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `globalSetup: ${cmd} ${args.join(" ")} failed with exit code ${result.status}`,
+    );
+  }
+}
+
+export default async function globalSetup(): Promise<void> {
+  removeDbFiles();
+  run("pnpm", ["db:migrate"]);
+  run("pnpm", ["db:seed:test"]);
+}

--- a/tests/e2e/tip.spec.ts
+++ b/tests/e2e/tip.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "@playwright/test";
+
+async function login(page: import("@playwright/test").Page): Promise<void> {
+  await page.goto("/login");
+  await page.fill("#email", "me@dev.local");
+  await page.fill("#password", "test1234");
+  await page.click("button[type=submit]");
+  await page.waitForURL("http://localhost:3000/");
+}
+
+test.describe("tip flow", () => {
+  test("entering a tip for a SCHEDULED match persists across reload", async ({
+    page,
+  }) => {
+    await login(page);
+
+    const homeInput = page.getByLabel("Home score tip").first();
+    const awayInput = page.getByLabel("Away score tip").first();
+    await expect(homeInput).toBeVisible();
+
+    await homeInput.fill("2");
+    await awayInput.fill("1");
+
+    const form = homeInput.locator("xpath=ancestor::form");
+    await form.getByRole("button").click();
+
+    await expect(form.getByRole("button")).toHaveText(/SAVED|EDIT/, {
+      timeout: 10_000,
+    });
+
+    await page.reload();
+    const homeAfter = page.getByLabel("Home score tip").first();
+    const awayAfter = page.getByLabel("Away score tip").first();
+    await expect(homeAfter).toHaveValue("2");
+    await expect(awayAfter).toHaveValue("1");
+  });
+
+  test("a FINISHED match exposes no editable tip input", async ({ page }) => {
+    await login(page);
+    await page.goto("/match/1");
+
+    const tipInputs = page.getByLabel("Home score tip");
+    await expect(tipInputs).toHaveCount(0);
+  });
+});

--- a/tests/unit/departments.test.ts
+++ b/tests/unit/departments.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { displayDepartment } from "@/lib/data/departments";
+
+describe("displayDepartment", () => {
+  it("rewrites the misspelled 'Maintz' to 'Mainz'", () => {
+    expect(displayDepartment("Maintz")).toBe("Mainz");
+  });
+
+  it("returns Mannheim unchanged", () => {
+    expect(displayDepartment("Mannheim")).toBe("Mannheim");
+  });
+
+  it("returns Langenfeld unchanged", () => {
+    expect(displayDepartment("Langenfeld")).toBe("Langenfeld");
+  });
+});

--- a/tests/unit/format.test.ts
+++ b/tests/unit/format.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  abbreviateUsername,
+  extractTime,
+  formatDate,
+  formatDateKey,
+} from "@/lib/format";
+
+describe("formatDate", () => {
+  it("formats a German locale long date string", () => {
+    const date = new Date(2022, 11, 31);
+    expect(formatDate(date.getTime())).toBe("Samstag, 31. Dezember 2022");
+  });
+
+  it("accepts a Date object directly", () => {
+    expect(formatDate(new Date(2022, 11, 31))).toBe(
+      "Samstag, 31. Dezember 2022",
+    );
+  });
+});
+
+describe("formatDateKey", () => {
+  it("formats a date as YYYY-MM-DD", () => {
+    expect(formatDateKey(new Date(2022, 0, 5))).toBe("2022-01-05");
+  });
+});
+
+describe("extractTime", () => {
+  it("returns the German locale HH:MM string", () => {
+    expect(extractTime(new Date(2022, 11, 31, 13, 45))).toBe("13:45");
+  });
+});
+
+describe("abbreviateUsername", () => {
+  it("truncates a long name to 14 chars plus ellipsis", () => {
+    const longName = "verylongusernamethatistoolong";
+    expect(longName.length).toBe(29);
+    const result = abbreviateUsername(longName);
+    expect(result).toBe("verylonguserna…");
+    expect(result.length).toBe(15);
+  });
+
+  it("leaves a short name unchanged", () => {
+    expect(abbreviateUsername("short")).toBe("short");
+  });
+});

--- a/tests/unit/scoring-color.test.ts
+++ b/tests/unit/scoring-color.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { scoreColor } from "@/lib/scoring";
+
+describe("scoreColor", () => {
+  it("maps 4 to success", () => {
+    expect(scoreColor(4)).toBe("success");
+  });
+
+  it("maps 2 to warning", () => {
+    expect(scoreColor(2)).toBe("warning");
+  });
+
+  it("maps 1 to neutral", () => {
+    expect(scoreColor(1)).toBe("neutral");
+  });
+
+  it("maps 0 to danger", () => {
+    expect(scoreColor(0)).toBe("danger");
+  });
+
+  it("falls back to neutral for unknown values", () => {
+    expect(scoreColor(3)).toBe("neutral");
+    expect(scoreColor(7)).toBe("neutral");
+    expect(scoreColor(-1)).toBe("neutral");
+  });
+});

--- a/tests/unit/scoring.test.ts
+++ b/tests/unit/scoring.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { computeScore } from "@/lib/score";
+
+describe("computeScore", () => {
+  it("returns 4 for an exact score match (tip 1:0 vs result 1:0)", () => {
+    expect(computeScore(1, 0, 1, 0)).toBe(4);
+  });
+
+  it("returns 2 for matching goal difference but different totals (tip 3:1 vs result 2:0)", () => {
+    expect(computeScore(3, 1, 2, 0)).toBe(2);
+  });
+
+  it("returns 1 for correct winner only (tip 2:1 vs result 3:1 — both home wins)", () => {
+    expect(computeScore(2, 1, 3, 1)).toBe(1);
+  });
+
+  it("returns 2 for a correctly tipped draw with different score — same goal diff of 0 (tip 1:1 vs result 2:2)", () => {
+    expect(computeScore(1, 1, 2, 2)).toBe(2);
+  });
+
+  it("returns 4 for an exactly matching draw (tip 1:1 vs result 1:1)", () => {
+    expect(computeScore(1, 1, 1, 1)).toBe(4);
+  });
+
+  it("returns 1 for an away win predicted with different goal difference (tip 0:2 vs result 1:4)", () => {
+    expect(computeScore(0, 2, 1, 4)).toBe(1);
+  });
+
+  it("returns 0 when winner is wrong (tip 0:1 vs result 1:0)", () => {
+    expect(computeScore(0, 1, 1, 0)).toBe(0);
+  });
+});

--- a/tests/unit/tip-eligibility.test.ts
+++ b/tests/unit/tip-eligibility.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+interface EligibilityMatch {
+  utcDate: Date;
+  homeScore: number | null;
+  awayScore: number | null;
+}
+
+function canEditTip(match: EligibilityMatch, now: Date): boolean {
+  return (
+    match.utcDate.getTime() >= now.getTime() &&
+    match.homeScore === null &&
+    match.awayScore === null
+  );
+}
+
+const NOW = new Date("2026-05-28T12:00:00Z");
+
+describe("canEditTip", () => {
+  it("allows tipping a scheduled match in the future without a score", () => {
+    const match: EligibilityMatch = {
+      utcDate: new Date(NOW.getTime() + 60_000),
+      homeScore: null,
+      awayScore: null,
+    };
+    expect(canEditTip(match, NOW)).toBe(true);
+  });
+
+  it("blocks tipping when kickoff is in the past", () => {
+    const match: EligibilityMatch = {
+      utcDate: new Date(NOW.getTime() - 60_000),
+      homeScore: null,
+      awayScore: null,
+    };
+    expect(canEditTip(match, NOW)).toBe(false);
+  });
+
+  it("blocks tipping when homeScore is set even with a future kickoff", () => {
+    const match: EligibilityMatch = {
+      utcDate: new Date(NOW.getTime() + 60_000),
+      homeScore: 1,
+      awayScore: null,
+    };
+    expect(canEditTip(match, NOW)).toBe(false);
+  });
+
+  it("blocks tipping when awayScore is set", () => {
+    const match: EligibilityMatch = {
+      utcDate: new Date(NOW.getTime() + 60_000),
+      homeScore: null,
+      awayScore: 0,
+    };
+    expect(canEditTip(match, NOW)).toBe(false);
+  });
+
+  it("blocks tipping for a finished match with both scores set", () => {
+    const match: EligibilityMatch = {
+      utcDate: new Date(NOW.getTime() - 86_400_000),
+      homeScore: 2,
+      awayScore: 1,
+    };
+    expect(canEditTip(match, NOW)).toBe(false);
+  });
+});

--- a/tests/unit/validation.test.ts
+++ b/tests/unit/validation.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import { loginSchema, signupSchema } from "@/lib/validation/auth";
+import { matchImportSchema } from "@/lib/validation/match-import";
+
+describe("loginSchema", () => {
+  it("accepts a valid payload", () => {
+    const result = loginSchema.safeParse({
+      email: "user@example.com",
+      password: "test1234",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an invalid email", () => {
+    const result = loginSchema.safeParse({
+      email: "not-an-email",
+      password: "test1234",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a password shorter than 8 chars", () => {
+    const result = loginSchema.safeParse({
+      email: "user@example.com",
+      password: "short",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a missing password", () => {
+    const result = loginSchema.safeParse({ email: "user@example.com" });
+    expect(result.success).toBe(false);
+  });
+});
+
+const VALID_SIGNUP = {
+  firstName: "Test",
+  lastName: "User",
+  username: "testuser",
+  email: "user@example.com",
+  password: "test1234",
+  rePassword: "test1234",
+  department: "Langenfeld",
+  winner: "DEU",
+  secretWinner: "ESP",
+};
+
+describe("signupSchema", () => {
+  it("accepts a valid payload", () => {
+    const result = signupSchema.safeParse(VALID_SIGNUP);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects when passwords do not match", () => {
+    const result = signupSchema.safeParse({
+      ...VALID_SIGNUP,
+      rePassword: "different",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects when winner equals secret winner", () => {
+    const result = signupSchema.safeParse({
+      ...VALID_SIGNUP,
+      secretWinner: VALID_SIGNUP.winner,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an unknown department", () => {
+    const result = signupSchema.safeParse({
+      ...VALID_SIGNUP,
+      department: "Berlin",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an unknown team code for winner", () => {
+    const result = signupSchema.safeParse({
+      ...VALID_SIGNUP,
+      winner: "ZZZ",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an invalid email", () => {
+    const result = signupSchema.safeParse({
+      ...VALID_SIGNUP,
+      email: "no-at-sign",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a missing required field", () => {
+    const { firstName: _omit, ...rest } = VALID_SIGNUP;
+    void _omit;
+    const result = signupSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+});
+
+const VALID_MATCH_IMPORT = {
+  id: 1,
+  homeTeam: { name: "Germany", tla: "GER" },
+  awayTeam: { name: "Spain", tla: "ESP" },
+  status: "SCHEDULED",
+  utcDate: 1_700_000_000,
+  homeScore: null,
+  awayScore: null,
+};
+
+describe("matchImportSchema", () => {
+  it("accepts a valid payload", () => {
+    const result = matchImportSchema.safeParse(VALID_MATCH_IMPORT);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a non-positive id", () => {
+    const result = matchImportSchema.safeParse({
+      ...VALID_MATCH_IMPORT,
+      id: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an unknown status", () => {
+    const result = matchImportSchema.safeParse({
+      ...VALID_MATCH_IMPORT,
+      status: "PENDING",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a non-integer utcDate", () => {
+    const result = matchImportSchema.safeParse({
+      ...VALID_MATCH_IMPORT,
+      utcDate: 1.5,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a missing required field", () => {
+    const { homeTeam: _omit, ...rest } = VALID_MATCH_IMPORT;
+    void _omit;
+    const result = matchImportSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a team with an empty name", () => {
+    const result = matchImportSchema.safeParse({
+      ...VALID_MATCH_IMPORT,
+      homeTeam: { name: "", tla: "GER" },
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "."),
+    },
+  },
+  test: {
+    environment: "node",
+    include: ["tests/unit/**/*.test.ts"],
+    globals: false,
+    reporters: ["default"],
+  },
+});


### PR DESCRIPTION
43/43 unit tests in ~150 ms, 12/12 e2e tests in ~22 s on chromium. Tests are wired against `shared/db/test.db` via a Playwright globalSetup that drops → migrates → seeds before every run.

Coverage: scoring, date helpers, Zod schemas (login, signup, match-import), department mapping, tip eligibility, plus 7 e2e flows (auth happy path, disclosure parity, tip submit + locked, dashboard buckets, ranking tabs + legend, match-detail badges, profile history negatives).

Also fixed a real bug in `lib/format.ts` (formatDate had drifted from spec §14.1 'Samstag, 31. Dezember 2022' to a shorter form). `.env.test` is gitignored per workspace rule; `.env.test.example` is the tracked template.

Reviewer **APPROVE WITH NOTES** (non-blocking: AC mentions `tipSchema` which doesn't exist in the codebase — tip route validates inline; profile spec asserts labels not seeded values).