### PR TITLE
FE-014: apply security headers on /api/match/import response

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -41,7 +41,7 @@ function withSecurityHeaders(res: NextResponse): NextResponse {
 
 export function middleware(request: NextRequest): NextResponse {
   if (request.nextUrl.pathname === "/api/match/import") {
-    return NextResponse.next();
+    return withSecurityHeaders(NextResponse.next());
   }
 
   if (request.method !== "GET") {


### PR DESCRIPTION
Audit finding M-2. One-line wrap of the middleware pass-through through `withSecurityHeaders()` so the five baseline response headers land on every /api/match/import response (401, 400, 500, 200), not just routes that pass through the main middleware branch. CSRF origin-check still skipped (FE-008 x-api-key auth unchanged).

Verified via curl: all five headers present on the 401 no-key path.