### PR TITLE
FE-015: harden rate-limiter against X-Forwarded-For spoofing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,10 @@
 DATABASE_URL=../shared/db/database.db
 RUST_API_URL=http://localhost:8080
 MATCH_IMPORT_API_KEY=devkey-change-me
+
+# When set (1 / true / yes), the rate-limiter trusts the first IP in
+# X-Forwarded-For / X-Real-IP as the client address. Leave unset in
+# direct-public deploys — otherwise an attacker can rotate the header
+# per request and bypass the limit. Set only when a trusted reverse
+# proxy strips client-supplied X-Forwarded-For headers.
+TRUST_PROXY=

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,9 +1,26 @@
 const WINDOW_MS = 10 * 60 * 1000;
 const MAX_ATTEMPTS = 5;
+const MAX_BUCKETS = 10_000;
+const SWEEP_MS = 60 * 1000;
 
 type Entry = { count: number; resetAt: number };
 
 const buckets = new Map<string, Entry>();
+
+let sweepTimer: ReturnType<typeof setInterval> | undefined;
+
+function startSweep(): void {
+  if (sweepTimer || typeof setInterval !== "function") return;
+  sweepTimer = setInterval(() => {
+    const now = Date.now();
+    for (const [key, entry] of buckets) {
+      if (entry.resetAt <= now) buckets.delete(key);
+    }
+  }, SWEEP_MS);
+  if (typeof sweepTimer === "object" && sweepTimer !== null && "unref" in sweepTimer) {
+    (sweepTimer as { unref(): void }).unref();
+  }
+}
 
 export interface RateLimitResult {
   ok: boolean;
@@ -11,6 +28,20 @@ export interface RateLimitResult {
 }
 
 export function checkRateLimit(ip: string, bucket: string): RateLimitResult {
+  startSweep();
+
+  if (buckets.size >= MAX_BUCKETS) {
+    const now = Date.now();
+    for (const [key, entry] of buckets) {
+      if (entry.resetAt <= now) buckets.delete(key);
+      if (buckets.size < MAX_BUCKETS) break;
+    }
+    if (buckets.size >= MAX_BUCKETS) {
+      const oldest = buckets.keys().next().value;
+      if (oldest !== undefined) buckets.delete(oldest);
+    }
+  }
+
   const key = `${bucket}:${ip}`;
   const now = Date.now();
   const entry = buckets.get(key);
@@ -32,13 +63,30 @@ export function resetRateLimit(ip: string, bucket: string): void {
   buckets.delete(`${bucket}:${ip}`);
 }
 
+function isTrustProxy(): boolean {
+  const value = process.env.TRUST_PROXY;
+  if (!value) return false;
+  const normalized = value.toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
+}
+
 export function getClientIp(headers: Headers): string {
-  const xff = headers.get("x-forwarded-for");
-  if (xff) {
-    const first = xff.split(",")[0]?.trim();
-    if (first) return first;
+  if (isTrustProxy()) {
+    const xff = headers.get("x-forwarded-for");
+    if (xff) {
+      const first = xff.split(",")[0]?.trim();
+      if (first) return first;
+    }
+    const real = headers.get("x-real-ip");
+    if (real) return real.trim();
   }
-  const real = headers.get("x-real-ip");
-  if (real) return real.trim();
   return "unknown";
 }
+
+export const _internal = {
+  buckets,
+  MAX_ATTEMPTS,
+  WINDOW_MS,
+  MAX_BUCKETS,
+  SWEEP_MS,
+};

--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  _internal,
+  checkRateLimit,
+  getClientIp,
+  resetRateLimit,
+} from "@/lib/rate-limit";
+
+function headers(init: Record<string, string>): Headers {
+  return new Headers(init);
+}
+
+describe("checkRateLimit", () => {
+  beforeEach(() => {
+    _internal.buckets.clear();
+  });
+
+  it("allows the first MAX_ATTEMPTS calls and blocks the next", () => {
+    for (let i = 1; i <= _internal.MAX_ATTEMPTS; i += 1) {
+      expect(checkRateLimit("1.1.1.1", "login").ok).toBe(true);
+    }
+    const blocked = checkRateLimit("1.1.1.1", "login");
+    expect(blocked.ok).toBe(false);
+    expect(blocked.retryAfter).toBeGreaterThan(0);
+  });
+
+  it("uses independent buckets per (bucket, ip) pair", () => {
+    for (let i = 0; i < _internal.MAX_ATTEMPTS; i += 1) {
+      checkRateLimit("1.1.1.1", "login");
+    }
+    expect(checkRateLimit("1.1.1.1", "login").ok).toBe(false);
+    expect(checkRateLimit("1.1.1.1", "signup").ok).toBe(true);
+    expect(checkRateLimit("2.2.2.2", "login").ok).toBe(true);
+  });
+
+  it("resetRateLimit clears the bucket", () => {
+    for (let i = 0; i < _internal.MAX_ATTEMPTS; i += 1) {
+      checkRateLimit("3.3.3.3", "login");
+    }
+    expect(checkRateLimit("3.3.3.3", "login").ok).toBe(false);
+    resetRateLimit("3.3.3.3", "login");
+    expect(checkRateLimit("3.3.3.3", "login").ok).toBe(true);
+  });
+});
+
+describe("getClientIp", () => {
+  const originalTrustProxy = process.env.TRUST_PROXY;
+
+  afterEach(() => {
+    if (originalTrustProxy === undefined) {
+      delete process.env.TRUST_PROXY;
+    } else {
+      process.env.TRUST_PROXY = originalTrustProxy;
+    }
+  });
+
+  it("ignores x-forwarded-for when TRUST_PROXY is unset", () => {
+    delete process.env.TRUST_PROXY;
+    expect(getClientIp(headers({ "x-forwarded-for": "1.2.3.4" }))).toBe(
+      "unknown",
+    );
+  });
+
+  it("ignores x-forwarded-for when TRUST_PROXY is '0'", () => {
+    process.env.TRUST_PROXY = "0";
+    expect(getClientIp(headers({ "x-forwarded-for": "1.2.3.4" }))).toBe(
+      "unknown",
+    );
+  });
+
+  it("honors x-forwarded-for when TRUST_PROXY=1", () => {
+    process.env.TRUST_PROXY = "1";
+    expect(getClientIp(headers({ "x-forwarded-for": "1.2.3.4" }))).toBe(
+      "1.2.3.4",
+    );
+  });
+
+  it("honors x-forwarded-for when TRUST_PROXY=true", () => {
+    process.env.TRUST_PROXY = "true";
+    expect(getClientIp(headers({ "x-forwarded-for": "1.2.3.4, 5.6.7.8" }))).toBe(
+      "1.2.3.4",
+    );
+  });
+
+  it("falls back to x-real-ip when TRUST_PROXY=1 and no x-forwarded-for", () => {
+    process.env.TRUST_PROXY = "1";
+    expect(getClientIp(headers({ "x-real-ip": "9.9.9.9" }))).toBe("9.9.9.9");
+  });
+
+  it("returns 'unknown' when TRUST_PROXY=1 but no proxy headers present", () => {
+    process.env.TRUST_PROXY = "1";
+    expect(getClientIp(headers({}))).toBe("unknown");
+  });
+});
+
+describe("spoofed X-Forwarded-For without TRUST_PROXY does not bypass limit", () => {
+  const originalTrustProxy = process.env.TRUST_PROXY;
+
+  beforeEach(() => {
+    _internal.buckets.clear();
+    delete process.env.TRUST_PROXY;
+  });
+
+  afterEach(() => {
+    if (originalTrustProxy === undefined) {
+      delete process.env.TRUST_PROXY;
+    } else {
+      process.env.TRUST_PROXY = originalTrustProxy;
+    }
+  });
+
+  it("100 requests with rotating fake XFF all bucket under 'unknown'", () => {
+    let blocked = 0;
+    for (let i = 0; i < 100; i += 1) {
+      const ip = getClientIp(
+        headers({ "x-forwarded-for": `10.0.${i}.${i}` }),
+      );
+      const res = checkRateLimit(ip, "login");
+      if (!res.ok) blocked += 1;
+    }
+    expect(blocked).toBe(100 - _internal.MAX_ATTEMPTS);
+  });
+});


### PR DESCRIPTION
Audit finding M-3. The rate-limiter trusted `X-Forwarded-For` unconditionally — an attacker rotating the header per request got a fresh bucket each time, so the documented 5/10min limit was effectively infinite. Plus unbounded Map growth.

**Two fixes:**

1. **`TRUST_PROXY` env gate.** Default unset → headers ignored, all requests bucket under 'unknown'. Operators behind a real proxy that strips client XFF set `TRUST_PROXY=1`. Documented in `.env.example`.

2. **Eviction sweep + hard cap.** `setInterval` (with `.unref()`) sweeps expired entries every 60s. `MAX_BUCKETS=10000` hard cap with inline sweep + oldest-eviction on overflow.

**10 new vitest cases** including an explicit attack simulation: 100 requests with rotating fake XFF all bucket under 'unknown' → only `MAX_ATTEMPTS` pass, 95 blocked.

Suite: 53/53 tests pass. Build clean.