### PR TITLE
FE-016: hide secretWinner on other users' profiles

### DIFF
--- a/app/(app)/user/[id]/page.tsx
+++ b/app/(app)/user/[id]/page.tsx
@@ -81,7 +81,7 @@ export default async function UserProfilePage({
           <div className="md:col-span-4">
             <WinnerCards
               winner={localUser.winner}
-              secretWinner={localUser.secretWinner}
+              secretWinner={isOwnProfile ? localUser.secretWinner : null}
             />
           </div>
         </div>

--- a/components/profile/WinnerCards.tsx
+++ b/components/profile/WinnerCards.tsx
@@ -2,7 +2,7 @@ import { Flag } from "@/components/dashboard/Flag";
 
 interface WinnerCardsProps {
   winner: string;
-  secretWinner: string;
+  secretWinner: string | null;
 }
 
 function WinnerCard({
@@ -40,6 +40,37 @@ function WinnerCard({
   );
 }
 
+function HiddenSecretWinnerCard(): React.ReactElement {
+  return (
+    <div className="bg-surface-container border border-outline-variant p-lg relative overflow-hidden">
+      <div className="relative z-10">
+        <span className="text-label-caps uppercase text-on-surface-variant">
+          SECRET WINNER
+        </span>
+        <div className="flex items-center gap-md mt-sm">
+          <div className="w-10 h-7 rounded-xs bg-surface-container-high flex items-center justify-center">
+            <span
+              className="material-symbols-outlined text-on-surface-variant"
+              style={{ fontSize: 18 }}
+              aria-hidden
+            >
+              lock
+            </span>
+          </div>
+          <span className="text-headline-md font-bold uppercase tracking-widest text-on-surface-variant">
+            Hidden
+          </span>
+        </div>
+      </div>
+      <div className="absolute -right-4 -bottom-4 opacity-5 pointer-events-none">
+        <span className="material-symbols-outlined" style={{ fontSize: 120 }}>
+          visibility_off
+        </span>
+      </div>
+    </div>
+  );
+}
+
 export function WinnerCards({
   winner,
   secretWinner,
@@ -47,11 +78,15 @@ export function WinnerCards({
   return (
     <div className="flex flex-col gap-md">
       <WinnerCard label="TOURNAMENT WINNER" tla={winner} icon="emoji_events" />
-      <WinnerCard
-        label="SECRET WINNER"
-        tla={secretWinner}
-        icon="visibility_off"
-      />
+      {secretWinner === null ? (
+        <HiddenSecretWinnerCard />
+      ) : (
+        <WinnerCard
+          label="SECRET WINNER"
+          tla={secretWinner}
+          icon="visibility_off"
+        />
+      )}
     </div>
   );
 }

--- a/tests/e2e/profile.spec.ts
+++ b/tests/e2e/profile.spec.ts
@@ -45,4 +45,32 @@ test.describe("profile page", () => {
       }
     }
   });
+
+  test("shows my own secretWinner on /user/6 but hides it on other users", async ({
+    page,
+  }) => {
+    await login(page);
+
+    // Own profile (user 6 = TestUser, secretWinner = NLD per FE-007 seed)
+    await page.goto("/user/6");
+    const ownSecretCard = page
+      .locator("div", { hasText: "SECRET WINNER" })
+      .first();
+    await expect(ownSecretCard).toBeVisible();
+    await expect(ownSecretCard).toContainText("NLD");
+    await expect(ownSecretCard).not.toContainText("Hidden");
+
+    // Another user's profile (user 1 = AdaLovelace, secretWinner = ESP per FE-007 seed)
+    await page.goto("/user/1");
+    const otherSecretCard = page
+      .locator("div", { hasText: "SECRET WINNER" })
+      .first();
+    await expect(otherSecretCard).toBeVisible();
+    await expect(otherSecretCard).toContainText("Hidden");
+    await expect(otherSecretCard).not.toContainText("ESP");
+
+    // Tournament Winner is still public — AdaLovelace.winner = DEU
+    await expect(page.locator("body")).toContainText("TOURNAMENT WINNER");
+    await expect(page.locator("body")).toContainText("DEU");
+  });
 });


### PR DESCRIPTION
Audit finding L-1. `/user/[id]` exposed every user's `secretWinner` to every other logged-in user. The feature is literally called 'SECRET WINNER' — meant to be private.

**Two changes:**
1. `app/(app)/user/[id]/page.tsx` passes `secretWinner` only when `isOwnProfile`, otherwise `null`.
2. `WinnerCards.tsx` renders a `<HiddenSecretWinnerCard>` placeholder with a `lock` icon and 'Hidden' text when the prop is `null`. Card layout stays consistent.

**New Playwright test** (`profile.spec.ts`): own profile shows the TLA (NLD); other user's profile shows 'Hidden' and explicitly does NOT contain the other user's secret TLA (ESP). Tournament Winner stays public.

53 vitest + 13 e2e tests green.