### PR TITLE
FE-017: revert FE-016, secret winner is public again

### DIFF
--- a/app/(app)/user/[id]/page.tsx
+++ b/app/(app)/user/[id]/page.tsx
@@ -81,7 +81,7 @@ export default async function UserProfilePage({
           <div className="md:col-span-4">
             <WinnerCards
               winner={localUser.winner}
-              secretWinner={isOwnProfile ? localUser.secretWinner : null}
+              secretWinner={localUser.secretWinner}
             />
           </div>
         </div>

--- a/components/profile/WinnerCards.tsx
+++ b/components/profile/WinnerCards.tsx
@@ -2,7 +2,7 @@ import { Flag } from "@/components/dashboard/Flag";
 
 interface WinnerCardsProps {
   winner: string;
-  secretWinner: string | null;
+  secretWinner: string;
 }
 
 function WinnerCard({
@@ -40,37 +40,6 @@ function WinnerCard({
   );
 }
 
-function HiddenSecretWinnerCard(): React.ReactElement {
-  return (
-    <div className="bg-surface-container border border-outline-variant p-lg relative overflow-hidden">
-      <div className="relative z-10">
-        <span className="text-label-caps uppercase text-on-surface-variant">
-          SECRET WINNER
-        </span>
-        <div className="flex items-center gap-md mt-sm">
-          <div className="w-10 h-7 rounded-xs bg-surface-container-high flex items-center justify-center">
-            <span
-              className="material-symbols-outlined text-on-surface-variant"
-              style={{ fontSize: 18 }}
-              aria-hidden
-            >
-              lock
-            </span>
-          </div>
-          <span className="text-headline-md font-bold uppercase tracking-widest text-on-surface-variant">
-            Hidden
-          </span>
-        </div>
-      </div>
-      <div className="absolute -right-4 -bottom-4 opacity-5 pointer-events-none">
-        <span className="material-symbols-outlined" style={{ fontSize: 120 }}>
-          visibility_off
-        </span>
-      </div>
-    </div>
-  );
-}
-
 export function WinnerCards({
   winner,
   secretWinner,
@@ -78,15 +47,11 @@ export function WinnerCards({
   return (
     <div className="flex flex-col gap-md">
       <WinnerCard label="TOURNAMENT WINNER" tla={winner} icon="emoji_events" />
-      {secretWinner === null ? (
-        <HiddenSecretWinnerCard />
-      ) : (
-        <WinnerCard
-          label="SECRET WINNER"
-          tla={secretWinner}
-          icon="visibility_off"
-        />
-      )}
+      <WinnerCard
+        label="SECRET WINNER"
+        tla={secretWinner}
+        icon="visibility_off"
+      />
     </div>
   );
 }

--- a/tests/e2e/profile.spec.ts
+++ b/tests/e2e/profile.spec.ts
@@ -46,9 +46,7 @@ test.describe("profile page", () => {
     }
   });
 
-  test("shows my own secretWinner on /user/6 but hides it on other users", async ({
-    page,
-  }) => {
+  test("secretWinner is public on every profile", async ({ page }) => {
     await login(page);
 
     // Own profile (user 6 = TestUser, secretWinner = NLD per FE-007 seed)
@@ -58,7 +56,6 @@ test.describe("profile page", () => {
       .first();
     await expect(ownSecretCard).toBeVisible();
     await expect(ownSecretCard).toContainText("NLD");
-    await expect(ownSecretCard).not.toContainText("Hidden");
 
     // Another user's profile (user 1 = AdaLovelace, secretWinner = ESP per FE-007 seed)
     await page.goto("/user/1");
@@ -66,10 +63,9 @@ test.describe("profile page", () => {
       .locator("div", { hasText: "SECRET WINNER" })
       .first();
     await expect(otherSecretCard).toBeVisible();
-    await expect(otherSecretCard).toContainText("Hidden");
-    await expect(otherSecretCard).not.toContainText("ESP");
+    await expect(otherSecretCard).toContainText("ESP");
 
-    // Tournament Winner is still public — AdaLovelace.winner = DEU
+    // Tournament Winner is also public — AdaLovelace.winner = DEU
     await expect(page.locator("body")).toContainText("TOURNAMENT WINNER");
     await expect(page.locator("body")).toContainText("DEU");
   });


### PR DESCRIPTION
Owner correction: the secretWinner pick is part of the public office-pool profile by design. Revert FE-016. 53 Vitest + 13 Playwright tests green. Follow-up FE-018 will add editability locked at first kickoff.