### PR TITLE
FE-018: edit winner + secretWinner before tournament starts

### DIFF
--- a/app/(app)/user/[id]/page.tsx
+++ b/app/(app)/user/[id]/page.tsx
@@ -9,6 +9,7 @@ import { ProfileHeader } from "@/components/profile/ProfileHeader";
 import { StatTiles } from "@/components/profile/StatTiles";
 import { WinnerCards } from "@/components/profile/WinnerCards";
 import { PredictionHistory } from "@/components/profile/PredictionHistory";
+import { isTournamentLocked } from "@/lib/tournament";
 
 interface UserPageProps {
   params: Promise<{ id: string }>;
@@ -64,6 +65,8 @@ export default async function UserProfilePage({
   const tips = ratingLoad.status === "ok" ? ratingLoad.data.tips : [];
 
   const isOwnProfile = Number(sessionUser.id) === userId;
+  const locked = await isTournamentLocked();
+  const editable = isOwnProfile && !locked;
 
   return (
     <>
@@ -82,6 +85,8 @@ export default async function UserProfilePage({
             <WinnerCards
               winner={localUser.winner}
               secretWinner={localUser.secretWinner}
+              userId={userId}
+              editable={editable}
             />
           </div>
         </div>

--- a/app/api/user/winners/route.ts
+++ b/app/api/user/winners/route.ts
@@ -1,0 +1,99 @@
+import { getCurrentSession } from "@/lib/session";
+import { updateUserWinners } from "@/lib/user";
+import { winnersSchema } from "@/lib/validation/winners";
+import { isTournamentLocked } from "@/lib/tournament";
+import { checkRateLimit, getClientIp } from "@/lib/rate-limit";
+
+function jsonError(message: string, status: number): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+async function readBody(
+  request: Request,
+): Promise<{ winner: unknown; secretWinner: unknown } | null> {
+  const contentType = request.headers.get("content-type") ?? "";
+  try {
+    if (contentType.includes("application/json")) {
+      const body = (await request.json()) as Record<string, unknown>;
+      return {
+        winner: body.winner,
+        secretWinner: body.secretWinner,
+      };
+    }
+    const formData = await request.formData();
+    return {
+      winner: formData.get("winner"),
+      secretWinner: formData.get("secretWinner"),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const { user: sessionUser } = await getCurrentSession();
+  if (!sessionUser) {
+    return jsonError("Not logged in", 401);
+  }
+
+  const userId = Number(sessionUser.id);
+  if (!Number.isFinite(userId) || userId <= 0) {
+    return jsonError("Not logged in", 401);
+  }
+
+  const ip = getClientIp(request.headers);
+  const limit = checkRateLimit(ip, "winners");
+  if (!limit.ok) {
+    return new Response(
+      JSON.stringify({ error: "Too many requests, try again later." }),
+      {
+        status: 429,
+        headers: {
+          "Content-Type": "application/json",
+          ...(limit.retryAfter
+            ? { "Retry-After": String(limit.retryAfter) }
+            : {}),
+        },
+      },
+    );
+  }
+
+  if (await isTournamentLocked()) {
+    return jsonError(
+      "Tournament has already started — picks are locked.",
+      400,
+    );
+  }
+
+  const raw = await readBody(request);
+  if (!raw) {
+    return jsonError("Invalid request body", 400);
+  }
+
+  const parsed = winnersSchema.safeParse(raw);
+  if (!parsed.success) {
+    const first = parsed.error.issues[0];
+    const message = first?.message ?? "Invalid input";
+    return jsonError(message, 400);
+  }
+
+  const { winner, secretWinner } = parsed.data;
+
+  try {
+    await updateUserWinners(userId, winner, secretWinner);
+  } catch (error) {
+    console.error("[winners] update failed", error);
+    return jsonError("Failed to update winners", 500);
+  }
+
+  return new Response(
+    JSON.stringify({ success: true, winner, secretWinner }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+}

--- a/components/profile/WinnerCards.tsx
+++ b/components/profile/WinnerCards.tsx
@@ -1,18 +1,28 @@
+"use client";
+
+import { useState } from "react";
 import { Flag } from "@/components/dashboard/Flag";
+import { WinnerEditForm } from "@/components/profile/WinnerEditForm";
 
 interface WinnerCardsProps {
   winner: string;
   secretWinner: string;
+  userId: number;
+  editable?: boolean;
 }
 
 function WinnerCard({
   label,
   tla,
   icon,
+  editable,
+  onEdit,
 }: {
   label: string;
   tla: string;
   icon: string;
+  editable: boolean;
+  onEdit: () => void;
 }): React.ReactElement {
   return (
     <div className="bg-surface-container border border-outline-variant p-lg relative overflow-hidden group">
@@ -31,6 +41,16 @@ function WinnerCard({
           </span>
         </div>
       </div>
+      {editable ? (
+        <button
+          type="button"
+          onClick={onEdit}
+          aria-label={`Edit ${label}`}
+          className="absolute top-sm right-sm z-20 w-9 h-9 flex items-center justify-center rounded-full bg-surface-container-low border border-outline-variant text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high active:scale-95 transition-colors"
+        >
+          <span className="material-symbols-outlined text-[18px]">edit</span>
+        </button>
+      ) : null}
       <div className="absolute -right-4 -bottom-4 opacity-5 pointer-events-none">
         <span className="material-symbols-outlined" style={{ fontSize: 120 }}>
           {icon}
@@ -43,14 +63,40 @@ function WinnerCard({
 export function WinnerCards({
   winner,
   secretWinner,
+  userId,
+  editable = false,
 }: WinnerCardsProps): React.ReactElement {
+  const [isEditing, setIsEditing] = useState(false);
+  void userId;
+
+  if (editable && isEditing) {
+    return (
+      <div className="flex flex-col gap-md">
+        <WinnerEditForm
+          winner={winner}
+          secretWinner={secretWinner}
+          onCancel={() => setIsEditing(false)}
+          onSaved={() => setIsEditing(false)}
+        />
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col gap-md">
-      <WinnerCard label="TOURNAMENT WINNER" tla={winner} icon="emoji_events" />
+      <WinnerCard
+        label="TOURNAMENT WINNER"
+        tla={winner}
+        icon="emoji_events"
+        editable={editable}
+        onEdit={() => setIsEditing(true)}
+      />
       <WinnerCard
         label="SECRET WINNER"
         tla={secretWinner}
         icon="visibility_off"
+        editable={editable}
+        onEdit={() => setIsEditing(true)}
       />
     </div>
   );

--- a/components/profile/WinnerEditForm.tsx
+++ b/components/profile/WinnerEditForm.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, type FormEvent } from "react";
+import { TEAMS } from "@/lib/data/teams";
+
+interface WinnerEditFormProps {
+  winner: string;
+  secretWinner: string;
+  onCancel: () => void;
+  onSaved: () => void;
+}
+
+export function WinnerEditForm({
+  winner: initialWinner,
+  secretWinner: initialSecret,
+  onCancel,
+  onSaved,
+}: WinnerEditFormProps): React.ReactElement {
+  const router = useRouter();
+  const [winner, setWinner] = useState(initialWinner);
+  const [secretWinner, setSecretWinner] = useState(initialSecret);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+    setError(null);
+    if (winner === secretWinner) {
+      setError("Winner and secret winner must differ.");
+      return;
+    }
+    setPending(true);
+
+    const form = new FormData();
+    form.set("winner", winner);
+    form.set("secretWinner", secretWinner);
+
+    try {
+      const res = await fetch("/api/user/winners", {
+        method: "POST",
+        body: form,
+        headers: { Accept: "application/json" },
+      });
+      if (res.ok) {
+        onSaved();
+        router.refresh();
+        return;
+      }
+      let message = "Failed to update winners.";
+      try {
+        const body: unknown = await res.json();
+        if (
+          body &&
+          typeof body === "object" &&
+          "error" in body &&
+          typeof (body as { error: unknown }).error === "string"
+        ) {
+          message = (body as { error: string }).error;
+        }
+      } catch {
+        // ignore
+      }
+      setError(message);
+    } catch {
+      setError("Network error. Try again.");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <form
+      onSubmit={onSubmit}
+      className="bg-surface-container border border-outline-variant p-lg flex flex-col gap-md"
+    >
+      <label className="flex flex-col gap-xs">
+        <span className="text-label-caps uppercase text-on-surface-variant">
+          Tournament Winner
+        </span>
+        <select
+          required
+          value={winner}
+          onChange={(e) => setWinner(e.target.value)}
+          disabled={pending}
+          aria-label="Tournament winner"
+          className="min-h-12 px-md bg-surface-container-low border border-outline-variant rounded text-body-lg focus:border-primary focus:ring-0 disabled:opacity-60"
+        >
+          {TEAMS.map((t) => (
+            <option key={t.code} value={t.code}>
+              {t.code} — {t.name}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="flex flex-col gap-xs">
+        <span className="text-label-caps uppercase text-on-surface-variant">
+          Secret Winner
+        </span>
+        <select
+          required
+          value={secretWinner}
+          onChange={(e) => setSecretWinner(e.target.value)}
+          disabled={pending}
+          aria-label="Secret winner"
+          className="min-h-12 px-md bg-surface-container-low border border-outline-variant rounded text-body-lg focus:border-primary focus:ring-0 disabled:opacity-60"
+        >
+          {TEAMS.map((t) => (
+            <option key={t.code} value={t.code}>
+              {t.code} — {t.name}
+            </option>
+          ))}
+        </select>
+      </label>
+      {error ? (
+        <p
+          aria-live="polite"
+          className="text-body-sm text-danger px-xs"
+        >
+          {error}
+        </p>
+      ) : null}
+      <div className="flex gap-sm justify-end">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={pending}
+          className="px-lg py-2 min-h-12 rounded-lg text-label-caps uppercase font-bold bg-surface-container-low border border-outline-variant hover:opacity-90 active:scale-95 disabled:opacity-60"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={pending}
+          className="px-lg py-2 min-h-12 rounded-lg text-label-caps uppercase font-bold bg-primary text-on-primary hover:opacity-90 active:scale-95 disabled:opacity-60"
+        >
+          {pending ? "..." : "Save"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/lib/tournament.ts
+++ b/lib/tournament.ts
@@ -1,0 +1,19 @@
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { match } from "@/db/schema";
+
+export function isLockedFromTimestamp(
+  minUtcSeconds: number | null,
+  nowMs: number,
+): boolean {
+  if (minUtcSeconds === null) return false;
+  return minUtcSeconds * 1000 <= nowMs;
+}
+
+export async function isTournamentLocked(): Promise<boolean> {
+  const rows = await db
+    .select({ min: sql<number | null>`MIN(${match.utcDate})` })
+    .from(match);
+  const minUtc = rows[0]?.min ?? null;
+  return isLockedFromTimestamp(minUtc, Date.now());
+}

--- a/lib/user.ts
+++ b/lib/user.ts
@@ -28,3 +28,14 @@ export async function createUser(newUser: NewUser): Promise<number> {
   }
   return created.id;
 }
+
+export async function updateUserWinners(
+  userId: number,
+  winner: string,
+  secretWinner: string,
+): Promise<void> {
+  await db
+    .update(user)
+    .set({ winner, secretWinner })
+    .where(eq(user.id, userId));
+}

--- a/lib/validation/winners.ts
+++ b/lib/validation/winners.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+import { TEAM_CODES } from "@/lib/data/teams";
+
+export const winnersSchema = z
+  .object({
+    winner: z.enum(TEAM_CODES as unknown as [string, ...string[]], {
+      message: "winner",
+    }),
+    secretWinner: z.enum(TEAM_CODES as unknown as [string, ...string[]], {
+      message: "secretWinner",
+    }),
+  })
+  .refine((data) => data.winner !== data.secretWinner, {
+    message: "Winner and secret winner must differ.",
+    path: ["secretWinner"],
+  });
+
+export type WinnersInput = z.infer<typeof winnersSchema>;

--- a/tests/e2e/winner-edit.spec.ts
+++ b/tests/e2e/winner-edit.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "@playwright/test";
+
+async function login(page: import("@playwright/test").Page): Promise<void> {
+  await page.goto("/login");
+  await page.fill("#email", "me@dev.local");
+  await page.fill("#password", "test1234");
+  await page.click("button[type=submit]");
+  await page.waitForURL("http://localhost:3000/");
+}
+
+test.describe("winner edit (locked path)", () => {
+  test("own profile shows no Edit button when tournament has started", async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto("/user/6");
+
+    await expect(page.getByText("TOURNAMENT WINNER")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Edit TOURNAMENT WINNER/i }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: /Edit SECRET WINNER/i }),
+    ).toHaveCount(0);
+  });
+
+  test("other user's profile never shows an Edit button", async ({ page }) => {
+    await login(page);
+    await page.goto("/user/1");
+
+    await expect(page.getByText("TOURNAMENT WINNER")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Edit TOURNAMENT WINNER/i }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: /Edit SECRET WINNER/i }),
+    ).toHaveCount(0);
+  });
+
+  test("POST /api/user/winners rejects when tournament is locked", async ({
+    page,
+  }) => {
+    await login(page);
+
+    const res = await page.request.post("/api/user/winners", {
+      form: { winner: "DEU", secretWinner: "ESP" },
+      headers: { Origin: "http://localhost:3000" },
+    });
+    expect(res.status()).toBe(400);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe(
+      "Tournament has already started — picks are locked.",
+    );
+  });
+
+  test("POST /api/user/winners rejects when winner === secretWinner", async ({
+    page,
+  }) => {
+    await login(page);
+
+    const res = await page.request.post("/api/user/winners", {
+      form: { winner: "ESP", secretWinner: "ESP" },
+      headers: { Origin: "http://localhost:3000" },
+    });
+    expect(res.status()).toBe(400);
+  });
+
+  test("POST /api/user/winners requires a session", async ({ request }) => {
+    const res = await request.post("/api/user/winners", {
+      form: { winner: "DEU", secretWinner: "ESP" },
+      headers: { Origin: "http://localhost:3000" },
+    });
+    expect(res.status()).toBe(401);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe("Not logged in");
+  });
+});

--- a/tests/unit/tournament.test.ts
+++ b/tests/unit/tournament.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { isLockedFromTimestamp } from "@/lib/tournament";
+
+describe("isLockedFromTimestamp", () => {
+  const now = 1_700_000_000_000;
+
+  it("returns false when there are no matches (min is null)", () => {
+    expect(isLockedFromTimestamp(null, now)).toBe(false);
+  });
+
+  it("returns true when the earliest match is in the past", () => {
+    const oneHourAgoSeconds = Math.floor(now / 1000) - 3600;
+    expect(isLockedFromTimestamp(oneHourAgoSeconds, now)).toBe(true);
+  });
+
+  it("returns true at the exact kickoff instant", () => {
+    const nowSeconds = Math.floor(now / 1000);
+    expect(isLockedFromTimestamp(nowSeconds, nowSeconds * 1000)).toBe(true);
+  });
+
+  it("returns false when every match is in the future", () => {
+    const oneHourFromNowSeconds = Math.floor(now / 1000) + 3600;
+    expect(isLockedFromTimestamp(oneHourFromNowSeconds, now)).toBe(false);
+  });
+});

--- a/tests/unit/winners-validation.test.ts
+++ b/tests/unit/winners-validation.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { winnersSchema } from "@/lib/validation/winners";
+
+describe("winnersSchema", () => {
+  it("accepts a valid payload with winner !== secretWinner", () => {
+    const result = winnersSchema.safeParse({
+      winner: "DEU",
+      secretWinner: "ESP",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects when winner equals secretWinner", () => {
+    const result = winnersSchema.safeParse({
+      winner: "DEU",
+      secretWinner: "DEU",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) =>
+        i.path.includes("secretWinner"),
+      );
+      expect(issue?.message).toBe("Winner and secret winner must differ.");
+    }
+  });
+
+  it("rejects an unknown team code", () => {
+    const result = winnersSchema.safeParse({
+      winner: "ZZZ",
+      secretWinner: "ESP",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects when a field is missing", () => {
+    const result = winnersSchema.safeParse({ winner: "DEU" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects when winner is not a string", () => {
+    const result = winnersSchema.safeParse({
+      winner: 123,
+      secretWinner: "ESP",
+    });
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
Users can now edit their tournament-winner and secret-winner picks on their own profile until the first match kicks off. Once any match has `utcDate <= now`, both fields are locked permanently (UI hides the Edit button; server endpoint rejects manual POSTs with 400).

userId for the DB write comes ONLY from the session — never from body or URL. No IDOR. Rate-limit bucket "winners" (5/10min/IP, FE-015 TRUST_PROXY-aware).

Reviewer **APPROVE WITH NOTES**: vestigial userId prop on WinnerCards, rate-limit-before-lock ordering doc, Playwright unlocked-path coverage gap (FE-007 seed has past matches → tournament always locked in e2e). All non-blocking.

56 vitest + 18 e2e tests green; tsc + build clean.