### PR TITLE
FE-013: Zod-validate Rust API responses in fetchApi

### DIFF
--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -2,7 +2,7 @@ import { getCurrentSession } from "@/lib/session";
 import { getLiveMatches, getUpcomingMatches } from "@/lib/match";
 import { getTipByUserAndMatchIds, type TipRow } from "@/lib/tip";
 import { fetchApi } from "@/lib/api";
-import type { RatingResponse } from "@/lib/rating";
+import { RatingResponseSchema, type RatingResponse } from "@/lib/rating";
 import { LiveBlock } from "@/components/dashboard/LiveBlock";
 import { UpcomingList } from "@/components/dashboard/UpcomingList";
 import { RankingSidebar } from "@/components/dashboard/RankingSidebar";
@@ -11,7 +11,10 @@ import { TopAppBar } from "@/components/dashboard/TopAppBar";
 
 async function loadRating(): Promise<RatingResponse | null> {
   try {
-    return await fetchApi<RatingResponse>("rating", "table");
+    return await fetchApi("rating", {
+      wrappedByKey: "table",
+      schema: RatingResponseSchema,
+    });
   } catch (error) {
     console.error("[dashboard] rating API offline:", error);
     return null;

--- a/app/(app)/ranking/page.tsx
+++ b/app/(app)/ranking/page.tsx
@@ -1,15 +1,12 @@
 import { getCurrentSession } from "@/lib/session";
 import { fetchApi } from "@/lib/api";
-import type { RatingResponse } from "@/lib/rating";
+import { RatingResponseSchema, type RatingResponse } from "@/lib/rating";
 import { DEPARTMENTS, displayDepartment } from "@/lib/data/departments";
 import { TopAppBar } from "@/components/dashboard/TopAppBar";
 import { BottomNav } from "@/components/dashboard/BottomNav";
 import { RankingTable } from "@/components/ranking/RankingTable";
 import { ScoringInfobox } from "@/components/ranking/ScoringInfobox";
-import {
-  RankingTabs,
-  type RankingTab,
-} from "@/components/ranking/RankingTabs";
+import { RankingTabs, type RankingTab } from "@/components/ranking/RankingTabs";
 
 interface RankingPageProps {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
@@ -24,16 +21,17 @@ const TAB_BY_PARAM: Record<string, string> = {
 
 async function loadRating(): Promise<RatingResponse | null> {
   try {
-    return await fetchApi<RatingResponse>("rating", "table");
+    return await fetchApi("rating", {
+      wrappedByKey: "table",
+      schema: RatingResponseSchema,
+    });
   } catch (error) {
     console.error("[ranking] rating API offline:", error);
     return null;
   }
 }
 
-function resolveInitialTab(
-  raw: string | string[] | undefined,
-): string {
+function resolveInitialTab(raw: string | string[] | undefined): string {
   if (typeof raw !== "string") {
     return "global";
   }

--- a/app/(app)/user/[id]/page.tsx
+++ b/app/(app)/user/[id]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from "next/navigation";
 import { getCurrentSession } from "@/lib/session";
 import { getUserById } from "@/lib/user";
 import { fetchApi } from "@/lib/api";
-import type { RatingUser } from "@/lib/rating";
+import { RatingUserSchema, type RatingUser } from "@/lib/rating";
 import { TopAppBar } from "@/components/dashboard/TopAppBar";
 import { BottomNav } from "@/components/dashboard/BottomNav";
 import { ProfileHeader } from "@/components/profile/ProfileHeader";
@@ -15,13 +15,14 @@ interface UserPageProps {
   params: Promise<{ id: string }>;
 }
 
-type RatingLoad =
-  | { status: "ok"; data: RatingUser }
-  | { status: "offline" };
+type RatingLoad = { status: "ok"; data: RatingUser } | { status: "offline" };
 
 async function loadUserRating(id: number): Promise<RatingLoad> {
   try {
-    const data = await fetchApi<RatingUser>(`user/${id}`, "data");
+    const data = await fetchApi(`user/${id}`, {
+      wrappedByKey: "data",
+      schema: RatingUserSchema,
+    });
     return { status: "ok", data };
   } catch (error) {
     console.error("[profile] user rating API offline:", error);

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,7 +1,31 @@
+import { z } from "zod";
+
+export interface FetchApiOptions<T> {
+  wrappedByKey?: string;
+  schema?: z.ZodType<T>;
+}
+
+/**
+ * Fetches a JSON response from the Rust API.
+ *
+ * Pass an options object with `schema` (a Zod schema) to validate the parsed
+ * response at runtime. When the schema rejects the payload, this function
+ * throws an Error with a stable prefix; callers' existing try/catch branches
+ * fall through to their offline UI just as they do for network errors.
+ *
+ * The legacy signature `fetchApi(endpoint, wrappedByKey)` is still accepted
+ * for backwards compatibility, but new callers should pass a schema — without
+ * it, the response is returned via an unchecked cast.
+ */
 export async function fetchApi<T>(
   endpoint: string,
-  wrappedByKey?: string,
+  optionsOrKey?: FetchApiOptions<T> | string,
 ): Promise<T> {
+  const options: FetchApiOptions<T> =
+    typeof optionsOrKey === "string"
+      ? { wrappedByKey: optionsOrKey }
+      : (optionsOrKey ?? {});
+
   let path = endpoint;
   if (path.startsWith("/")) {
     path = path.slice(1);
@@ -23,20 +47,31 @@ export async function fetchApi<T>(
 
   const raw: unknown = await res.json();
 
-  if (wrappedByKey) {
+  let candidate: unknown = raw;
+  if (options.wrappedByKey) {
     if (
       raw === null ||
       typeof raw !== "object" ||
-      !(wrappedByKey in (raw as Record<string, unknown>))
+      !(options.wrappedByKey in (raw as Record<string, unknown>))
     ) {
       throw new Error(
-        `fetchApi: response missing key '${wrappedByKey}' for ${url.toString()}`,
+        `fetchApi: response missing key '${options.wrappedByKey}' for ${url.toString()}`,
       );
     }
-    return (raw as Record<string, unknown>)[wrappedByKey] as T;
+    candidate = (raw as Record<string, unknown>)[options.wrappedByKey];
   }
 
-  return raw as T;
+  if (options.schema) {
+    const result = options.schema.safeParse(candidate);
+    if (!result.success) {
+      throw new Error(
+        `fetchApi: schema validation failed for ${url.toString()}: ${result.error.message}`,
+      );
+    }
+    return result.data;
+  }
+
+  return candidate as T;
 }
 
 export default fetchApi;

--- a/lib/rating.ts
+++ b/lib/rating.ts
@@ -1,39 +1,48 @@
-export interface RatingTeam {
-  name: string;
-  tla: string;
-}
+import { z } from "zod";
 
-export interface RatingMatchInfo {
-  match_id: string;
-  user: string;
-  user_id: number;
-  score: number;
-  team1: RatingTeam;
-  team2: RatingTeam;
-  tip_home: number | null;
-  tip_away: number | null;
-  score_home: number | null;
-  score_away: number | null;
-  date: number;
-}
+export const RatingTeamSchema = z.object({
+  name: z.string(),
+  tla: z.string(),
+});
 
-export interface RatingUser {
-  name: string;
-  user_id: number;
-  department: string;
-  position: number;
-  score_sum: number;
-  sum_win_exact: number;
-  sum_score_diff: number;
-  sum_team: number;
-  extra_point: number;
-  tips: RatingMatchInfo[];
-}
+export const RatingMatchInfoSchema = z.object({
+  match_id: z.string(),
+  user: z.string(),
+  user_id: z.number().int(),
+  score: z.number().int(),
+  team1: RatingTeamSchema,
+  team2: RatingTeamSchema,
+  tip_home: z.number().int().nullable(),
+  tip_away: z.number().int().nullable(),
+  score_home: z.number().int().nullable(),
+  score_away: z.number().int().nullable(),
+  date: z.number().int(),
+});
 
-export interface RatingResponse {
-  global: RatingUser[];
-  departments: Record<string, RatingUser[]>;
-}
+export const RatingUserSchema = z.object({
+  name: z.string(),
+  user_id: z.number().int(),
+  department: z.string(),
+  position: z.number().int(),
+  score_sum: z.number().int(),
+  sum_win_exact: z.number().int(),
+  sum_score_diff: z.number().int(),
+  sum_team: z.number().int(),
+  extra_point: z.number().int(),
+  tips: z.array(RatingMatchInfoSchema),
+});
+
+export const RatingResponseSchema = z.object({
+  global: z.array(RatingUserSchema),
+  departments: z.record(z.string(), z.array(RatingUserSchema)),
+});
+
+export const RatingTableSchema = RatingResponseSchema;
+
+export type RatingTeam = z.infer<typeof RatingTeamSchema>;
+export type RatingMatchInfo = z.infer<typeof RatingMatchInfoSchema>;
+export type RatingUser = z.infer<typeof RatingUserSchema>;
+export type RatingResponse = z.infer<typeof RatingResponseSchema>;
 
 export interface ShortTableSlice {
   topRows: RatingUser[];
@@ -49,7 +58,9 @@ export function sliceGlobalShortTable(
     return { topRows: [], neighborRows: [], hasGap: false };
   }
 
-  const userIndexInTail = global.slice(3).findIndex((u) => u.user_id === currentUserId);
+  const userIndexInTail = global
+    .slice(3)
+    .findIndex((u) => u.user_id === currentUserId);
 
   if (userIndexInTail > 0) {
     const start = Math.max(0, userIndexInTail - 1);

--- a/tests/unit/rating-schemas.test.ts
+++ b/tests/unit/rating-schemas.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import {
+  RatingMatchInfoSchema,
+  RatingResponseSchema,
+  RatingTableSchema,
+  RatingUserSchema,
+} from "@/lib/rating";
+
+function makeMatchInfo(
+  overrides: Partial<Record<string, unknown>> = {},
+): Record<string, unknown> {
+  return {
+    match_id: "2",
+    user: "ToniKroos",
+    user_id: 2,
+    score: 4,
+    team1: { name: "Poland", tla: "POL" },
+    team2: { name: "France", tla: "FRA" },
+    tip_home: 1,
+    tip_away: 1,
+    score_home: 1,
+    score_away: 1,
+    date: 1718048296,
+    ...overrides,
+  };
+}
+
+function makeUser(
+  overrides: Partial<Record<string, unknown>> = {},
+): Record<string, unknown> {
+  return {
+    name: "ToniKroos",
+    user_id: 2,
+    department: "Langenfeld",
+    position: 1,
+    score_sum: 21,
+    sum_win_exact: 1,
+    sum_score_diff: 1,
+    sum_team: 0,
+    extra_point: 15,
+    tips: [makeMatchInfo()],
+    ...overrides,
+  };
+}
+
+describe("RatingMatchInfoSchema", () => {
+  it("accepts a valid Rust MatchInfo payload", () => {
+    expect(RatingMatchInfoSchema.safeParse(makeMatchInfo()).success).toBe(true);
+  });
+
+  it("accepts null tip_home/tip_away/score_home/score_away (Option<i32> serialises as null)", () => {
+    const payload = makeMatchInfo({
+      tip_home: null,
+      tip_away: null,
+      score_home: null,
+      score_away: null,
+    });
+    expect(RatingMatchInfoSchema.safeParse(payload).success).toBe(true);
+  });
+
+  it("rejects when match_id is a number (Rust serialises as String)", () => {
+    expect(
+      RatingMatchInfoSchema.safeParse(makeMatchInfo({ match_id: 2 })).success,
+    ).toBe(false);
+  });
+
+  it("rejects when team1 is missing the tla field", () => {
+    expect(
+      RatingMatchInfoSchema.safeParse(
+        makeMatchInfo({ team1: { name: "Poland" } }),
+      ).success,
+    ).toBe(false);
+  });
+
+  it("rejects when score is a string", () => {
+    expect(
+      RatingMatchInfoSchema.safeParse(makeMatchInfo({ score: "4" })).success,
+    ).toBe(false);
+  });
+});
+
+describe("RatingUserSchema", () => {
+  it("accepts a valid Rust UserRating payload", () => {
+    expect(RatingUserSchema.safeParse(makeUser()).success).toBe(true);
+  });
+
+  it("accepts an empty tips array (e.g. when calculate_positions clears tips)", () => {
+    expect(RatingUserSchema.safeParse(makeUser({ tips: [] })).success).toBe(
+      true,
+    );
+  });
+
+  it("rejects when score_sum is a string", () => {
+    expect(
+      RatingUserSchema.safeParse(makeUser({ score_sum: "21" })).success,
+    ).toBe(false);
+  });
+
+  it("rejects when name is missing", () => {
+    const { name: _name, ...rest } = makeUser();
+    expect(RatingUserSchema.safeParse(rest).success).toBe(false);
+  });
+
+  it("rejects when a tip inside tips[] is malformed", () => {
+    const payload = makeUser({
+      tips: [makeMatchInfo({ team2: "France" })],
+    });
+    expect(RatingUserSchema.safeParse(payload).success).toBe(false);
+  });
+});
+
+describe("RatingResponseSchema", () => {
+  it("accepts a valid table payload (matches the unwrapped /rating response)", () => {
+    const payload = {
+      global: [makeUser()],
+      departments: {
+        Langenfeld: [makeUser()],
+        London: [makeUser({ name: "RobbieFowler", department: "London" })],
+      },
+    };
+    expect(RatingResponseSchema.safeParse(payload).success).toBe(true);
+  });
+
+  it("accepts an empty global list and empty departments map", () => {
+    expect(
+      RatingResponseSchema.safeParse({ global: [], departments: {} }).success,
+    ).toBe(true);
+  });
+
+  it("rejects when the table field shape is missing 'departments'", () => {
+    expect(RatingResponseSchema.safeParse({ global: [] }).success).toBe(false);
+  });
+
+  it("rejects when 'global' is an object instead of an array", () => {
+    expect(
+      RatingResponseSchema.safeParse({ global: {}, departments: {} }).success,
+    ).toBe(false);
+  });
+
+  it("rejects when a department value is not an array", () => {
+    expect(
+      RatingResponseSchema.safeParse({
+        global: [],
+        departments: { Langenfeld: makeUser() },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("RatingTableSchema is an alias of RatingResponseSchema", () => {
+    expect(RatingTableSchema).toBe(RatingResponseSchema);
+  });
+});


### PR DESCRIPTION
Adds optional schema?: z.ZodSchema<T> to fetchApi; safeParse failures throw so callers fall through to their existing offline branch. Schemas for RatingResponse / RatingUser in lib/rating.ts (types derived via z.infer). Dashboard / ranking / profile updated to pass schemas; match-detail intentionally keeps its tolerant parseTips() since a Zod schema would regress UX (one bad element would fail the whole tips list).

75 vitest + 18 e2e tests green; tsc + build clean.