### PR TITLE
FE-020: bypass rate-limit in playwright suite via DISABLE_RATE_LIMIT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,9 @@ RUST_API_URL=http://localhost:8080
 # per request and bypass the limit. Set only when a trusted reverse
 # proxy strips client-supplied X-Forwarded-For headers.
 TRUST_PROXY=
+
+# DEV / TEST ONLY. When set (1 / true / yes), the rate-limiter
+# disables itself completely. Used by the Playwright suite so the
+# 5/10min/IP limit does not trip after 5 login specs. The server logs
+# a warning if this is ever seen with NODE_ENV=production.
+DISABLE_RATE_LIMIT=

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -27,7 +27,30 @@ export interface RateLimitResult {
   retryAfter?: number;
 }
 
+function isRateLimitDisabled(): boolean {
+  const value = process.env.DISABLE_RATE_LIMIT;
+  if (!value) return false;
+  const normalized = value.toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
+}
+
+let warnedAboutProdBypass = false;
+
 export function checkRateLimit(ip: string, bucket: string): RateLimitResult {
+  if (isRateLimitDisabled()) {
+    if (
+      process.env.NODE_ENV === "production" &&
+      !warnedAboutProdBypass
+    ) {
+      console.warn(
+        "[rate-limit] DISABLE_RATE_LIMIT is set in NODE_ENV=production. " +
+          "This is a dev/test bypass and MUST NOT be enabled in production.",
+      );
+      warnedAboutProdBypass = true;
+    }
+    return { ok: true };
+  }
+
   startSweep();
 
   if (buckets.size >= MAX_BUCKETS) {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
     env: {
       DATABASE_URL: "../shared/db/test.db",
       RUST_API_URL: process.env.RUST_API_URL ?? "http://localhost:8080",
-      MATCH_IMPORT_API_KEY: "devkey-test",
+      DISABLE_RATE_LIMIT: "1",
     },
   },
 });

--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -11,8 +11,19 @@ function headers(init: Record<string, string>): Headers {
 }
 
 describe("checkRateLimit", () => {
+  const originalDisable = process.env.DISABLE_RATE_LIMIT;
+
   beforeEach(() => {
     _internal.buckets.clear();
+    delete process.env.DISABLE_RATE_LIMIT;
+  });
+
+  afterEach(() => {
+    if (originalDisable === undefined) {
+      delete process.env.DISABLE_RATE_LIMIT;
+    } else {
+      process.env.DISABLE_RATE_LIMIT = originalDisable;
+    }
   });
 
   it("allows the first MAX_ATTEMPTS calls and blocks the next", () => {
@@ -22,6 +33,22 @@ describe("checkRateLimit", () => {
     const blocked = checkRateLimit("1.1.1.1", "login");
     expect(blocked.ok).toBe(false);
     expect(blocked.retryAfter).toBeGreaterThan(0);
+  });
+
+  it("DISABLE_RATE_LIMIT=1 always returns ok and never fills buckets", () => {
+    process.env.DISABLE_RATE_LIMIT = "1";
+    for (let i = 0; i < _internal.MAX_ATTEMPTS * 5; i += 1) {
+      expect(checkRateLimit("9.9.9.9", "login").ok).toBe(true);
+    }
+    expect(_internal.buckets.size).toBe(0);
+  });
+
+  it("DISABLE_RATE_LIMIT='0' / unset → normal limit applies", () => {
+    process.env.DISABLE_RATE_LIMIT = "0";
+    for (let i = 1; i <= _internal.MAX_ATTEMPTS; i += 1) {
+      expect(checkRateLimit("8.8.8.8", "login").ok).toBe(true);
+    }
+    expect(checkRateLimit("8.8.8.8", "login").ok).toBe(false);
   });
 
   it("uses independent buckets per (bucket, ip) pair", () => {


### PR DESCRIPTION
Adds a dev/test-only `DISABLE_RATE_LIMIT` env flag honoured by `lib/rate-limit.ts`. `playwright.config.ts` webServer.env sets it to 1. Prod behaviour unchanged; a console.warn fires if the flag is ever seen with NODE_ENV=production.

**Playwright 6/18 → 17/18.** The one remaining failure is the pre-existing ranking spec when betting-api Rust is offline. FE-015 attack-simulation test still confirms real-network limit holds.