### PR TITLE
FE-021: redirect unauthenticated visitors instead of throwing

### DIFF
--- a/app/(app)/match/[id]/page.tsx
+++ b/app/(app)/match/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { getCurrentSession } from "@/lib/session";
 import { getMatchById } from "@/lib/match";
 import { fetchApi } from "@/lib/api";
@@ -106,9 +106,7 @@ export default async function MatchDetailPage({
 }: MatchPageProps): Promise<React.ReactElement> {
   const { user } = await getCurrentSession();
   if (!user) {
-    throw new Error(
-      "Match detail rendered without a session — auth guard failed",
-    );
+    redirect("/login");
   }
   const userId = Number(user.id);
 

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -1,3 +1,4 @@
+import { redirect } from "next/navigation";
 import { getCurrentSession } from "@/lib/session";
 import { getLiveMatches, getUpcomingMatches } from "@/lib/match";
 import { getTipByUserAndMatchIds, type TipRow } from "@/lib/tip";
@@ -24,7 +25,7 @@ async function loadRating(): Promise<RatingResponse | null> {
 export default async function DashboardPage(): Promise<React.ReactElement> {
   const { user } = await getCurrentSession();
   if (!user) {
-    throw new Error("Dashboard rendered without a session — auth guard failed");
+    redirect("/login");
   }
   const userId = Number(user.id);
 

--- a/app/(app)/ranking/page.tsx
+++ b/app/(app)/ranking/page.tsx
@@ -1,3 +1,4 @@
+import { redirect } from "next/navigation";
 import { getCurrentSession } from "@/lib/session";
 import { fetchApi } from "@/lib/api";
 import { RatingResponseSchema, type RatingResponse } from "@/lib/rating";
@@ -43,7 +44,7 @@ export default async function RankingPage({
 }: RankingPageProps): Promise<React.ReactElement> {
   const { user } = await getCurrentSession();
   if (!user) {
-    throw new Error("Ranking rendered without a session — auth guard failed");
+    redirect("/login");
   }
   const userId = Number(user.id);
 

--- a/app/(app)/user/[id]/page.tsx
+++ b/app/(app)/user/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { getCurrentSession } from "@/lib/session";
 import { getUserById } from "@/lib/user";
 import { fetchApi } from "@/lib/api";
@@ -35,7 +35,7 @@ export default async function UserProfilePage({
 }: UserPageProps): Promise<React.ReactElement> {
   const { user: sessionUser } = await getCurrentSession();
   if (!sessionUser) {
-    throw new Error("Profile rendered without a session — auth guard failed");
+    redirect("/login");
   }
 
   const { id: rawId } = await params;


### PR DESCRIPTION
## Background

Visiting a protected page without a session logged a server error on every request, even though the visitor was correctly redirected to the login page. The page-level guards threw a generic error instead of redirecting, while the layout already handled the redirect — so each unauthenticated visit produced misleading error-log noise and risked surfacing as a real server error in production.

## What this changes

Unauthenticated visits to the protected pages (dashboard, profile, ranking, match detail) now redirect cleanly to the login page with no spurious error logged, in line with the project's documented guard convention. Authenticated users see no change.
