### PR TITLE
FE-026: show kickoff date and time on match detail

### DIFF
--- a/components/match/MatchHeader.tsx
+++ b/components/match/MatchHeader.tsx
@@ -137,26 +137,23 @@ function StatusSublabel({
   status: Status;
   liveMinute?: number | null;
   kickoff: Date;
-}): React.ReactElement | null {
-  if (status === "LIVE") {
-    return (
-      <div className="text-label-caps uppercase text-on-surface-variant mt-xs">
-        {typeof liveMinute === "number" ? `${liveMinute}'` : "Live"}
-      </div>
-    );
-  }
-
-  if (status === "FINISHED") {
-    return (
-      <div className="text-label-caps uppercase text-on-surface-variant mt-xs">
-        FULL TIME
-      </div>
-    );
-  }
-
-  return (
+}): React.ReactElement {
+  const kickoffLine = (
     <div className="text-label-caps uppercase text-on-surface-variant mt-xs font-mono">
       {formatDate(kickoff)} &middot; {extractTime(kickoff)}
     </div>
   );
+
+  if (status === "LIVE") {
+    return (
+      <>
+        <div className="text-label-caps uppercase text-on-surface-variant mt-xs">
+          {typeof liveMinute === "number" ? `${liveMinute}'` : "Live"}
+        </div>
+        {kickoffLine}
+      </>
+    );
+  }
+
+  return kickoffLine;
 }


### PR DESCRIPTION
## Background

On the match detail page, the kickoff date and time were only shown for upcoming matches. For matches that were already played or currently in progress, the date and time were replaced by the status label, so there was no way to see when the match actually took place.

## What this changes

The match detail page now shows the kickoff date and time for every match — finished, live, and upcoming. For live matches the playing minute is shown alongside the date and time.
