### PR TITLE
FE-029: add /profile route for the signed-in user

### DIFF
--- a/app/(app)/profile/page.tsx
+++ b/app/(app)/profile/page.tsx
@@ -1,0 +1,10 @@
+import { redirect } from "next/navigation";
+import { getCurrentSession } from "@/lib/session";
+
+export default async function ProfilePage(): Promise<never> {
+  const { user } = await getCurrentSession();
+  if (!user) {
+    redirect("/login");
+  }
+  redirect(`/user/${user.id}`);
+}


### PR DESCRIPTION
## Background

The "Profile" entry in the top navigation and bottom navigation linked to `/profile`, but no such route existed — profiles live under `/user/{id}`. Clicking "Profile" (or opening `/profile` directly) therefore landed on a 404 page instead of showing the user's own profile.

## What this changes

`/profile` now resolves to the signed-in user's own profile. Visiting it while logged in shows that profile; visiting it while logged out redirects to the login page, consistent with the other protected pages. The "Profile" navigation links work again.
