### PR TITLE
FE-022: remember-me login option

### DIFF
--- a/app/(auth)/login/login-form.tsx
+++ b/app/(auth)/login/login-form.tsx
@@ -99,6 +99,22 @@ export function LoginForm(): React.ReactElement {
         </div>
       </div>
 
+      <div className="flex items-center gap-sm">
+        <input
+          className="size-4 accent-primary"
+          id="remember"
+          name="remember"
+          type="checkbox"
+          disabled={pending}
+        />
+        <label
+          className="text-body-sm text-on-surface-variant"
+          htmlFor="remember"
+        >
+          Remember me
+        </label>
+      </div>
+
       {error ? (
         <p
           aria-live="polite"

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,6 +1,6 @@
 import { cookies } from "next/headers";
 import { Argon2id } from "oslo/password";
-import { lucia } from "@/lib/auth";
+import { lucia, REMEMBER_COOKIE, REMEMBER_MAX_AGE_SECONDS } from "@/lib/auth";
 import { getUserByEmail } from "@/lib/user";
 import { loginSchema } from "@/lib/validation/auth";
 import { checkRateLimit, getClientIp } from "@/lib/rate-limit";
@@ -77,11 +77,33 @@ export async function POST(request: Request): Promise<Response> {
   const session = await lucia.createSession(String(existing.id), {});
   const sessionCookie = lucia.createSessionCookie(session.id);
   const cookieStore = await cookies();
-  cookieStore.set(
-    sessionCookie.name,
-    sessionCookie.value,
-    sessionCookie.attributes,
-  );
+
+  const rememberValue = formData.get("remember");
+  const remember =
+    rememberValue === "on" ||
+    rememberValue === "true" ||
+    rememberValue === "1";
+
+  if (remember) {
+    cookieStore.set(
+      sessionCookie.name,
+      sessionCookie.value,
+      sessionCookie.attributes,
+    );
+    cookieStore.set(REMEMBER_COOKIE, "1", {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      path: "/",
+      maxAge: REMEMBER_MAX_AGE_SECONDS,
+    });
+  } else {
+    const sessionScoped = { ...sessionCookie.attributes };
+    delete sessionScoped.maxAge;
+    delete sessionScoped.expires;
+    cookieStore.set(sessionCookie.name, sessionCookie.value, sessionScoped);
+    cookieStore.set(REMEMBER_COOKIE, "", { path: "/", maxAge: 0 });
+  }
 
   if (wantsJson(request)) {
     return new Response(JSON.stringify({ ok: true }), {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -48,3 +48,9 @@ declare module "lucia" {
     DatabaseUserAttributes: DatabaseUserAttributes;
   }
 }
+
+// Companion cookie marking a "remember me" login. Lucia's session-cookie
+// expiry is global, so the login route and session refresh read this flag to
+// decide whether the session cookie is persistent (30 days) or session-scoped.
+export const REMEMBER_COOKIE = "auth_remember";
+export const REMEMBER_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -1,7 +1,7 @@
 import { cookies } from "next/headers";
 import { cache } from "react";
 import type { Session, User } from "lucia";
-import { lucia } from "@/lib/auth";
+import { lucia, REMEMBER_COOKIE } from "@/lib/auth";
 
 // Auth guard pattern: protected routes live under `app/(app)/` and inherit the
 // redirect from `app/(app)/layout.tsx`. Do not re-implement the unauthenticated
@@ -18,7 +18,13 @@ export const getCurrentSession = cache(
     try {
       if (result.session && result.session.fresh) {
         const fresh = lucia.createSessionCookie(result.session.id);
-        cookieStore.set(fresh.name, fresh.value, fresh.attributes);
+        const remembered = cookieStore.get(REMEMBER_COOKIE)?.value === "1";
+        const attributes = { ...fresh.attributes };
+        if (!remembered) {
+          delete attributes.maxAge;
+          delete attributes.expires;
+        }
+        cookieStore.set(fresh.name, fresh.value, attributes);
       }
       if (!result.session) {
         const blank = lucia.createBlankSessionCookie();


### PR DESCRIPTION
## Background

Until now, how long a login lasted was decided solely by the auth library's default and was the same for everyone. Users want to optionally stay signed in across browser restarts without having to re-authenticate on every visit.

## What this changes

The login page now offers a "Remember me" option. When enabled, the session persists for 30 days via a long-lived cookie; when disabled, the login behaves as a session cookie that ends when the browser is closed. The choice is honoured consistently, including when the session is later refreshed, and the cookie keeps its existing security attributes.
