### PR TITLE
FE-030: log Rust API call duration

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -38,7 +38,18 @@ export async function fetchApi<T>(
 
   const url = new URL(`${apiUrl}/${path}`);
 
-  const res = await fetch(url.toString());
+  const start = performance.now();
+  let res: Response;
+  try {
+    res = await fetch(url.toString());
+  } catch (error) {
+    const ms = Math.round(performance.now() - start);
+    // Path only — never request bodies, tokens, cookies or auth headers.
+    console.log(`[rust-api] GET /${path} failed after ${ms}ms`);
+    throw error;
+  }
+  const ms = Math.round(performance.now() - start);
+  console.log(`[rust-api] GET /${path} ${ms}ms`);
   if (!res.ok) {
     throw new Error(
       `fetchApi: ${res.status} ${res.statusText} for ${url.toString()}`,

--- a/tests/unit/api-timing.test.ts
+++ b/tests/unit/api-timing.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchApi } from "@/lib/api";
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => body,
+  } as Response;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("fetchApi timing log", () => {
+  it("logs method, path and duration on success and returns data", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ table: [] })),
+    );
+
+    const data = await fetchApi("rating", { wrappedByKey: "table" });
+
+    expect(data).toEqual([]);
+    expect(log).toHaveBeenCalledWith(
+      expect.stringMatching(/^\[rust-api\] GET \/rating \d+ms$/),
+    );
+  });
+
+  it("logs failure with duration and rethrows on network error", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("boom");
+      }),
+    );
+
+    await expect(fetchApi("user/5")).rejects.toThrow("boom");
+    expect(log).toHaveBeenCalledWith(
+      expect.stringMatching(/^\[rust-api\] GET \/user\/5 failed after \d+ms$/),
+    );
+  });
+});


### PR DESCRIPTION
## Background

There was no easy way to see how long calls to the Rust read API take. While developing and in production, it should be visible how long each request to the Rust service lasts, without changing how the API behaves.

## What this changes

Every call to the Rust API now logs its duration to the server console — method, endpoint and milliseconds — including a separate line when a request fails. Only the endpoint path is logged; request bodies, tokens, cookies and auth headers are never included. The API's return values and error handling are unchanged.
