### PR TITLE
FE-030: dev-only Rust API timing log

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -38,18 +38,25 @@ export async function fetchApi<T>(
 
   const url = new URL(`${apiUrl}/${path}`);
 
+  // Dev-only timing visibility (incl. duplicate queries). Production stays
+  // silent to avoid log noise. Path only — never bodies, tokens, cookies or
+  // auth headers.
+  const logTiming = process.env.NODE_ENV !== "production";
   const start = performance.now();
   let res: Response;
   try {
     res = await fetch(url.toString());
   } catch (error) {
-    const ms = Math.round(performance.now() - start);
-    // Path only — never request bodies, tokens, cookies or auth headers.
-    console.log(`[rust-api] GET /${path} failed after ${ms}ms`);
+    if (logTiming) {
+      const ms = Math.round(performance.now() - start);
+      console.log(`[rust-api] GET /${path} failed after ${ms}ms`);
+    }
     throw error;
   }
-  const ms = Math.round(performance.now() - start);
-  console.log(`[rust-api] GET /${path} ${ms}ms`);
+  if (logTiming) {
+    const ms = Math.round(performance.now() - start);
+    console.log(`[rust-api] GET /${path} ${ms}ms`);
+  }
   if (!res.ok) {
     throw new Error(
       `fetchApi: ${res.status} ${res.statusText} for ${url.toString()}`,

--- a/tests/unit/api-timing.test.ts
+++ b/tests/unit/api-timing.test.ts
@@ -13,6 +13,7 @@ function jsonResponse(body: unknown): Response {
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
 });
 
 describe("fetchApi timing log", () => {
@@ -29,6 +30,20 @@ describe("fetchApi timing log", () => {
     expect(log).toHaveBeenCalledWith(
       expect.stringMatching(/^\[rust-api\] GET \/rating \d+ms$/),
     );
+  });
+
+  it("stays silent in production but still returns data", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ table: [] })),
+    );
+
+    const data = await fetchApi("rating", { wrappedByKey: "table" });
+
+    expect(data).toEqual([]);
+    expect(log).not.toHaveBeenCalled();
   });
 
   it("logs failure with duration and rethrows on network error", async () => {


### PR DESCRIPTION
## Background

The Rust API call-duration logging should help during development — including spotting duplicate queries — but must not add noise to production logs.

## What this changes

The per-call timing log now only prints in development. In production the helper stays silent. A browser-visible Server-Timing header was evaluated but is not feasible for these calls, since they run during server-side page rendering, where response headers cannot be set; the dev-only console output covers the actual need without production log noise.
