### PR TITLE
FE-028: single responsive background for authenticated pages

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { getCurrentSession } from "@/lib/session";
+import { PageBackground } from "@/components/PageBackground";
 
 export default async function AppLayout({
   children,
@@ -10,5 +11,10 @@ export default async function AppLayout({
   if (!user) {
     redirect("/login");
   }
-  return <>{children}</>;
+  return (
+    <>
+      <PageBackground />
+      {children}
+    </>
+  );
 }

--- a/app/(app)/match/[id]/page.tsx
+++ b/app/(app)/match/[id]/page.tsx
@@ -10,7 +10,6 @@ import {
   PredictionsTable,
   type PredictionRow,
 } from "@/components/match/PredictionsTable";
-import { PageBackground } from "@/components/PageBackground";
 
 interface MatchPageProps {
   params: Promise<{ id: string }>;
@@ -133,7 +132,6 @@ export default async function MatchDetailPage({
 
   return (
     <>
-      <PageBackground src="/img/bg2.png" />
       <TopAppBar active="dashboard" />
       <main className="pt-4 md:pt-24 pb-24 md:pb-8 px-margin-mobile md:px-margin-desktop max-w-(--container-max-desktop) mx-auto">
         <MatchHeader match={match} liveMinute={null} />

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -9,7 +9,6 @@ import { UpcomingList } from "@/components/dashboard/UpcomingList";
 import { RankingSidebar } from "@/components/dashboard/RankingSidebar";
 import { BottomNav } from "@/components/dashboard/BottomNav";
 import { TopAppBar } from "@/components/dashboard/TopAppBar";
-import { PageBackground } from "@/components/PageBackground";
 
 async function loadRating(): Promise<RatingResponse | null> {
   try {
@@ -51,7 +50,6 @@ export default async function DashboardPage(): Promise<React.ReactElement> {
 
   return (
     <>
-      <PageBackground src="/img/bg1.png" />
       <TopAppBar active="dashboard" />
       <main className="pt-4 md:pt-24 pb-24 md:pb-8 px-margin-mobile md:px-margin-desktop max-w-(--container-max-desktop) mx-auto grid grid-cols-12 gap-lg">
         <div className="col-span-12 md:col-span-8 space-y-lg">

--- a/app/(app)/ranking/page.tsx
+++ b/app/(app)/ranking/page.tsx
@@ -9,7 +9,6 @@ import { BottomNav } from "@/components/dashboard/BottomNav";
 import { RankingTable } from "@/components/ranking/RankingTable";
 import { ScoringInfobox } from "@/components/ranking/ScoringInfobox";
 import { RankingTabs, type RankingTab } from "@/components/ranking/RankingTabs";
-import { PageBackground } from "@/components/PageBackground";
 
 interface RankingPageProps {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
@@ -59,7 +58,6 @@ export default async function RankingPage({
 
   return (
     <>
-      <PageBackground src="/img/bg2.png" />
       <TopAppBar active="ranking" />
       <main className="pt-4 md:pt-24 pb-24 md:pb-8 px-margin-mobile md:px-margin-desktop max-w-(--container-max-desktop) mx-auto">
         <div className="mb-lg">

--- a/app/(app)/user/[id]/page.tsx
+++ b/app/(app)/user/[id]/page.tsx
@@ -10,7 +10,6 @@ import { StatTiles } from "@/components/profile/StatTiles";
 import { WinnerCards } from "@/components/profile/WinnerCards";
 import { PredictionHistory } from "@/components/profile/PredictionHistory";
 import { isTournamentLocked } from "@/lib/tournament";
-import { PageBackground } from "@/components/PageBackground";
 
 interface UserPageProps {
   params: Promise<{ id: string }>;
@@ -72,7 +71,6 @@ export default async function UserProfilePage({
 
   return (
     <>
-      <PageBackground src="/img/bg2.png" />
       <TopAppBar active={isOwnProfile ? "profile" : "dashboard"} />
       <main className="pt-4 md:pt-24 pb-24 md:pb-8 px-margin-mobile md:px-margin-desktop max-w-(--container-max-desktop) mx-auto">
         <div className="grid grid-cols-1 md:grid-cols-12 gap-lg mb-xl">

--- a/components/PageBackground.tsx
+++ b/components/PageBackground.tsx
@@ -1,8 +1,17 @@
-export function PageBackground({ src }: { src: string }): React.ReactElement {
+export function PageBackground(): React.ReactElement {
   return (
     <div aria-hidden className="fixed inset-0 -z-10 pointer-events-none">
-      <img src={src} alt="" className="h-full w-full object-cover" />
-      <div className="absolute inset-0 bg-background/95" />
+      <img
+        src="/img/bg2.png"
+        alt=""
+        className="hidden md:block h-full w-full object-cover"
+      />
+      <img
+        src="/img/bg1.png"
+        alt=""
+        className="md:hidden h-full w-full object-cover"
+      />
+      <div className="absolute inset-0 bg-background/85 md:bg-background/95" />
     </div>
   );
 }


### PR DESCRIPTION
## Background

The authenticated areas previously set a different background image per page. The design should instead use one background across all signed-in pages, varying only by device, while login and signup stay plain.

## What this changes

All signed-in pages now share a single background, applied once in the app layout: a desktop image and a separate mobile image, with the dark overlay slightly lighter on mobile so the image stays visible. Login and signup remain without a background.
