### PR TITLE
FE-024: demo data — multiple fixtures per upcoming day

### DIFF
--- a/scripts/demo_data.ts
+++ b/scripts/demo_data.ts
@@ -230,6 +230,26 @@ function buildMatches(now: number): SeedMatch[] {
       homeScore: null,
       awayScore: null,
     },
+    // Second fixtures sharing an already-used upcoming day (identical utcDate)
+    // so the per-day grouping shows days with more than one match.
+    {
+      id: 13,
+      homeTeam: TEAM.POR,
+      awayTeam: TEAM.NED,
+      status: "SCHEDULED",
+      utcDate: now + 1 * DAY,
+      homeScore: null,
+      awayScore: null,
+    },
+    {
+      id: 14,
+      homeTeam: TEAM.CRO,
+      awayTeam: TEAM.POL,
+      status: "SCHEDULED",
+      utcDate: now + 2 * DAY,
+      homeScore: null,
+      awayScore: null,
+    },
   ];
 }
 


### PR DESCRIPTION
## Background

The Upcoming Fixtures list groups matches by day, but the demo seed had only one match per day, so the grouping was never visibly exercised.

## What this changes

The demo seed now places a second fixture on two of the upcoming days, so the dashboard's day grouping shows days with more than one match.