### PR TITLE
FE-025/FE-027/FE-037: tip view-edit flow, responsive actions, dashboard layout & focus polish

### DIFF
--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -52,14 +52,19 @@ export default async function DashboardPage(): Promise<React.ReactElement> {
     <>
       <TopAppBar active="dashboard" />
       <main className="pt-4 md:pt-24 pb-24 md:pb-8 px-margin-mobile md:px-margin-desktop max-w-(--container-max-desktop) mx-auto grid grid-cols-12 gap-lg">
-        <div className="col-span-12 md:col-span-8 space-y-lg">
+        <div className="col-span-12 min-[980px]:col-span-8 space-y-lg">
           <LiveBlock matches={liveMatches} tipsByMatchId={tipsByMatchId} />
+          {/* Below 980px: ranking sits between live and upcoming fixtures */}
+          <div className="min-[980px]:hidden">
+            <RankingSidebar rating={rating} currentUserId={userId} />
+          </div>
           <UpcomingList
             matches={upcomingMatches}
             tipsByMatchId={tipsByMatchId}
           />
         </div>
-        <div className="col-span-12 md:col-span-4">
+        {/* From 980px: ranking as the right sidebar */}
+        <div className="hidden min-[980px]:block col-span-12 min-[980px]:col-span-4">
           <RankingSidebar rating={rating} currentUserId={userId} />
         </div>
       </main>

--- a/app/globals.css
+++ b/app/globals.css
@@ -124,6 +124,11 @@ body {
   font-family: var(--font-sans);
 }
 
+:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 .material-symbols-outlined {
   font-family: "Material Symbols Outlined";
   font-weight: normal;

--- a/components/dashboard/MatchRow.tsx
+++ b/components/dashboard/MatchRow.tsx
@@ -21,7 +21,7 @@ export function MatchRow({ match, tip }: MatchRowProps): React.ReactElement {
       className={`bg-surface-container border border-outline-variant rounded-lg p-lg transition-all ${
         disabled
           ? "opacity-60"
-          : "hover:border-primary/30 focus-within:border-primary"
+          : "hover:border-primary/30 has-[[data-editing]]:border-primary"
       }`}
     >
       <div className="flex flex-col md:flex-row md:justify-between md:items-center gap-md">

--- a/components/dashboard/MatchRow.tsx
+++ b/components/dashboard/MatchRow.tsx
@@ -18,12 +18,10 @@ export function MatchRow({ match, tip }: MatchRowProps): React.ReactElement {
 
   return (
     <div
-      className={`bg-surface-container border rounded-lg p-lg transition-all ${
+      className={`bg-surface-container border border-outline-variant rounded-lg p-lg transition-all ${
         disabled
-          ? "border-outline-variant opacity-60"
-          : tip
-            ? "border-outline-variant hover:border-primary/30"
-            : "border-outline hover:border-primary/40"
+          ? "opacity-60"
+          : "hover:border-primary/30 focus-within:border-outline"
       }`}
     >
       <div className="flex flex-col md:flex-row md:justify-between md:items-center gap-md">

--- a/components/dashboard/MatchRow.tsx
+++ b/components/dashboard/MatchRow.tsx
@@ -21,7 +21,7 @@ export function MatchRow({ match, tip }: MatchRowProps): React.ReactElement {
       className={`bg-surface-container border border-outline-variant rounded-lg p-lg transition-all ${
         disabled
           ? "opacity-60"
-          : "hover:border-primary/30 focus-within:border-outline"
+          : "hover:border-primary/30 focus-within:border-primary"
       }`}
     >
       <div className="flex flex-col md:flex-row md:justify-between md:items-center gap-md">

--- a/components/dashboard/MatchRow.tsx
+++ b/components/dashboard/MatchRow.tsx
@@ -18,10 +18,12 @@ export function MatchRow({ match, tip }: MatchRowProps): React.ReactElement {
 
   return (
     <div
-      className={`bg-surface-container border border-outline-variant rounded-lg p-lg transition-all ${
+      className={`bg-surface-container border rounded-lg p-lg transition-all ${
         disabled
-          ? "opacity-60"
-          : "hover:border-primary/30"
+          ? "border-outline-variant opacity-60"
+          : tip
+            ? "border-outline-variant hover:border-primary/30"
+            : "border-outline hover:border-primary/40"
       }`}
     >
       <div className="flex flex-col md:flex-row md:justify-between md:items-center gap-md">

--- a/components/dashboard/TipForm.tsx
+++ b/components/dashboard/TipForm.tsx
@@ -144,7 +144,7 @@ export function TipForm({
             disabled={disabled || pending}
             placeholder="-"
             aria-label={t("homeScoreTip")}
-            className="w-12 min-h-12 bg-surface-container-low border border-outline-variant rounded text-center text-headline-md font-mono focus:border-primary focus:ring-0 transition-colors disabled:opacity-60"
+            className="w-12 min-h-12 bg-surface-container-low border border-outline-variant rounded text-center text-headline-md font-mono focus:border-primary focus:ring-0 transition-colors disabled:opacity-60 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
           />
           <span className="text-outline-variant">:</span>
           <input
@@ -157,7 +157,7 @@ export function TipForm({
             disabled={disabled || pending}
             placeholder="-"
             aria-label={t("awayScoreTip")}
-            className="w-12 min-h-12 bg-surface-container-low border border-outline-variant rounded text-center text-headline-md font-mono focus:border-primary focus:ring-0 transition-colors disabled:opacity-60"
+            className="w-12 min-h-12 bg-surface-container-low border border-outline-variant rounded text-center text-headline-md font-mono focus:border-primary focus:ring-0 transition-colors disabled:opacity-60 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
           />
         </div>
         {/* Mobile: text button (finger-friendly tap target) */}

--- a/components/dashboard/TipForm.tsx
+++ b/components/dashboard/TipForm.tsx
@@ -3,11 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useState, type FormEvent } from "react";
-import {
-  formatTipScore,
-  initialTipEditing,
-  type TipScore,
-} from "@/lib/tip-view";
+import { initialTipEditing, type TipScore } from "@/lib/tip-view";
 
 interface TipFormProps {
   matchId: number;
@@ -97,15 +93,20 @@ export function TipForm({
     return (
       <div className="flex flex-col gap-xs">
         <div className="flex items-center gap-md justify-end">
-          <button
-            type="button"
-            onClick={enterEdit}
-            disabled={disabled}
-            aria-label={t("editTip")}
-            className="text-headline-md font-mono min-h-12 px-md tabular-nums disabled:cursor-default disabled:opacity-100 enabled:hover:text-primary transition-colors"
+          <div
+            onClick={disabled ? undefined : enterEdit}
+            className={`flex items-center gap-xs ${
+              disabled ? "" : "cursor-pointer"
+            }`}
           >
-            {formatTipScore(savedTip)}
-          </button>
+            <span className="w-12 min-h-12 flex items-center justify-center bg-surface-container-low border border-outline-variant rounded text-center text-headline-md font-mono tabular-nums">
+              {savedTip.scoreHome}
+            </span>
+            <span className="text-outline-variant">:</span>
+            <span className="w-12 min-h-12 flex items-center justify-center bg-surface-container-low border border-outline-variant rounded text-center text-headline-md font-mono tabular-nums">
+              {savedTip.scoreAway}
+            </span>
+          </div>
           {disabled ? null : (
             <button
               type="button"

--- a/components/dashboard/TipForm.tsx
+++ b/components/dashboard/TipForm.tsx
@@ -100,27 +100,13 @@ export function TipForm({
             {formatTipScore(savedTip)}
           </div>
           {disabled ? null : (
-            <>
-              {/* Mobile: secondary text button (grey with primary border) */}
-              <button
-                type="button"
-                onClick={enterEdit}
-                className="md:hidden px-lg py-2 min-h-12 rounded-lg text-label-caps uppercase font-bold border border-primary text-on-surface bg-surface-container-low hover:bg-surface-container transition-colors active:scale-95"
-              >
-                {t("edit")}
-              </button>
-              {/* Desktop: compact pencil icon */}
-              <button
-                type="button"
-                onClick={enterEdit}
-                aria-label={t("editTip")}
-                className="hidden md:flex w-10 h-10 min-h-10 items-center justify-center rounded-lg text-on-surface-variant hover:text-primary hover:bg-surface-container-high transition-colors active:scale-95"
-              >
-                <span className="material-symbols-outlined text-[20px]">
-                  edit
-                </span>
-              </button>
-            </>
+            <button
+              type="button"
+              onClick={enterEdit}
+              className="px-lg py-2 min-h-12 rounded-lg text-label-caps uppercase font-bold border border-primary text-on-surface bg-surface-container-low hover:bg-surface-container transition-colors active:scale-95"
+            >
+              {t("edit")}
+            </button>
           )}
         </div>
       </div>
@@ -160,28 +146,12 @@ export function TipForm({
             className="w-12 min-h-12 bg-surface-container-low border border-outline-variant rounded text-center text-headline-md font-mono focus:border-primary focus:ring-0 transition-colors disabled:opacity-60"
           />
         </div>
-        {/* Mobile: full text button (room available in the single column) */}
         <button
           type="submit"
           disabled={disabled || pending}
-          className="md:hidden px-lg py-2 min-h-12 rounded-lg text-label-caps uppercase font-bold bg-primary text-on-primary hover:opacity-90 transition-all active:scale-95 disabled:opacity-60"
+          className="px-lg py-2 min-h-12 rounded-lg text-label-caps uppercase font-bold bg-primary text-on-primary hover:opacity-90 transition-all active:scale-95 disabled:opacity-60"
         >
           {pending ? "..." : t("save")}
-        </button>
-        {/* Desktop: compact icon (narrow two-column grid) */}
-        <button
-          type="submit"
-          disabled={disabled || pending}
-          aria-label={t("save")}
-          className="hidden md:flex w-10 h-10 min-h-10 items-center justify-center rounded-lg text-primary hover:bg-primary/10 transition-colors active:scale-95 disabled:opacity-60"
-        >
-          <span
-            className={`material-symbols-outlined text-[20px] ${
-              pending ? "animate-spin" : ""
-            }`}
-          >
-            {pending ? "progress_activity" : "check"}
-          </span>
         </button>
       </form>
       {error ? (

--- a/components/dashboard/TipForm.tsx
+++ b/components/dashboard/TipForm.tsx
@@ -158,7 +158,7 @@ export function TipForm({
             disabled={disabled || pending}
             placeholder="-"
             aria-label={t("homeScoreTip")}
-            className="w-12 min-h-12 bg-surface-container-low border border-outline-variant rounded text-center text-headline-md font-mono focus:border-primary focus:ring-0 transition-colors disabled:opacity-60 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+            className="w-12 min-h-12 bg-surface-container-low border border-outline-variant rounded text-center text-headline-md font-mono focus:border-primary focus:outline-none focus:ring-0 hover:border-primary/50 transition-colors disabled:opacity-60 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
           />
           <span className="text-outline-variant">:</span>
           <input
@@ -171,7 +171,7 @@ export function TipForm({
             disabled={disabled || pending}
             placeholder="-"
             aria-label={t("awayScoreTip")}
-            className="w-12 min-h-12 bg-surface-container-low border border-outline-variant rounded text-center text-headline-md font-mono focus:border-primary focus:ring-0 transition-colors disabled:opacity-60 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+            className="w-12 min-h-12 bg-surface-container-low border border-outline-variant rounded text-center text-headline-md font-mono focus:border-primary focus:outline-none focus:ring-0 hover:border-primary/50 transition-colors disabled:opacity-60 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
           />
         </div>
         {/* Mobile: text button (finger-friendly tap target) */}

--- a/components/dashboard/TipForm.tsx
+++ b/components/dashboard/TipForm.tsx
@@ -100,14 +100,27 @@ export function TipForm({
             {formatTipScore(savedTip)}
           </div>
           {disabled ? null : (
-            <button
-              type="button"
-              onClick={enterEdit}
-              aria-label={t("editTip")}
-              className="w-10 h-10 min-h-10 flex items-center justify-center rounded-lg text-on-surface-variant/70 hover:text-on-surface-variant hover:bg-surface-container-high transition-colors active:scale-95"
-            >
-              <span className="material-symbols-outlined text-[20px]">edit</span>
-            </button>
+            <>
+              {/* Mobile: text button (finger-friendly tap target) */}
+              <button
+                type="button"
+                onClick={enterEdit}
+                className="md:hidden px-lg py-2 min-h-12 rounded-lg text-label-caps uppercase font-bold border border-primary text-on-surface bg-surface-container-low hover:bg-surface-container transition-colors active:scale-95"
+              >
+                {t("edit")}
+              </button>
+              {/* Desktop: muted pencil icon */}
+              <button
+                type="button"
+                onClick={enterEdit}
+                aria-label={t("editTip")}
+                className="hidden md:flex w-10 h-10 min-h-10 items-center justify-center rounded-lg text-on-surface-variant/70 hover:text-on-surface-variant hover:bg-surface-container-high transition-colors active:scale-95"
+              >
+                <span className="material-symbols-outlined text-[20px]">
+                  edit
+                </span>
+              </button>
+            </>
           )}
         </div>
       </div>
@@ -147,11 +160,20 @@ export function TipForm({
             className="w-12 min-h-12 bg-surface-container-low border border-outline-variant rounded text-center text-headline-md font-mono focus:border-primary focus:ring-0 transition-colors disabled:opacity-60"
           />
         </div>
+        {/* Mobile: text button (finger-friendly tap target) */}
+        <button
+          type="submit"
+          disabled={disabled || pending}
+          className="md:hidden px-lg py-2 min-h-12 rounded-lg text-label-caps uppercase font-bold bg-primary text-on-primary hover:opacity-90 transition-all active:scale-95 disabled:opacity-60"
+        >
+          {pending ? "..." : t("save")}
+        </button>
+        {/* Desktop: compact save icon */}
         <button
           type="submit"
           disabled={disabled || pending}
           aria-label={t("save")}
-          className="w-10 h-10 min-h-10 flex items-center justify-center rounded-lg text-primary hover:bg-primary/10 transition-colors active:scale-95 disabled:opacity-60"
+          className="hidden md:flex w-10 h-10 min-h-10 items-center justify-center rounded-lg text-primary hover:bg-primary/10 transition-colors active:scale-95 disabled:opacity-60"
         >
           <span
             className={`material-symbols-outlined text-[20px] ${

--- a/components/dashboard/TipForm.tsx
+++ b/components/dashboard/TipForm.tsx
@@ -103,9 +103,10 @@ export function TipForm({
             <button
               type="button"
               onClick={enterEdit}
-              className="px-lg py-2 min-h-12 rounded-lg text-label-caps uppercase font-bold border border-primary text-on-surface bg-surface-container-low hover:bg-surface-container transition-colors active:scale-95"
+              aria-label={t("editTip")}
+              className="w-10 h-10 min-h-10 flex items-center justify-center rounded-lg text-on-surface-variant hover:text-primary hover:bg-surface-container-high transition-colors active:scale-95"
             >
-              {t("edit")}
+              <span className="material-symbols-outlined text-[20px]">edit</span>
             </button>
           )}
         </div>
@@ -149,9 +150,16 @@ export function TipForm({
         <button
           type="submit"
           disabled={disabled || pending}
-          className="px-lg py-2 min-h-12 rounded-lg text-label-caps uppercase font-bold bg-primary text-on-primary hover:opacity-90 transition-all active:scale-95 disabled:opacity-60"
+          aria-label={t("save")}
+          className="w-10 h-10 min-h-10 flex items-center justify-center rounded-lg text-primary hover:bg-primary/10 transition-colors active:scale-95 disabled:opacity-60"
         >
-          {pending ? "..." : t("save")}
+          <span
+            className={`material-symbols-outlined text-[20px] ${
+              pending ? "animate-spin" : ""
+            }`}
+          >
+            {pending ? "progress_activity" : "save"}
+          </span>
         </button>
       </form>
       {error ? (

--- a/components/dashboard/TipForm.tsx
+++ b/components/dashboard/TipForm.tsx
@@ -105,7 +105,7 @@ export function TipForm({
               <button
                 type="button"
                 onClick={enterEdit}
-                className="md:hidden px-lg py-2 min-h-12 rounded-lg text-label-caps uppercase font-bold border border-primary text-on-surface bg-surface-container-low hover:bg-surface-container transition-colors active:scale-95"
+                className="md:hidden px-lg py-2 min-h-12 rounded-lg text-label-caps uppercase font-bold border border-outline-variant text-on-surface-variant bg-surface-container-low hover:bg-surface-container transition-colors active:scale-95"
               >
                 {t("edit")}
               </button>

--- a/components/dashboard/TipForm.tsx
+++ b/components/dashboard/TipForm.tsx
@@ -3,10 +3,15 @@
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useState, type FormEvent } from "react";
+import {
+  formatTipScore,
+  initialTipEditing,
+  type TipScore,
+} from "@/lib/tip-view";
 
 interface TipFormProps {
   matchId: number;
-  initialTip?: { scoreHome: number; scoreAway: number } | null;
+  initialTip?: TipScore | null;
   disabled?: boolean;
 }
 
@@ -22,6 +27,10 @@ export function TipForm({
   );
   const [tipAway, setTipAway] = useState<string>(
     initialTip ? String(initialTip.scoreAway) : "",
+  );
+  const [savedTip, setSavedTip] = useState<TipScore | null>(initialTip);
+  const [isEditing, setIsEditing] = useState<boolean>(
+    initialTipEditing(initialTip),
   );
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -47,6 +56,8 @@ export function TipForm({
 
       if (res.ok) {
         setSaved(true);
+        setSavedTip({ scoreHome: Number(tipHome), scoreAway: Number(tipAway) });
+        setIsEditing(false);
         router.refresh();
         return;
       }
@@ -73,13 +84,42 @@ export function TipForm({
     }
   }
 
-  const buttonLabel = saved
-    ? t("saved")
-    : pending
-      ? "..."
-      : initialTip
-        ? t("edit")
-        : t("save");
+  function enterEdit(): void {
+    if (disabled) return;
+    setSaved(false);
+    setError(null);
+    setIsEditing(true);
+  }
+
+  const buttonLabel = saved ? t("saved") : pending ? "..." : t("save");
+
+  if (!isEditing && savedTip) {
+    return (
+      <div className="flex flex-col gap-xs">
+        <div className="flex items-center gap-md justify-end">
+          <button
+            type="button"
+            onClick={enterEdit}
+            disabled={disabled}
+            aria-label={t("editTip")}
+            className="text-headline-md font-mono min-h-12 px-md tabular-nums disabled:cursor-default disabled:opacity-100 enabled:hover:text-primary transition-colors"
+          >
+            {formatTipScore(savedTip)}
+          </button>
+          {disabled ? null : (
+            <button
+              type="button"
+              onClick={enterEdit}
+              aria-label={t("editTip")}
+              className="w-10 h-10 min-h-10 flex items-center justify-center rounded-lg text-on-surface-variant hover:text-primary hover:bg-surface-container-high transition-colors active:scale-95"
+            >
+              <span className="material-symbols-outlined text-[20px]">edit</span>
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col gap-xs">

--- a/components/dashboard/TipForm.tsx
+++ b/components/dashboard/TipForm.tsx
@@ -104,7 +104,7 @@ export function TipForm({
               type="button"
               onClick={enterEdit}
               aria-label={t("editTip")}
-              className="w-10 h-10 min-h-10 flex items-center justify-center rounded-lg text-on-surface-variant hover:text-primary hover:bg-surface-container-high transition-colors active:scale-95"
+              className="w-10 h-10 min-h-10 flex items-center justify-center rounded-lg text-on-surface-variant/70 hover:text-on-surface-variant hover:bg-surface-container-high transition-colors active:scale-95"
             >
               <span className="material-symbols-outlined text-[20px]">edit</span>
             </button>

--- a/components/dashboard/TipForm.tsx
+++ b/components/dashboard/TipForm.tsx
@@ -138,7 +138,10 @@ export function TipForm({
   }
 
   return (
-    <div className="flex flex-col gap-xs">
+    <div
+      className="flex flex-col gap-xs"
+      data-editing={savedTip ? "true" : undefined}
+    >
       <form
         onSubmit={onSubmit}
         className="flex items-center gap-md justify-end"

--- a/components/dashboard/TipForm.tsx
+++ b/components/dashboard/TipForm.tsx
@@ -34,13 +34,11 @@ export function TipForm({
   );
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [saved, setSaved] = useState(false);
 
   async function onSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
     event.preventDefault();
     if (disabled) return;
     setError(null);
-    setSaved(false);
     setPending(true);
 
     const form = new FormData();
@@ -55,7 +53,6 @@ export function TipForm({
       });
 
       if (res.ok) {
-        setSaved(true);
         setSavedTip({ scoreHome: Number(tipHome), scoreAway: Number(tipAway) });
         setIsEditing(false);
         router.refresh();
@@ -86,12 +83,9 @@ export function TipForm({
 
   function enterEdit(): void {
     if (disabled) return;
-    setSaved(false);
     setError(null);
     setIsEditing(true);
   }
-
-  const buttonLabel = saved ? t("saved") : pending ? "..." : t("save");
 
   if (!isEditing && savedTip) {
     return (
@@ -106,14 +100,27 @@ export function TipForm({
             {formatTipScore(savedTip)}
           </div>
           {disabled ? null : (
-            <button
-              type="button"
-              onClick={enterEdit}
-              aria-label={t("editTip")}
-              className="w-10 h-10 min-h-10 flex items-center justify-center rounded-lg text-on-surface-variant hover:text-primary hover:bg-surface-container-high transition-colors active:scale-95"
-            >
-              <span className="material-symbols-outlined text-[20px]">edit</span>
-            </button>
+            <>
+              {/* Mobile: secondary text button (grey with primary border) */}
+              <button
+                type="button"
+                onClick={enterEdit}
+                className="md:hidden px-lg py-2 min-h-12 rounded-lg text-label-caps uppercase font-bold border border-primary text-on-surface bg-surface-container-low hover:bg-surface-container transition-colors active:scale-95"
+              >
+                {t("edit")}
+              </button>
+              {/* Desktop: compact pencil icon */}
+              <button
+                type="button"
+                onClick={enterEdit}
+                aria-label={t("editTip")}
+                className="hidden md:flex w-10 h-10 min-h-10 items-center justify-center rounded-lg text-on-surface-variant hover:text-primary hover:bg-surface-container-high transition-colors active:scale-95"
+              >
+                <span className="material-symbols-outlined text-[20px]">
+                  edit
+                </span>
+              </button>
+            </>
           )}
         </div>
       </div>
@@ -153,16 +160,28 @@ export function TipForm({
             className="w-12 min-h-12 bg-surface-container-low border border-outline-variant rounded text-center text-headline-md font-mono focus:border-primary focus:ring-0 transition-colors disabled:opacity-60"
           />
         </div>
+        {/* Mobile: full text button (room available in the single column) */}
         <button
           type="submit"
           disabled={disabled || pending}
-          className={`px-lg py-2 min-h-12 rounded-lg text-label-caps uppercase font-bold transition-all active:scale-95 disabled:opacity-60 ${
-            saved
-              ? "bg-tertiary text-on-tertiary"
-              : "bg-primary text-on-primary hover:opacity-90"
-          }`}
+          className="md:hidden px-lg py-2 min-h-12 rounded-lg text-label-caps uppercase font-bold bg-primary text-on-primary hover:opacity-90 transition-all active:scale-95 disabled:opacity-60"
         >
-          {buttonLabel}
+          {pending ? "..." : t("save")}
+        </button>
+        {/* Desktop: compact icon (narrow two-column grid) */}
+        <button
+          type="submit"
+          disabled={disabled || pending}
+          aria-label={t("save")}
+          className="hidden md:flex w-10 h-10 min-h-10 items-center justify-center rounded-lg text-primary hover:bg-primary/10 transition-colors active:scale-95 disabled:opacity-60"
+        >
+          <span
+            className={`material-symbols-outlined text-[20px] ${
+              pending ? "animate-spin" : ""
+            }`}
+          >
+            {pending ? "progress_activity" : "check"}
+          </span>
         </button>
       </form>
       {error ? (

--- a/components/dashboard/TipForm.tsx
+++ b/components/dashboard/TipForm.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useState, type FormEvent } from "react";
+import { useEffect, useRef, useState, type FormEvent } from "react";
 import {
   formatTipScore,
   initialTipEditing,
@@ -34,6 +34,15 @@ export function TipForm({
   );
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const homeInputRef = useRef<HTMLInputElement>(null);
+  const focusOnEdit = useRef(false);
+
+  useEffect(() => {
+    if (isEditing && focusOnEdit.current) {
+      focusOnEdit.current = false;
+      homeInputRef.current?.focus();
+    }
+  }, [isEditing]);
 
   async function onSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
     event.preventDefault();
@@ -84,6 +93,7 @@ export function TipForm({
   function enterEdit(): void {
     if (disabled) return;
     setError(null);
+    focusOnEdit.current = true;
     setIsEditing(true);
   }
 
@@ -139,6 +149,7 @@ export function TipForm({
             min={0}
             max={20}
             required
+            ref={homeInputRef}
             value={tipHome}
             onChange={(e) => setTipHome(e.target.value)}
             disabled={disabled || pending}

--- a/components/dashboard/TipForm.tsx
+++ b/components/dashboard/TipForm.tsx
@@ -3,7 +3,11 @@
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useState, type FormEvent } from "react";
-import { initialTipEditing, type TipScore } from "@/lib/tip-view";
+import {
+  formatTipScore,
+  initialTipEditing,
+  type TipScore,
+} from "@/lib/tip-view";
 
 interface TipFormProps {
   matchId: number;
@@ -95,17 +99,11 @@ export function TipForm({
         <div className="flex items-center gap-md justify-end">
           <div
             onClick={disabled ? undefined : enterEdit}
-            className={`flex items-center gap-xs ${
+            className={`text-headline-md font-mono min-h-12 flex items-center tabular-nums ${
               disabled ? "" : "cursor-pointer"
             }`}
           >
-            <span className="w-12 min-h-12 flex items-center justify-center bg-surface-container-low border border-outline-variant rounded text-center text-headline-md font-mono tabular-nums">
-              {savedTip.scoreHome}
-            </span>
-            <span className="text-outline-variant">:</span>
-            <span className="w-12 min-h-12 flex items-center justify-center bg-surface-container-low border border-outline-variant rounded text-center text-headline-md font-mono tabular-nums">
-              {savedTip.scoreAway}
-            </span>
+            {formatTipScore(savedTip)}
           </div>
           {disabled ? null : (
             <button

--- a/lib/tip-view.ts
+++ b/lib/tip-view.ts
@@ -1,0 +1,14 @@
+export interface TipScore {
+  scoreHome: number;
+  scoreAway: number;
+}
+
+// A tip starts in view mode only when one already exists to display.
+// With no existing tip there is nothing to view, so we open the form.
+export function initialTipEditing(initialTip: TipScore | null): boolean {
+  return initialTip === null;
+}
+
+export function formatTipScore(score: TipScore): string {
+  return `${score.scoreHome} : ${score.scoreAway}`;
+}

--- a/messages/de.json
+++ b/messages/de.json
@@ -29,6 +29,7 @@
   "TipForm": {
     "saved": "GESPEICHERT",
     "edit": "BEARBEITEN",
+    "editTip": "Tipp bearbeiten",
     "save": "SPEICHERN",
     "failedToSave": "Tipp konnte nicht gespeichert werden.",
     "networkError": "Netzwerkfehler. Bitte erneut versuchen.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -29,6 +29,7 @@
   "TipForm": {
     "saved": "SAVED",
     "edit": "EDIT",
+    "editTip": "Edit tip",
     "save": "SAVE",
     "failedToSave": "Failed to save tip.",
     "networkError": "Network error. Try again.",

--- a/tests/unit/tip-view-mode.test.ts
+++ b/tests/unit/tip-view-mode.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatTipScore,
+  initialTipEditing,
+  type TipScore,
+} from "@/lib/tip-view";
+
+describe("initialTipEditing", () => {
+  it("opens the form when there is no existing tip", () => {
+    expect(initialTipEditing(null)).toBe(true);
+  });
+
+  it("starts in view mode when a tip already exists", () => {
+    const tip: TipScore = { scoreHome: 2, scoreAway: 1 };
+    expect(initialTipEditing(tip)).toBe(false);
+  });
+});
+
+describe("formatTipScore", () => {
+  it("renders the predicted result as spaced text", () => {
+    expect(formatTipScore({ scoreHome: 2, scoreAway: 1 })).toBe("2 : 1");
+  });
+
+  it("handles zero scores", () => {
+    expect(formatTipScore({ scoreHome: 0, scoreAway: 0 })).toBe("0 : 0");
+  });
+});


### PR DESCRIPTION
## Background

The dashboard tip flow and layout needed several usability improvements: once a tip was submitted the score inputs stayed visible, the small ranking sat at the very bottom on narrow screens, there was no clear signal for a row being actively edited, and focus/hover states used the browser's default white/blue styling that clashed with the dark theme.

## What this changes

- A submitted tip now shows compactly as its result; editing reopens the inputs (icons on desktop, text buttons on mobile for finger-friendly tapping).
- A row being actively edited is clearly highlighted and stays highlighted until saved.
- The small ranking appears between the live games and the upcoming fixtures on narrower screens and moves to a right sidebar from 980px upward.
- Focus and hover states across the app use the brand colour instead of the default white/blue ring, and the number inputs no longer show stepper arrows.
