### PR TITLE
FE-039: language switcher on login/register

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,0 +1,16 @@
+import { LocaleSwitcher } from "@/components/LocaleSwitcher";
+
+export default function AuthLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <>
+      <div className="fixed top-4 right-4 z-20">
+        <LocaleSwitcher />
+      </div>
+      {children}
+    </>
+  );
+}


### PR DESCRIPTION
## Background

The language switcher was only available on signed-in pages (in the top bar), so visitors could not change the language on the login or registration screens.

## What this changes

Login and registration now show the same language switcher, added once via a shared layout for the auth pages. The choice persists in the same locale cookie used everywhere else.