### PR TITLE
FE-038: production-only valantic.com signup email

### DIFF
--- a/app/(auth)/signup/signup-form.tsx
+++ b/app/(auth)/signup/signup-form.tsx
@@ -129,6 +129,9 @@ export function SignupForm(): React.ReactElement {
             disabled={pending}
           />
         </div>
+        <p className="text-body-sm text-on-surface-variant">
+          {t("valanticEmailHint")}
+        </p>
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-md">

--- a/lib/validation/auth.ts
+++ b/lib/validation/auth.ts
@@ -9,6 +9,14 @@ export const loginSchema = z.object({
 
 export type LoginInput = z.infer<typeof loginSchema>;
 
+export function isAllowedSignupEmailDomain(email: string): boolean {
+  const domain = email.split("@")[1]?.toLowerCase();
+  if (!domain) {
+    return false;
+  }
+  return domain === "valantic.com" || domain.endsWith(".valantic.com");
+}
+
 export const signupSchema = z
   .object({
     username: z.string().min(1, { message: "username" }),
@@ -30,6 +38,15 @@ export const signupSchema = z
   .refine((data) => data.winner !== data.secretWinner, {
     message: "Winner and secret winner must differ.",
     path: ["secretWinner"],
-  });
+  })
+  .refine(
+    (data) =>
+      process.env.NODE_ENV !== "production" ||
+      isAllowedSignupEmailDomain(data.email),
+    {
+      message: "Only valantic.com email addresses are allowed.",
+      path: ["email"],
+    },
+  );
 
 export type SignupInput = z.infer<typeof signupSchema>;

--- a/messages/de.json
+++ b/messages/de.json
@@ -130,6 +130,7 @@
     "loginHere": "Hier anmelden",
     "username": "Nutzername",
     "usernameNotEmailHint": "Das ist nicht deine Email-Adresse.",
+    "valanticEmailHint": "Nur valantic.com-Email-Adressen sind erlaubt.",
     "repeatPassword": "Passwort wiederholen",
     "department": "Standort",
     "selectLocation": "Standort wählen ...",

--- a/messages/en.json
+++ b/messages/en.json
@@ -130,6 +130,7 @@
     "loginHere": "Login here",
     "username": "Username",
     "usernameNotEmailHint": "This is not your email address.",
+    "valanticEmailHint": "Only valantic.com email addresses are allowed.",
     "repeatPassword": "Repeat Password",
     "department": "Department",
     "selectLocation": "Select location...",

--- a/tests/unit/validation.test.ts
+++ b/tests/unit/validation.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "vitest";
-import { loginSchema, signupSchema } from "@/lib/validation/auth";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  isAllowedSignupEmailDomain,
+  loginSchema,
+  signupSchema,
+} from "@/lib/validation/auth";
 
 describe("loginSchema", () => {
   it("accepts a valid payload", () => {
@@ -93,6 +97,64 @@ describe("signupSchema", () => {
     void _omit;
     const result = signupSchema.safeParse(rest);
     expect(result.success).toBe(false);
+  });
+});
+
+describe("isAllowedSignupEmailDomain", () => {
+  it("accepts valantic.com and its subdomains", () => {
+    expect(isAllowedSignupEmailDomain("a@valantic.com")).toBe(true);
+    expect(isAllowedSignupEmailDomain("a@cec.valantic.com")).toBe(true);
+    expect(isAllowedSignupEmailDomain("a@pim.valantic.com")).toBe(true);
+  });
+
+  it("accepts case-insensitively", () => {
+    expect(isAllowedSignupEmailDomain("a@VALANTIC.com")).toBe(true);
+    expect(isAllowedSignupEmailDomain("a@CEC.Valantic.COM")).toBe(true);
+  });
+
+  it("rejects foreign and look-alike domains", () => {
+    expect(isAllowedSignupEmailDomain("a@gmail.com")).toBe(false);
+    expect(isAllowedSignupEmailDomain("a@valantic.com.evil.com")).toBe(false);
+    expect(isAllowedSignupEmailDomain("a@evilvalantic.com")).toBe(false);
+  });
+
+  it("rejects malformed input", () => {
+    expect(isAllowedSignupEmailDomain("no-at-sign")).toBe(false);
+    expect(isAllowedSignupEmailDomain("")).toBe(false);
+    expect(isAllowedSignupEmailDomain("a@")).toBe(false);
+  });
+});
+
+describe("signupSchema email domain gate", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("rejects a non-valantic email in production", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const result = signupSchema.safeParse({
+      ...VALID_SIGNUP,
+      email: "a@gmail.com",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a valantic subdomain email in production", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const result = signupSchema.safeParse({
+      ...VALID_SIGNUP,
+      email: "a@cec.valantic.com",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts any email outside production", () => {
+    vi.stubEnv("NODE_ENV", "test");
+    const result = signupSchema.safeParse({
+      ...VALID_SIGNUP,
+      email: "a@local.dev",
+    });
+    expect(result.success).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Background

In production, only employees should be able to register, i.e. only valantic.com email addresses (including subdomains like cec.valantic.com). In development any address must still work for testing and demo seeding.

## What this changes

Registration in production only accepts emails on valantic.com or one of its subdomains; other addresses are rejected, validated on the server. Development and test environments are unaffected. The sign-up form shows a hint that only valantic.com addresses are allowed.