### PR TITLE
FE-042: consistent border radius

### DIFF
--- a/app/(app)/match/[id]/page.tsx
+++ b/app/(app)/match/[id]/page.tsx
@@ -147,7 +147,7 @@ export default async function MatchDetailPage({
           </div>
 
           {predictions.status === "offline" ? (
-            <div className="bg-surface-container-low border border-outline-variant rounded-xl p-xl text-center">
+            <div className="bg-surface-container-low border border-outline-variant rounded-lg p-xl text-center">
               <p className="text-body-lg text-on-surface mb-sm">
                 {t("predictionsOffline")}
               </p>

--- a/app/(app)/ranking/page.tsx
+++ b/app/(app)/ranking/page.tsx
@@ -81,7 +81,7 @@ export default async function RankingPage({
             </div>
           </>
         ) : (
-          <div className="bg-surface-container-low border border-outline-variant rounded-xl p-xl text-center">
+          <div className="bg-surface-container-low border border-outline-variant rounded-lg p-xl text-center">
             <p className="text-body-lg text-on-surface mb-sm">{t("offline")}</p>
             <p className="text-body-sm text-on-surface-variant">
               {t("offlineHint")}

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -38,7 +38,7 @@ export default async function LoginPage({
           </p>
         </div>
 
-        <div className="bg-surface-container border border-outline-variant p-xl shadow-2xl">
+        <div className="bg-surface-container border border-outline-variant rounded-lg p-xl shadow-2xl">
           {registered ? (
             <p
               aria-live="polite"

--- a/components/dashboard/Flag.tsx
+++ b/components/dashboard/Flag.tsx
@@ -25,7 +25,7 @@ export function Flag({
     <img
       src={`/svg/${mapped}.svg`}
       alt={name}
-      className={className ?? "w-8 h-5 object-cover rounded-xs"}
+      className={className ?? "w-8 h-5 object-cover rounded-sm"}
     />
   );
 }

--- a/components/match/PredictionsTable.tsx
+++ b/components/match/PredictionsTable.tsx
@@ -80,7 +80,7 @@ export function PredictionsTable({
   const tCommon = useTranslations("Common");
   if (rows.length === 0) {
     return (
-      <div className="bg-surface-container-low border border-outline-variant rounded-xl p-xl text-center text-body-sm text-on-surface-variant">
+      <div className="bg-surface-container-low border border-outline-variant rounded-lg p-xl text-center text-body-sm text-on-surface-variant">
         {emptyMessage}
       </div>
     );

--- a/components/profile/PredictionHistory.tsx
+++ b/components/profile/PredictionHistory.tsx
@@ -50,7 +50,7 @@ export function PredictionHistory({
       </div>
 
       {status === "offline" ? (
-        <div className="bg-surface-container-low border border-outline-variant rounded-xl p-xl text-center">
+        <div className="bg-surface-container-low border border-outline-variant rounded-lg p-xl text-center">
           <p className="text-body-lg text-on-surface mb-sm">
             {t("serviceOffline")}
           </p>
@@ -59,7 +59,7 @@ export function PredictionHistory({
           </p>
         </div>
       ) : tips.length === 0 ? (
-        <div className="bg-surface-container-low border border-outline-variant rounded-xl p-xl text-center text-body-sm text-on-surface-variant">
+        <div className="bg-surface-container-low border border-outline-variant rounded-lg p-xl text-center text-body-sm text-on-surface-variant">
           {t("noPredictions")}
         </div>
       ) : (

--- a/components/profile/WinnerCards.tsx
+++ b/components/profile/WinnerCards.tsx
@@ -36,7 +36,7 @@ function WinnerCard({
           <Flag
             tla={tla}
             name={tla}
-            className="w-10 h-auto rounded-xs"
+            className="w-10 h-auto rounded-sm"
           />
           <span className="text-headline-md font-bold uppercase tracking-widest">
             {tla}

--- a/components/ranking/RankingTable.tsx
+++ b/components/ranking/RankingTable.tsx
@@ -33,14 +33,14 @@ export function RankingTable({
   const tCommon = useTranslations("Common");
   if (users.length === 0) {
     return (
-      <div className="bg-surface-container-low border border-outline-variant rounded-xl p-xl text-center text-body-sm text-on-surface-variant">
+      <div className="bg-surface-container-low border border-outline-variant rounded-lg p-xl text-center text-body-sm text-on-surface-variant">
         {emptyMessage ?? t("noUsersYet")}
       </div>
     );
   }
 
   return (
-    <div className="bg-surface-container-low border border-outline-variant rounded-xl overflow-hidden shadow-2xl">
+    <div className="bg-surface-container-low border border-outline-variant rounded-lg overflow-hidden shadow-2xl">
       <div className="hidden md:block overflow-x-auto">
         <table className="w-full text-left border-collapse">
           <thead>

--- a/components/ranking/ScoringInfobox.tsx
+++ b/components/ranking/ScoringInfobox.tsx
@@ -19,7 +19,7 @@ const ROWS: {
 export function ScoringInfobox(): React.ReactElement {
   const t = useTranslations("Scoring");
   return (
-    <aside className="bg-surface-container border border-outline-variant p-lg rounded-xl">
+    <aside className="bg-surface-container border border-outline-variant p-lg rounded-lg">
       <div className="flex items-center gap-sm mb-md text-primary">
         <span className="material-symbols-outlined">info</span>
         <h3 className="text-label-caps uppercase">{t("title")}</h3>


### PR DESCRIPTION
## Background

Corner rounding was inconsistent across pages — some cards were rounded, others (notably the login card) were sharp, and card containers mixed several radius sizes.

## What this changes

Card and panel containers now share one rounded style, the previously sharp login card is rounded like the others, and tiny tag radii are consolidated. Pills, avatars and fully-round elements are unchanged. No layout, colour or spacing changes — only the corner radius.