### PR TITLE
FE-032: profile settings page (change password, logout, avatar slot)

### DIFF
--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -1,0 +1,139 @@
+import { redirect } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+import { getCurrentSession } from "@/lib/session";
+import { TopAppBar } from "@/components/dashboard/TopAppBar";
+import { BottomNav } from "@/components/dashboard/BottomNav";
+import { PasswordChangeForm } from "@/components/settings/PasswordChangeForm";
+
+function LogoutButton({ label }: { label: string }): React.ReactElement {
+  return (
+    <form action="/api/auth/logout" method="POST">
+      <button
+        type="submit"
+        className="text-error bg-error/10 hover:bg-error/20 px-4 py-2 rounded-lg text-label-caps uppercase font-bold transition-colors active:scale-95"
+      >
+        {label}
+      </button>
+    </form>
+  );
+}
+
+export default async function SettingsPage(): Promise<React.ReactElement> {
+  const { user } = await getCurrentSession();
+  if (!user) {
+    redirect("/login");
+  }
+  const t = await getTranslations("Settings");
+
+  return (
+    <>
+      <TopAppBar active="settings" />
+      {/* Mobile header carries logout because BottomNav has none. */}
+      <header className="flex md:hidden items-center justify-between px-margin-mobile h-16 border-b border-outline-variant bg-background">
+        <span className="text-headline-md font-black text-on-background tracking-tighter">
+          {t("title")}
+        </span>
+        <form action="/api/auth/logout" method="POST">
+          <button
+            type="submit"
+            aria-label={t("logout")}
+            className="material-symbols-outlined text-primary"
+          >
+            logout
+          </button>
+        </form>
+      </header>
+
+      <main className="pt-4 md:pt-24 pb-24 md:pb-8 px-margin-mobile md:px-margin-desktop max-w-(--container-max-desktop) mx-auto">
+        <div className="mb-lg">
+          <h1 className="text-headline-lg font-bold mb-xs">{t("title")}</h1>
+          <p className="text-body-sm text-on-surface-variant">{t("subtitle")}</p>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-12 gap-lg">
+          <div className="lg:col-span-5 space-y-lg">
+            <section className="bg-surface-container rounded-lg p-lg border border-outline-variant">
+              <h2 className="text-label-caps uppercase tracking-widest text-primary mb-lg">
+                {t("identity")}
+              </h2>
+              <div className="flex flex-col items-center mb-xl">
+                <div className="relative">
+                  <div className="h-32 w-32 rounded-full border-4 border-outline-variant overflow-hidden bg-surface-container-highest flex items-center justify-center">
+                    <span className="material-symbols-outlined text-[64px] text-on-surface-variant">
+                      person
+                    </span>
+                  </div>
+                  <span
+                    aria-hidden="true"
+                    className="absolute bottom-0 right-0 bg-surface-container-highest text-on-surface-variant p-2 rounded-full border-2 border-background"
+                  >
+                    <span className="material-symbols-outlined text-[20px]">
+                      photo_camera
+                    </span>
+                  </span>
+                </div>
+                <button
+                  type="button"
+                  disabled
+                  title={t("changePhotoSoon")}
+                  className="mt-md text-label-caps uppercase text-on-surface-variant opacity-50 cursor-not-allowed"
+                >
+                  {t("changePhoto")}
+                </button>
+                <p className="mt-xs text-[11px] text-on-surface-variant">
+                  {t("changePhotoSoon")}
+                </p>
+              </div>
+              <div className="space-y-md">
+                <div>
+                  <label className="block text-label-caps uppercase text-on-surface-variant mb-xs">
+                    {t("username")}
+                  </label>
+                  <div className="text-body-lg text-on-surface py-1">
+                    {user.username}
+                  </div>
+                </div>
+                <div>
+                  <label className="block text-label-caps uppercase text-on-surface-variant mb-xs">
+                    {t("email")}
+                  </label>
+                  <div className="text-body-lg text-on-surface py-1">
+                    {user.email}
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            <section className="bg-surface-container rounded-lg p-lg border border-outline-variant">
+              <h2 className="text-label-caps uppercase tracking-widest text-on-surface-variant mb-md">
+                {t("session")}
+              </h2>
+              <div className="flex items-center justify-between gap-md p-md bg-error-container/10 border border-error-container/30 rounded-lg">
+                <div>
+                  <p className="text-body-sm font-bold text-error">
+                    {t("logoutHeading")}
+                  </p>
+                  <p className="text-[11px] text-on-surface-variant">
+                    {t("logoutHint")}
+                  </p>
+                </div>
+                <LogoutButton label={t("logout")} />
+              </div>
+            </section>
+          </div>
+
+          <div className="lg:col-span-7">
+            <section className="bg-surface-container rounded-lg p-lg border border-outline-variant h-full">
+              <h2 className="text-label-caps uppercase tracking-widest text-primary mb-lg">
+                {t("security")}
+              </h2>
+              <PasswordChangeForm />
+            </section>
+          </div>
+        </div>
+      </main>
+
+      <BottomNav active="profile" />
+    </>
+  );
+}

--- a/app/api/user/password/route.ts
+++ b/app/api/user/password/route.ts
@@ -1,0 +1,118 @@
+import { Argon2id } from "oslo/password";
+import { getCurrentSession } from "@/lib/session";
+import { getUserById, updateUserPassword } from "@/lib/user";
+import { changePasswordSchema } from "@/lib/validation/password";
+import { checkRateLimit, getClientIp } from "@/lib/rate-limit";
+
+const argon2id = new Argon2id({
+  memorySize: 19456,
+  iterations: 2,
+  tagLength: 32,
+  parallelism: 1,
+});
+
+function jsonError(message: string, status: number): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+async function readBody(request: Request): Promise<{
+  currentPassword: unknown;
+  newPassword: unknown;
+  confirmPassword: unknown;
+} | null> {
+  const contentType = request.headers.get("content-type") ?? "";
+  try {
+    if (contentType.includes("application/json")) {
+      const body = (await request.json()) as Record<string, unknown>;
+      return {
+        currentPassword: body.currentPassword,
+        newPassword: body.newPassword,
+        confirmPassword: body.confirmPassword,
+      };
+    }
+    const formData = await request.formData();
+    return {
+      currentPassword: formData.get("currentPassword"),
+      newPassword: formData.get("newPassword"),
+      confirmPassword: formData.get("confirmPassword"),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const { user: sessionUser } = await getCurrentSession();
+  if (!sessionUser) {
+    return jsonError("Not logged in", 401);
+  }
+
+  const userId = Number(sessionUser.id);
+  if (!Number.isFinite(userId) || userId <= 0) {
+    return jsonError("Not logged in", 401);
+  }
+
+  const ip = getClientIp(request.headers);
+  const limit = checkRateLimit(ip, "password");
+  if (!limit.ok) {
+    return new Response(
+      JSON.stringify({ error: "Too many requests, try again later." }),
+      {
+        status: 429,
+        headers: {
+          "Content-Type": "application/json",
+          ...(limit.retryAfter
+            ? { "Retry-After": String(limit.retryAfter) }
+            : {}),
+        },
+      },
+    );
+  }
+
+  const raw = await readBody(request);
+  if (!raw) {
+    return jsonError("Invalid request body", 400);
+  }
+
+  const parsed = changePasswordSchema.safeParse(raw);
+  if (!parsed.success) {
+    const first = parsed.error.issues[0];
+    const message = first?.message ?? "Invalid input";
+    return jsonError(message, 400);
+  }
+
+  const { currentPassword, newPassword } = parsed.data;
+
+  const existing = await getUserById(userId);
+  if (!existing) {
+    return jsonError("Not logged in", 401);
+  }
+
+  const valid = await argon2id.verify(existing.password, currentPassword);
+  if (!valid) {
+    return jsonError("Current password is incorrect.", 400);
+  }
+
+  try {
+    const hash = await argon2id.hash(newPassword);
+    await updateUserPassword(userId, hash);
+  } catch (error) {
+    console.error("[password] update failed", error);
+    return jsonError("Failed to update password", 500);
+  }
+
+  return new Response(JSON.stringify({ success: true }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export function GET(): Response {
+  return new Response(null, {
+    status: 405,
+    headers: { Allow: "POST" },
+  });
+}

--- a/components/dashboard/BottomNav.tsx
+++ b/components/dashboard/BottomNav.tsx
@@ -2,13 +2,14 @@ import Link from "next/link";
 import { useTranslations } from "next-intl";
 
 interface BottomNavProps {
-  active: "dashboard" | "ranking" | "profile";
+  active: "dashboard" | "ranking" | "profile" | "settings";
 }
 
 const ITEMS = [
   { id: "dashboard", icon: "dashboard", href: "/" },
   { id: "ranking", icon: "leaderboard", href: "/ranking" },
   { id: "profile", icon: "person", href: "/profile" },
+  { id: "settings", icon: "settings", href: "/settings" },
 ] as const;
 
 export function BottomNav({ active }: BottomNavProps): React.ReactElement {

--- a/components/dashboard/TopAppBar.tsx
+++ b/components/dashboard/TopAppBar.tsx
@@ -3,7 +3,7 @@ import { useTranslations } from "next-intl";
 import { LocaleSwitcher } from "@/components/LocaleSwitcher";
 
 interface TopAppBarProps {
-  active: "dashboard" | "ranking" | "profile";
+  active: "dashboard" | "ranking" | "profile" | "settings";
 }
 
 const LINKS = [
@@ -39,6 +39,17 @@ export function TopAppBar({ active }: TopAppBarProps): React.ReactElement {
           })}
         </nav>
         <div className="flex items-center gap-lg">
+          <Link
+            href="/settings"
+            aria-label={t("settings")}
+            className={`material-symbols-outlined transition-colors ${
+              active === "settings"
+                ? "text-primary"
+                : "text-on-surface-variant hover:text-primary"
+            }`}
+          >
+            settings
+          </Link>
           <LocaleSwitcher />
           <form action="/api/auth/logout" method="POST">
             <button

--- a/components/settings/PasswordChangeForm.tsx
+++ b/components/settings/PasswordChangeForm.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useState, type FormEvent } from "react";
+
+export function PasswordChangeForm(): React.ReactElement {
+  const t = useTranslations("Settings");
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+  const [pending, setPending] = useState(false);
+
+  async function onSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+    setError(null);
+    setSuccess(false);
+
+    const form = event.currentTarget;
+    const data = new FormData(form);
+    const newPassword = String(data.get("newPassword") ?? "");
+    const confirmPassword = String(data.get("confirmPassword") ?? "");
+
+    if (newPassword.length < 8) {
+      setError(t("newPasswordTooShort"));
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setError(t("passwordsDoNotMatch"));
+      return;
+    }
+
+    setPending(true);
+    try {
+      const res = await fetch("/api/user/password", {
+        method: "POST",
+        body: data,
+        headers: { Accept: "application/json" },
+      });
+      if (res.ok) {
+        setSuccess(true);
+        form.reset();
+        return;
+      }
+      let message = t("updateFailed");
+      try {
+        const body: unknown = await res.json();
+        if (
+          body &&
+          typeof body === "object" &&
+          "error" in body &&
+          typeof (body as { error: unknown }).error === "string"
+        ) {
+          message = (body as { error: string }).error;
+        }
+      } catch {
+        // ignore JSON parse error, fall back to default
+      }
+      setError(message);
+    } catch {
+      setError(t("networkError"));
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <form className="space-y-lg" onSubmit={onSubmit} noValidate>
+      <div className="grid grid-cols-1 gap-md">
+        <div className="space-y-sm">
+          <label
+            className="block text-label-caps uppercase text-on-surface-variant"
+            htmlFor="currentPassword"
+          >
+            {t("currentPassword")}
+          </label>
+          <input
+            className="w-full bg-surface-container-highest border border-outline-variant text-on-surface px-md py-3 rounded-lg focus:border-primary focus:outline-none transition-all"
+            id="currentPassword"
+            name="currentPassword"
+            type="password"
+            placeholder="••••••••"
+            required
+            autoComplete="current-password"
+            disabled={pending}
+          />
+        </div>
+        <hr className="border-outline-variant my-sm" />
+        <div className="space-y-sm">
+          <label
+            className="block text-label-caps uppercase text-on-surface-variant"
+            htmlFor="newPassword"
+          >
+            {t("newPassword")}
+          </label>
+          <input
+            className="w-full bg-surface-container-highest border border-outline-variant text-on-surface px-md py-3 rounded-lg focus:border-primary focus:outline-none transition-all"
+            id="newPassword"
+            name="newPassword"
+            type="password"
+            placeholder={t("newPasswordPlaceholder")}
+            required
+            minLength={8}
+            autoComplete="new-password"
+            disabled={pending}
+          />
+        </div>
+        <div className="space-y-sm">
+          <label
+            className="block text-label-caps uppercase text-on-surface-variant"
+            htmlFor="confirmPassword"
+          >
+            {t("confirmPassword")}
+          </label>
+          <input
+            className="w-full bg-surface-container-highest border border-outline-variant text-on-surface px-md py-3 rounded-lg focus:border-primary focus:outline-none transition-all"
+            id="confirmPassword"
+            name="confirmPassword"
+            type="password"
+            placeholder={t("confirmPasswordPlaceholder")}
+            required
+            minLength={8}
+            autoComplete="new-password"
+            disabled={pending}
+          />
+        </div>
+      </div>
+
+      {error ? (
+        <p
+          aria-live="polite"
+          className="text-body-sm text-error border border-error/40 bg-error-container/20 px-md py-sm rounded-lg"
+        >
+          {error}
+        </p>
+      ) : null}
+      {success ? (
+        <p
+          aria-live="polite"
+          className="text-body-sm text-secondary border border-secondary/40 bg-secondary/10 px-md py-sm rounded-lg"
+        >
+          {t("updateSuccess")}
+        </p>
+      ) : null}
+
+      <div className="pt-lg">
+        <button
+          className="w-full bg-primary-container text-on-primary-container font-bold uppercase tracking-tight py-4 rounded-lg hover:brightness-110 active:scale-[0.98] transition-all disabled:opacity-60"
+          type="submit"
+          disabled={pending}
+        >
+          {pending ? (
+            <span className="material-symbols-outlined animate-spin text-[20px] align-middle">
+              progress_activity
+            </span>
+          ) : (
+            t("updatePassword")
+          )}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/lib/user.ts
+++ b/lib/user.ts
@@ -39,3 +39,10 @@ export async function updateUserWinners(
     .set({ winner, secretWinner })
     .where(eq(user.id, userId));
 }
+
+export async function updateUserPassword(
+  userId: number,
+  password: string,
+): Promise<void> {
+  await db.update(user).set({ password }).where(eq(user.id, userId));
+}

--- a/lib/validation/password.ts
+++ b/lib/validation/password.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const changePasswordSchema = z
+  .object({
+    currentPassword: z.string().min(1, { message: "currentPasswordRequired" }),
+    newPassword: z.string().min(8, { message: "newPasswordTooShort" }),
+    confirmPassword: z.string().min(1, { message: "confirmPasswordRequired" }),
+  })
+  .refine((data) => data.newPassword === data.confirmPassword, {
+    message: "passwordsDoNotMatch",
+    path: ["confirmPassword"],
+  });
+
+export type ChangePasswordInput = z.infer<typeof changePasswordSchema>;

--- a/messages/de.json
+++ b/messages/de.json
@@ -4,7 +4,8 @@
     "dashboard": "Dashboard",
     "ranking": "Rangliste",
     "profile": "Profil",
-    "logout": "Abmelden"
+    "logout": "Abmelden",
+    "settings": "Einstellungen"
   },
   "Common": {
     "you": "DU",
@@ -142,5 +143,30 @@
     "invalidPassword": "Ungültiges Passwort",
     "winnersMustDiffer": "Sieger und Geheimsieger müssen unterschiedlich sein.",
     "couldNotCreateAccount": "Konto konnte nicht erstellt werden."
+  },
+  "Settings": {
+    "title": "Profil-Einstellungen",
+    "subtitle": "Verwalte deine Konto-Identität und Sicherheitseinstellungen.",
+    "identity": "Identität",
+    "security": "Sicherheit & Zugangsdaten",
+    "session": "Sitzungsverwaltung",
+    "username": "Benutzername",
+    "email": "E-Mail-Adresse",
+    "changePhoto": "Foto ändern",
+    "changePhotoSoon": "Foto-Upload folgt in Kürze.",
+    "currentPassword": "Aktuelles Passwort",
+    "newPassword": "Neues Passwort",
+    "newPasswordPlaceholder": "Mindestens 8 Zeichen",
+    "confirmPassword": "Neues Passwort bestätigen",
+    "confirmPasswordPlaceholder": "Neues Passwort bestätigen",
+    "updatePassword": "Passwort aktualisieren",
+    "updateSuccess": "Passwort erfolgreich aktualisiert.",
+    "updateFailed": "Passwort konnte nicht aktualisiert werden.",
+    "newPasswordTooShort": "Das neue Passwort muss mindestens 8 Zeichen lang sein.",
+    "passwordsDoNotMatch": "Passwörter stimmen nicht überein.",
+    "networkError": "Netzwerkfehler. Bitte erneut versuchen.",
+    "logout": "Abmelden",
+    "logoutHeading": "Von diesem Gerät abmelden",
+    "logoutHint": "Deine aktuelle Sitzung wird sofort beendet."
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -4,7 +4,8 @@
     "dashboard": "Dashboard",
     "ranking": "Ranking",
     "profile": "Profile",
-    "logout": "Logout"
+    "logout": "Logout",
+    "settings": "Settings"
   },
   "Common": {
     "you": "YOU",
@@ -142,5 +143,30 @@
     "invalidPassword": "Invalid password",
     "winnersMustDiffer": "Winner and secret winner must differ.",
     "couldNotCreateAccount": "Could not create account."
+  },
+  "Settings": {
+    "title": "Profile Settings",
+    "subtitle": "Manage your account identity and security preferences.",
+    "identity": "Identity",
+    "security": "Security & Credentials",
+    "session": "Session Management",
+    "username": "Username",
+    "email": "Email Address",
+    "changePhoto": "Change photo",
+    "changePhotoSoon": "Photo upload coming soon.",
+    "currentPassword": "Current Password",
+    "newPassword": "New Password",
+    "newPasswordPlaceholder": "Minimum 8 characters",
+    "confirmPassword": "Confirm New Password",
+    "confirmPasswordPlaceholder": "Confirm your new password",
+    "updatePassword": "Update Password",
+    "updateSuccess": "Password updated successfully.",
+    "updateFailed": "Could not update password.",
+    "newPasswordTooShort": "New password must be at least 8 characters.",
+    "passwordsDoNotMatch": "Passwords do not match.",
+    "networkError": "Network error. Try again.",
+    "logout": "Logout",
+    "logoutHeading": "Logout from this device",
+    "logoutHint": "Your current session will be terminated immediately."
   }
 }

--- a/tests/unit/password-validation.test.ts
+++ b/tests/unit/password-validation.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { changePasswordSchema } from "@/lib/validation/password";
+
+describe("changePasswordSchema", () => {
+  it("accepts a valid payload where new equals confirm", () => {
+    const result = changePasswordSchema.safeParse({
+      currentPassword: "oldpass1",
+      newPassword: "newpass123",
+      confirmPassword: "newpass123",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects when new password is shorter than 8 characters", () => {
+    const result = changePasswordSchema.safeParse({
+      currentPassword: "oldpass1",
+      newPassword: "short",
+      confirmPassword: "short",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) =>
+        i.path.includes("newPassword"),
+      );
+      expect(issue?.message).toBe("newPasswordTooShort");
+    }
+  });
+
+  it("rejects when confirm does not equal new password", () => {
+    const result = changePasswordSchema.safeParse({
+      currentPassword: "oldpass1",
+      newPassword: "newpass123",
+      confirmPassword: "different123",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) =>
+        i.path.includes("confirmPassword"),
+      );
+      expect(issue?.message).toBe("passwordsDoNotMatch");
+    }
+  });
+
+  it("rejects an empty current password", () => {
+    const result = changePasswordSchema.safeParse({
+      currentPassword: "",
+      newPassword: "newpass123",
+      confirmPassword: "newpass123",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects when current password is missing", () => {
+    const result = changePasswordSchema.safeParse({
+      newPassword: "newpass123",
+      confirmPassword: "newpass123",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects when a field is not a string", () => {
+    const result = changePasswordSchema.safeParse({
+      currentPassword: "oldpass1",
+      newPassword: 12345678,
+      confirmPassword: 12345678,
+    });
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Background

There was no place to change the password, and the mobile navigation had no way to log out. The design also calls for a profile settings screen.

## What this changes

A new settings page (/settings) lets the signed-in user change their password and log out — the logout is reachable on mobile, where the bottom navigation had none. It shows the account's username and email and an avatar slot (photo upload comes later). Reachable from the navigation on both desktop and mobile.