### PR TITLE
FE-034: localize country names and dates

### DIFF
--- a/components/dashboard/LiveBlock.tsx
+++ b/components/dashboard/LiveBlock.tsx
@@ -4,6 +4,7 @@ import type { MatchRow } from "@/lib/match";
 import type { TipRow } from "@/lib/tip";
 import { Flag } from "@/components/dashboard/Flag";
 import { computeScore } from "@/lib/score";
+import { resolveCountryName } from "@/lib/country";
 import { scoreColor, scoreToneClass } from "@/lib/scoring";
 
 export function LiveBlock({
@@ -14,6 +15,7 @@ export function LiveBlock({
   tipsByMatchId: Map<number, TipRow>;
 }): React.ReactElement | null {
   const t = useTranslations("Dashboard");
+  const tc = useTranslations("Countries");
   const rows = matches
     .map((m) => {
       const tip = tipsByMatchId.get(m.id);
@@ -56,7 +58,7 @@ export function LiveBlock({
                     className="w-12 h-8 object-cover rounded-sm shadow-md"
                   />
                   <span className="text-label-caps uppercase">
-                    {match.homeTeam.name}
+                    {resolveCountryName(match.homeTeam.tla, match.homeTeam.name, tc)}
                   </span>
                 </div>
                 <div className="flex flex-col items-center gap-xs">
@@ -76,7 +78,7 @@ export function LiveBlock({
                     className="w-12 h-8 object-cover rounded-sm shadow-md"
                   />
                   <span className="text-label-caps uppercase">
-                    {match.awayTeam.name}
+                    {resolveCountryName(match.awayTeam.tla, match.awayTeam.name, tc)}
                   </span>
                 </div>
               </div>

--- a/components/dashboard/MatchRow.tsx
+++ b/components/dashboard/MatchRow.tsx
@@ -1,3 +1,4 @@
+import { useLocale } from "next-intl";
 import type { MatchRow as MatchRowData } from "@/lib/match";
 import type { TipRow } from "@/lib/tip";
 import { Flag } from "@/components/dashboard/Flag";
@@ -10,6 +11,7 @@ interface MatchRowProps {
 }
 
 export function MatchRow({ match, tip }: MatchRowProps): React.ReactElement {
+  const locale = useLocale();
   const now = new Date();
   const disabled =
     match.utcDate.getTime() < now.getTime() ||
@@ -36,7 +38,7 @@ export function MatchRow({ match, tip }: MatchRowProps): React.ReactElement {
             </span>
           </div>
           <div className="text-data-mono font-mono text-on-surface-variant">
-            {extractTime(match.utcDate)}
+            {extractTime(match.utcDate, locale)}
           </div>
           <div className="flex items-center gap-md w-32 justify-end">
             <span className="text-body-lg font-bold">

--- a/components/dashboard/UpcomingList.tsx
+++ b/components/dashboard/UpcomingList.tsx
@@ -1,4 +1,4 @@
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import type { MatchRow as MatchRowData } from "@/lib/match";
 import type { TipRow } from "@/lib/tip";
 import { MatchRow } from "@/components/dashboard/MatchRow";
@@ -15,6 +15,7 @@ export function UpcomingList({
   tipsByMatchId,
 }: UpcomingListProps): React.ReactElement {
   const t = useTranslations("Dashboard");
+  const locale = useLocale();
   if (matches.length === 0) {
     return (
       <section>
@@ -40,7 +41,7 @@ export function UpcomingList({
         {dateKeys.map((key) => {
           const dayMatches = grouped[key];
           if (!dayMatches || dayMatches.length === 0) return null;
-          const heading = formatDate(dayMatches[0]!.utcDate);
+          const heading = formatDate(dayMatches[0]!.utcDate, locale);
           return (
             <div key={key} className="space-y-sm">
               <div className="text-label-caps uppercase text-on-surface-variant/60 px-xs">

--- a/components/match/MatchHeader.tsx
+++ b/components/match/MatchHeader.tsx
@@ -1,6 +1,7 @@
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import type { MatchRow } from "@/lib/match";
 import { Flag } from "@/components/dashboard/Flag";
+import { resolveCountryName } from "@/lib/country";
 import { extractTime, formatDate } from "@/lib/format";
 
 interface MatchHeaderProps {
@@ -81,6 +82,7 @@ function TeamBlock({
   tla: string;
   name: string;
 }): React.ReactElement {
+  const tc = useTranslations("Countries");
   return (
     <div className="flex flex-col items-center flex-1 min-w-0 gap-sm">
       <Flag
@@ -89,7 +91,7 @@ function TeamBlock({
         className="w-16 h-10 md:w-20 md:h-12 object-cover rounded-sm shadow-md border border-outline-variant"
       />
       <h2 className="text-body-lg md:text-headline-md uppercase text-center font-bold truncate w-full">
-        {name}
+        {resolveCountryName(tla, name, tc)}
       </h2>
     </div>
   );
@@ -144,9 +146,10 @@ function StatusSublabel({
   kickoff: Date;
 }): React.ReactElement {
   const t = useTranslations("Match");
+  const locale = useLocale();
   const kickoffLine = (
     <div className="text-label-caps uppercase text-on-surface-variant mt-xs font-mono">
-      {formatDate(kickoff)} &middot; {extractTime(kickoff)}
+      {formatDate(kickoff, locale)} &middot; {extractTime(kickoff, locale)}
     </div>
   );
 

--- a/components/profile/PredictionHistory.tsx
+++ b/components/profile/PredictionHistory.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import type { RatingMatchInfo } from "@/lib/rating";
 import { formatDate } from "@/lib/format";
 import { scoreColor, scoreToneClass } from "@/lib/scoring";
@@ -38,6 +38,7 @@ export function PredictionHistory({
   tips,
 }: PredictionHistoryProps): React.ReactElement {
   const t = useTranslations("Profile");
+  const locale = useLocale();
   return (
     <section className="mt-xl">
       <div className="flex justify-between items-end border-b border-outline-variant pb-md mb-lg">
@@ -93,7 +94,7 @@ export function PredictionHistory({
                             {tip.team1.tla} vs {tip.team2.tla}
                           </span>
                           <span className="text-label-caps uppercase text-on-surface-variant font-mono">
-                            {formatDate(matchDate)}
+                            {formatDate(matchDate, locale)}
                           </span>
                         </Link>
                       </td>
@@ -138,7 +139,7 @@ export function PredictionHistory({
                           {tip.team1.tla} vs {tip.team2.tla}
                         </span>
                         <span className="text-label-caps uppercase text-on-surface-variant font-mono">
-                          {formatDate(matchDate)}
+                          {formatDate(matchDate, locale)}
                         </span>
                       </div>
                       <span

--- a/lib/country.ts
+++ b/lib/country.ts
@@ -1,0 +1,12 @@
+interface CountryTranslator {
+  has: (key: string) => boolean;
+  (key: string): string;
+}
+
+export function resolveCountryName(
+  tla: string,
+  fallback: string,
+  t: CountryTranslator,
+): string {
+  return t.has(tla) ? t(tla) : fallback;
+}

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -1,6 +1,6 @@
-export function formatDate(ts: Date | number): string {
+export function formatDate(ts: Date | number, locale: string): string {
   const d = ts instanceof Date ? ts : new Date(ts);
-  return d.toLocaleDateString("de-DE", {
+  return d.toLocaleDateString(locale, {
     weekday: "long",
     day: "numeric",
     month: "long",
@@ -16,9 +16,9 @@ export function formatDateKey(ts: Date | number): string {
   return `${yyyy}-${mm}-${dd}`;
 }
 
-export function extractTime(ts: Date | number): string {
+export function extractTime(ts: Date | number, locale: string): string {
   const d = ts instanceof Date ? ts : new Date(ts);
-  return d.toLocaleTimeString("de-DE", {
+  return d.toLocaleTimeString(locale, {
     hour: "2-digit",
     minute: "2-digit",
   });

--- a/messages/de.json
+++ b/messages/de.json
@@ -168,5 +168,16 @@
     "logout": "Abmelden",
     "logoutHeading": "Von diesem Gerät abmelden",
     "logoutHint": "Deine aktuelle Sitzung wird sofort beendet."
+  },
+  "Countries": {
+    "GER": "Deutschland",
+    "ESP": "Spanien",
+    "FRA": "Frankreich",
+    "ITA": "Italien",
+    "POR": "Portugal",
+    "ENG": "England",
+    "NED": "Niederlande",
+    "POL": "Polen",
+    "CRO": "Kroatien"
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -168,5 +168,16 @@
     "logout": "Logout",
     "logoutHeading": "Logout from this device",
     "logoutHint": "Your current session will be terminated immediately."
+  },
+  "Countries": {
+    "GER": "Germany",
+    "ESP": "Spain",
+    "FRA": "France",
+    "ITA": "Italy",
+    "POR": "Portugal",
+    "ENG": "England",
+    "NED": "Netherlands",
+    "POL": "Poland",
+    "CRO": "Croatia"
   }
 }

--- a/tests/unit/country.test.ts
+++ b/tests/unit/country.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { resolveCountryName } from "@/lib/country";
+
+function makeTranslator(catalog: Record<string, string>) {
+  const t = (key: string): string => catalog[key] ?? key;
+  return Object.assign(t, {
+    has: (key: string): boolean => key in catalog,
+  });
+}
+
+describe("resolveCountryName", () => {
+  it("returns the localized name when the TLA is mapped", () => {
+    const t = makeTranslator({ GER: "Deutschland" });
+    expect(resolveCountryName("GER", "Germany", t)).toBe("Deutschland");
+  });
+
+  it("falls back to the stored name when the TLA is unmapped", () => {
+    const t = makeTranslator({ GER: "Deutschland" });
+    expect(resolveCountryName("XYZ", "Atlantis", t)).toBe("Atlantis");
+  });
+});

--- a/tests/unit/format.test.ts
+++ b/tests/unit/format.test.ts
@@ -9,11 +9,16 @@ import {
 describe("formatDate", () => {
   it("formats a German locale long date string", () => {
     const date = new Date(2022, 11, 31);
-    expect(formatDate(date.getTime())).toBe("Samstag, 31. Dezember 2022");
+    expect(formatDate(date.getTime(), "de")).toBe("Samstag, 31. Dezember 2022");
+  });
+
+  it("formats an English locale long date string", () => {
+    const date = new Date(2022, 11, 31);
+    expect(formatDate(date.getTime(), "en")).toBe("Saturday, December 31, 2022");
   });
 
   it("accepts a Date object directly", () => {
-    expect(formatDate(new Date(2022, 11, 31))).toBe(
+    expect(formatDate(new Date(2022, 11, 31), "de")).toBe(
       "Samstag, 31. Dezember 2022",
     );
   });
@@ -27,7 +32,11 @@ describe("formatDateKey", () => {
 
 describe("extractTime", () => {
   it("returns the German locale HH:MM string", () => {
-    expect(extractTime(new Date(2022, 11, 31, 13, 45))).toBe("13:45");
+    expect(extractTime(new Date(2022, 11, 31, 13, 45), "de")).toBe("13:45");
+  });
+
+  it("returns the English locale 12-hour string", () => {
+    expect(extractTime(new Date(2022, 11, 31, 13, 45), "en")).toBe("01:45 PM");
   });
 });
 


### PR DESCRIPTION
## Background

After the bilingual rollout, two dynamic things stayed German-only: the full country names shown for matches, and the date/time formatting (weekday and month names).

## What this changes

Full country names now appear in the selected language (the short code stays the same), and dates and times follow the selected language. An unmapped country safely falls back to its stored name.