### PR TITLE
FE-052: match header team names readable on mobile

### DIFF
--- a/components/match/MatchHeader.tsx
+++ b/components/match/MatchHeader.tsx
@@ -91,7 +91,10 @@ function TeamBlock({
         className="w-16 h-10 md:w-20 md:h-12 object-cover rounded-sm shadow-md border border-outline-variant"
       />
       <h2 className="text-body-lg md:text-headline-md uppercase text-center font-bold truncate w-full">
-        {resolveCountryName(tla, name, tc)}
+        <span className="md:hidden">{tla}</span>
+        <span className="hidden md:inline">
+          {resolveCountryName(tla, name, tc)}
+        </span>
       </h2>
     </div>
   );


### PR DESCRIPTION
## Background

On the match detail header, mobile screens truncated the localized team names to a single letter ("F…" / "D…"), making the teams unreadable.

## What this changes

On mobile the header shows the short team code (e.g. FRA / GER); from the medium breakpoint up it shows the full localized country name as before.