### PR TITLE
XR-003: rework scoring scheme

### DIFF
--- a/components/profile/PredictionHistory.tsx
+++ b/components/profile/PredictionHistory.tsx
@@ -13,9 +13,9 @@ interface PredictionHistoryProps {
 }
 
 function clampPerMatchPoints(score: number): number {
-  if (score === 4) return 4;
+  if (score === 5) return 5;
+  if (score === 3) return 3;
   if (score === 2) return 2;
-  if (score === 1) return 1;
   return 0;
 }
 

--- a/components/ranking/ScoringInfobox.tsx
+++ b/components/ranking/ScoringInfobox.tsx
@@ -1,17 +1,25 @@
 import { useTranslations } from "next-intl";
 
 const ROWS: {
-  labelKey: "exactScore" | "goalDifference" | "correctOutcome" | "tournamentWinner" | "secretWinner";
+  labelKey:
+    | "exactScore"
+    | "goalDifference"
+    | "correctOutcome"
+    | "drawCorrect"
+    | "tournamentWinner"
+    | "secretWinner";
   valueKey:
     | "exactScoreValue"
     | "goalDifferenceValue"
     | "correctOutcomeValue"
+    | "drawCorrectValue"
     | "tournamentWinnerValue"
     | "secretWinnerValue";
 }[] = [
   { labelKey: "exactScore", valueKey: "exactScoreValue" },
   { labelKey: "goalDifference", valueKey: "goalDifferenceValue" },
   { labelKey: "correctOutcome", valueKey: "correctOutcomeValue" },
+  { labelKey: "drawCorrect", valueKey: "drawCorrectValue" },
   { labelKey: "tournamentWinner", valueKey: "tournamentWinnerValue" },
   { labelKey: "secretWinner", valueKey: "secretWinnerValue" },
 ];

--- a/lib/score.ts
+++ b/lib/score.ts
@@ -5,17 +5,15 @@ export function computeScore(
   scoreAway: number,
 ): number {
   if (tipHome === scoreHome && tipAway === scoreAway) {
-    return 4;
+    return 5;
   }
   const tipDiff = tipHome - tipAway;
   const scoreDiff = scoreHome - scoreAway;
   if (tipDiff === scoreDiff) {
-    return 2;
+    return scoreHome === scoreAway ? 2 : 3;
   }
-  const tipWinner = Math.sign(tipDiff);
-  const scoreWinner = Math.sign(scoreDiff);
-  if (tipWinner === scoreWinner) {
-    return 1;
+  if (Math.sign(tipDiff) === Math.sign(scoreDiff)) {
+    return 2;
   }
   return 0;
 }

--- a/lib/scoring.ts
+++ b/lib/scoring.ts
@@ -1,8 +1,8 @@
 export type ScoreTone = "success" | "warning" | "neutral" | "danger";
 
 export function scoreColor(points: number): ScoreTone {
-  if (points === 4) return "success";
-  if (points === 2) return "warning";
+  if (points === 5) return "success";
+  if (points === 3) return "warning";
   if (points === 0) return "danger";
   return "neutral";
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -61,15 +61,17 @@
   "Scoring": {
     "title": "Punktesystem",
     "exactScore": "Exaktes Ergebnis",
-    "goalDifference": "Tordifferenz",
+    "goalDifference": "Tordifferenz (kein Unentschieden)",
     "correctOutcome": "Richtiger Ausgang",
+    "drawCorrect": "Unentschieden richtig, Ergebnis falsch",
     "tournamentWinner": "Turniersieger",
     "secretWinner": "Geheimsieger",
-    "exactScoreValue": "4 Pkt",
-    "goalDifferenceValue": "2 Pkt",
-    "correctOutcomeValue": "1 Pkt",
-    "tournamentWinnerValue": "+15 Pkt (Bonus)",
-    "secretWinnerValue": "+7 Pkt (Bonus)"
+    "exactScoreValue": "5 Pkt",
+    "goalDifferenceValue": "3 Pkt",
+    "correctOutcomeValue": "2 Pkt",
+    "drawCorrectValue": "2 Pkt",
+    "tournamentWinnerValue": "+12 Pkt (Bonus)",
+    "secretWinnerValue": "+6 Pkt (Bonus)"
   },
   "Profile": {
     "globalRanking": "GLOBALE RANGLISTE",

--- a/messages/en.json
+++ b/messages/en.json
@@ -61,15 +61,17 @@
   "Scoring": {
     "title": "Scoring System",
     "exactScore": "Exact Score",
-    "goalDifference": "Goal Difference",
+    "goalDifference": "Goal Difference (non-draw)",
     "correctOutcome": "Correct Outcome",
+    "drawCorrect": "Draw correct, wrong score",
     "tournamentWinner": "Tournament Winner",
     "secretWinner": "Secret Winner",
-    "exactScoreValue": "4 Pts",
-    "goalDifferenceValue": "2 Pts",
-    "correctOutcomeValue": "1 Pt",
-    "tournamentWinnerValue": "+15 Pts (bonus)",
-    "secretWinnerValue": "+7 Pts (bonus)"
+    "exactScoreValue": "5 Pts",
+    "goalDifferenceValue": "3 Pts",
+    "correctOutcomeValue": "2 Pts",
+    "drawCorrectValue": "2 Pts",
+    "tournamentWinnerValue": "+12 Pts (bonus)",
+    "secretWinnerValue": "+6 Pts (bonus)"
   },
   "Profile": {
     "globalRanking": "GLOBAL RANKING",

--- a/tests/e2e/ranking.spec.ts
+++ b/tests/e2e/ranking.spec.ts
@@ -34,11 +34,11 @@ test.describe("ranking page", () => {
     expect(ranking || offline).toBe(true);
 
     if (ranking) {
-      await expect(page.getByText("4 Pts")).toBeVisible();
-      await expect(page.getByText("2 Pts")).toBeVisible();
-      await expect(page.getByText("1 Pt")).toBeVisible();
-      await expect(page.getByText("+15 Pts (bonus)")).toBeVisible();
-      await expect(page.getByText("+7 Pts (bonus)")).toBeVisible();
+      await expect(page.getByText("5 Pts")).toBeVisible();
+      await expect(page.getByText("3 Pts")).toBeVisible();
+      await expect(page.getByText("2 Pts").first()).toBeVisible();
+      await expect(page.getByText("+12 Pts (bonus)")).toBeVisible();
+      await expect(page.getByText("+6 Pts (bonus)")).toBeVisible();
       const youPill = page.getByText("YOU", { exact: true }).first();
       await expect(youPill).toBeVisible();
     }

--- a/tests/unit/scoring-color.test.ts
+++ b/tests/unit/scoring-color.test.ts
@@ -2,16 +2,16 @@ import { describe, expect, it } from "vitest";
 import { scoreColor } from "@/lib/scoring";
 
 describe("scoreColor", () => {
-  it("maps 4 to success", () => {
-    expect(scoreColor(4)).toBe("success");
+  it("maps 5 to success", () => {
+    expect(scoreColor(5)).toBe("success");
   });
 
-  it("maps 2 to warning", () => {
-    expect(scoreColor(2)).toBe("warning");
+  it("maps 3 to warning", () => {
+    expect(scoreColor(3)).toBe("warning");
   });
 
-  it("maps 1 to neutral", () => {
-    expect(scoreColor(1)).toBe("neutral");
+  it("maps 2 to neutral", () => {
+    expect(scoreColor(2)).toBe("neutral");
   });
 
   it("maps 0 to danger", () => {
@@ -19,7 +19,8 @@ describe("scoreColor", () => {
   });
 
   it("falls back to neutral for unknown values", () => {
-    expect(scoreColor(3)).toBe("neutral");
+    expect(scoreColor(4)).toBe("neutral");
+    expect(scoreColor(1)).toBe("neutral");
     expect(scoreColor(7)).toBe("neutral");
     expect(scoreColor(-1)).toBe("neutral");
   });

--- a/tests/unit/scoring.test.ts
+++ b/tests/unit/scoring.test.ts
@@ -2,28 +2,28 @@ import { describe, expect, it } from "vitest";
 import { computeScore } from "@/lib/score";
 
 describe("computeScore", () => {
-  it("returns 4 for an exact score match (tip 1:0 vs result 1:0)", () => {
-    expect(computeScore(1, 0, 1, 0)).toBe(4);
+  it("returns 5 for an exact score match (tip 1:0 vs result 1:0)", () => {
+    expect(computeScore(1, 0, 1, 0)).toBe(5);
   });
 
-  it("returns 2 for matching goal difference but different totals (tip 3:1 vs result 2:0)", () => {
-    expect(computeScore(3, 1, 2, 0)).toBe(2);
+  it("returns 3 for matching goal difference but different totals, non-draw (tip 3:1 vs result 2:0)", () => {
+    expect(computeScore(3, 1, 2, 0)).toBe(3);
   });
 
-  it("returns 1 for correct winner only (tip 2:1 vs result 3:1 — both home wins)", () => {
-    expect(computeScore(2, 1, 3, 1)).toBe(1);
+  it("returns 2 for correct winner only (tip 2:1 vs result 3:1 — both home wins)", () => {
+    expect(computeScore(2, 1, 3, 1)).toBe(2);
   });
 
-  it("returns 2 for a correctly tipped draw with different score — same goal diff of 0 (tip 1:1 vs result 2:2)", () => {
+  it("returns 2 for a correctly tipped draw with different score (tip 1:1 vs result 2:2)", () => {
     expect(computeScore(1, 1, 2, 2)).toBe(2);
   });
 
-  it("returns 4 for an exactly matching draw (tip 1:1 vs result 1:1)", () => {
-    expect(computeScore(1, 1, 1, 1)).toBe(4);
+  it("returns 5 for an exactly matching draw (tip 1:1 vs result 1:1)", () => {
+    expect(computeScore(1, 1, 1, 1)).toBe(5);
   });
 
-  it("returns 1 for an away win predicted with different goal difference (tip 0:2 vs result 1:4)", () => {
-    expect(computeScore(0, 2, 1, 4)).toBe(1);
+  it("returns 2 for an away win predicted with different goal difference (tip 0:2 vs result 1:4)", () => {
+    expect(computeScore(0, 2, 1, 4)).toBe(2);
   });
 
   it("returns 0 when winner is wrong (tip 0:1 vs result 1:0)", () => {


### PR DESCRIPTION
## Background

The leaderboard barely separated players by prediction quality: an exact score counted only marginally more than getting the goal difference or just the winner, while the champion bonuses dominated the table. Correct draws with the wrong score were also scored inconsistently with the read API.

## What this changes

Match points now spread more widely across prediction quality — a precise score, a correct goal difference, and a correct tendency each earn a clearly different amount, and the scoring explainer reflects this. A correct draw with the wrong final score now counts as a correct tendency, matching the scoring service. The champion and secret-champion bonuses are rebalanced so they no longer overwhelm the points earned from individual matches.