### PR TITLE
FE-053: ranking location tabs no longer clipped on mobile

### DIFF
--- a/components/ranking/RankingTabs.tsx
+++ b/components/ranking/RankingTabs.tsx
@@ -33,7 +33,7 @@ export function RankingTabs({
 
   return (
     <>
-      <div className="flex bg-surface-container-low rounded-lg p-xs border border-outline-variant overflow-x-auto no-scrollbar">
+      <div className="flex flex-wrap gap-xs bg-surface-container-low rounded-lg p-xs border border-outline-variant">
         {tabs.map((tab) => {
           const isActive = tab.id === active;
           return (


### PR DESCRIPTION
## Background

On the ranking page the location tabs (Global plus each department) were horizontally scrollable but without any visible scroll hint, so on narrow phones the last tab looked hard-cut ("Mainz" appeared as "Main") and seemed unreachable.

## What this changes

The location tabs now wrap onto a second row when they do not all fit, so every tab is fully readable and reachable on phone-sized screens regardless of how many departments exist.