### PR TITLE
FE-047: localize number formatting for points

### DIFF
--- a/components/profile/ProfileHeader.tsx
+++ b/components/profile/ProfileHeader.tsx
@@ -1,4 +1,4 @@
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 
 interface ProfileHeaderProps {
   username: string;
@@ -12,9 +12,9 @@ function formatRank(position: number | null): string {
   return `#${position}`;
 }
 
-function formatPoints(points: number | null): string {
+function formatPoints(points: number | null, locale: string): string {
   if (points === null) return "—";
-  return points.toLocaleString("de-DE");
+  return points.toLocaleString(locale);
 }
 
 export function ProfileHeader({
@@ -24,6 +24,7 @@ export function ProfileHeader({
   totalPoints,
 }: ProfileHeaderProps): React.ReactElement {
   const t = useTranslations("Profile");
+  const locale = useLocale();
   return (
     <div>
       <h1
@@ -52,7 +53,7 @@ export function ProfileHeader({
             {t("totalPoints")}
           </span>
           <span className="text-display font-mono text-tertiary tracking-tighter">
-            {formatPoints(totalPoints)}
+            {formatPoints(totalPoints, locale)}
           </span>
         </div>
       </div>


### PR DESCRIPTION
## Background

The points figure on the profile header was always grouped using German formatting, even when the interface was switched to English. Numbers should follow the active language.

## What this changes

The points figure now uses the grouping of the currently selected language, so it reads naturally in both German and English.