### PR TITLE
FE-054: show profile pictures in the dashboard ranking

### DIFF
--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 import { getCurrentSession } from "@/lib/session";
 import { getLiveMatches, getUpcomingMatches } from "@/lib/match";
 import { getTipByUserAndMatchIds, type TipRow } from "@/lib/tip";
+import { getUserAvatarsByIds } from "@/lib/user";
 import { fetchApi } from "@/lib/api";
 import { RatingResponseSchema, type RatingResponse } from "@/lib/rating";
 import { LiveBlock } from "@/components/dashboard/LiveBlock";
@@ -48,6 +49,16 @@ export default async function DashboardPage(): Promise<React.ReactElement> {
     }
   }
 
+  const rankedUserIds = rating
+    ? [
+        ...rating.global.map((u) => u.user_id),
+        ...Object.values(rating.departments).flatMap((list) =>
+          list.map((u) => u.user_id),
+        ),
+      ]
+    : [];
+  const avatarsById = await getUserAvatarsByIds([...new Set(rankedUserIds)]);
+
   return (
     <>
       <TopAppBar active="dashboard" />
@@ -56,7 +67,11 @@ export default async function DashboardPage(): Promise<React.ReactElement> {
           <LiveBlock matches={liveMatches} tipsByMatchId={tipsByMatchId} />
           {/* Below 980px: ranking sits between live and upcoming fixtures */}
           <div className="min-[980px]:hidden">
-            <RankingSidebar rating={rating} currentUserId={userId} />
+            <RankingSidebar
+              rating={rating}
+              currentUserId={userId}
+              avatarsById={avatarsById}
+            />
           </div>
           <UpcomingList
             matches={upcomingMatches}
@@ -65,7 +80,11 @@ export default async function DashboardPage(): Promise<React.ReactElement> {
         </div>
         {/* From 980px: ranking as the right sidebar */}
         <div className="hidden min-[980px]:block col-span-12 min-[980px]:col-span-4">
-          <RankingSidebar rating={rating} currentUserId={userId} />
+          <RankingSidebar
+            rating={rating}
+            currentUserId={userId}
+            avatarsById={avatarsById}
+          />
         </div>
       </main>
       <BottomNav active="dashboard" />

--- a/components/dashboard/RankingSidebar.tsx
+++ b/components/dashboard/RankingSidebar.tsx
@@ -5,19 +5,26 @@ import { sliceGlobalShortTable } from "@/lib/rating";
 import { abbreviateUsername } from "@/lib/format";
 import { TabBar } from "@/components/dashboard/TabBar";
 import { DEPARTMENTS, displayDepartment } from "@/lib/data/departments";
+import { Avatar } from "@/components/Avatar";
+import type { UserAvatarInfo } from "@/lib/user";
+
+type AvatarMap = Map<number, UserAvatarInfo>;
 
 interface RankingSidebarProps {
   rating: RatingResponse | null;
   currentUserId: number;
+  avatarsById: AvatarMap;
 }
 
 function RankingRow({
   user,
   isCurrent,
+  avatarInfo,
   showDivider = false,
 }: {
   user?: RatingUser;
   isCurrent?: boolean;
+  avatarInfo?: UserAvatarInfo;
   showDivider?: boolean;
 }): React.ReactElement {
   const t = useTranslations("Common");
@@ -50,22 +57,13 @@ function RankingRow({
         >
           {user.position}
         </span>
-        <div
-          className={`w-8 h-8 rounded-full flex items-center justify-center shrink-0 ${
-            isCurrent ? "bg-primary" : "bg-surface-container-highest"
-          }`}
-        >
-          <span
-            className={`material-symbols-outlined text-[18px] ${
-              isCurrent ? "text-on-primary" : ""
-            }`}
-            style={
-              isCurrent ? { fontVariationSettings: "'FILL' 1" } : undefined
-            }
-          >
-            person
-          </span>
-        </div>
+        <Avatar
+          avatarPath={avatarInfo?.avatar ?? null}
+          email={avatarInfo?.email ?? ""}
+          name={user.name}
+          size={32}
+          className={isCurrent ? "ring-2 ring-primary shrink-0" : "shrink-0"}
+        />
         <span
           className={`text-body-sm font-bold truncate ${
             isCurrent ? "text-primary" : ""
@@ -89,9 +87,11 @@ function RankingRow({
 function GlobalPanel({
   rating,
   currentUserId,
+  avatarsById,
 }: {
   rating: RatingResponse;
   currentUserId: number;
+  avatarsById: AvatarMap;
 }): React.ReactElement {
   const t = useTranslations("Dashboard");
   const { topRows, neighborRows, hasGap } = sliceGlobalShortTable(
@@ -114,6 +114,7 @@ function GlobalPanel({
           key={u.user_id}
           user={u}
           isCurrent={u.user_id === currentUserId}
+          avatarInfo={avatarsById.get(u.user_id)}
         />
       ))}
       {hasGap ? <RankingRow showDivider /> : null}
@@ -122,6 +123,7 @@ function GlobalPanel({
           key={u.user_id}
           user={u}
           isCurrent={u.user_id === currentUserId}
+          avatarInfo={avatarsById.get(u.user_id)}
         />
       ))}
     </div>
@@ -131,9 +133,11 @@ function GlobalPanel({
 function DepartmentPanel({
   users,
   currentUserId,
+  avatarsById,
 }: {
   users: RatingUser[];
   currentUserId: number;
+  avatarsById: AvatarMap;
 }): React.ReactElement {
   const t = useTranslations("Dashboard");
   if (users.length === 0) {
@@ -150,6 +154,7 @@ function DepartmentPanel({
           key={u.user_id}
           user={u}
           isCurrent={u.user_id === currentUserId}
+          avatarInfo={avatarsById.get(u.user_id)}
         />
       ))}
     </div>
@@ -159,6 +164,7 @@ function DepartmentPanel({
 export function RankingSidebar({
   rating,
   currentUserId,
+  avatarsById,
 }: RankingSidebarProps): React.ReactElement {
   const t = useTranslations("Dashboard");
   const tCommon = useTranslations("Common");
@@ -183,13 +189,20 @@ export function RankingSidebar({
   ];
 
   const panels: Record<string, React.ReactNode> = {
-    global: <GlobalPanel rating={rating} currentUserId={currentUserId} />,
+    global: (
+      <GlobalPanel
+        rating={rating}
+        currentUserId={currentUserId}
+        avatarsById={avatarsById}
+      />
+    ),
   };
   for (const dept of DEPARTMENTS) {
     panels[dept] = (
       <DepartmentPanel
         users={rating.departments[dept] ?? []}
         currentUserId={currentUserId}
+        avatarsById={avatarsById}
       />
     );
   }

--- a/lib/user.ts
+++ b/lib/user.ts
@@ -1,9 +1,31 @@
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { user } from "@/db/schema";
 
 export type DatabaseUser = typeof user.$inferSelect;
 export type NewUser = typeof user.$inferInsert;
+
+export interface UserAvatarInfo {
+  avatar: string | null;
+  email: string;
+}
+
+export async function getUserAvatarsByIds(
+  ids: number[],
+): Promise<Map<number, UserAvatarInfo>> {
+  const map = new Map<number, UserAvatarInfo>();
+  if (ids.length === 0) {
+    return map;
+  }
+  const rows = await db
+    .select({ id: user.id, avatar: user.avatar, email: user.email })
+    .from(user)
+    .where(inArray(user.id, ids));
+  for (const row of rows) {
+    map.set(row.id, { avatar: row.avatar, email: row.email });
+  }
+  return map;
+}
 
 export async function getUserByEmail(
   email: string,


### PR DESCRIPTION
## Background

In the compact ranking on the dashboard every entry showed the same generic placeholder icon instead of the user's profile picture, even for users who had uploaded an avatar.

## What this changes

The dashboard ranking now shows each listed user's profile picture, with a clean fallback to their initials (and a neutral icon when no name is available), consistent with how avatars appear elsewhere in the app.