### PR TITLE
FE-048: limit and progressively load the upcoming fixtures list

### DIFF
--- a/components/dashboard/UpcomingList.tsx
+++ b/components/dashboard/UpcomingList.tsx
@@ -1,14 +1,32 @@
+"use client";
+
+import { useState } from "react";
 import { useLocale, useTranslations } from "next-intl";
 import type { MatchRow as MatchRowData } from "@/lib/match";
 import type { TipRow } from "@/lib/tip";
 import { MatchRow } from "@/components/dashboard/MatchRow";
-import { groupByDate } from "@/lib/match";
-import { formatDate } from "@/lib/format";
+import { formatDate, formatDateKey } from "@/lib/format";
 
 interface UpcomingListProps {
   matches: MatchRowData[];
   tipsByMatchId: Map<number, TipRow>;
 }
+
+function groupByDate(
+  matches: MatchRowData[],
+): Record<string, MatchRowData[]> {
+  const groups: Record<string, MatchRowData[]> = {};
+  for (const m of matches) {
+    const key = formatDateKey(m.utcDate);
+    if (!groups[key]) groups[key] = [];
+    groups[key]!.push(m);
+  }
+  return groups;
+}
+
+const PAGINATE_THRESHOLD = 30;
+const INITIAL_VISIBLE = 20;
+const LOAD_STEP = 10;
 
 export function UpcomingList({
   matches,
@@ -16,6 +34,11 @@ export function UpcomingList({
 }: UpcomingListProps): React.ReactElement {
   const t = useTranslations("Dashboard");
   const locale = useLocale();
+  const paginated = matches.length > PAGINATE_THRESHOLD;
+  const [visibleCount, setVisibleCount] = useState(
+    paginated ? INITIAL_VISIBLE : matches.length,
+  );
+
   if (matches.length === 0) {
     return (
       <section>
@@ -29,7 +52,16 @@ export function UpcomingList({
     );
   }
 
-  const grouped = groupByDate(matches);
+  const ordered = paginated
+    ? [...matches].sort((a, b) => a.utcDate.getTime() - b.utcDate.getTime())
+    : matches;
+  const visibleMatches = paginated
+    ? ordered.slice(0, visibleCount)
+    : ordered;
+  const hiddenCount = matches.length - visibleMatches.length;
+  const showLoadAll = hiddenCount > LOAD_STEP;
+
+  const grouped = groupByDate(visibleMatches);
   const dateKeys = Object.keys(grouped).sort();
 
   return (
@@ -58,6 +90,28 @@ export function UpcomingList({
           );
         })}
       </div>
+      {hiddenCount > 0 ? (
+        <div className="flex flex-wrap gap-sm justify-center mt-lg">
+          <button
+            type="button"
+            onClick={() =>
+              setVisibleCount((c) => Math.min(c + LOAD_STEP, matches.length))
+            }
+            className="text-label-caps uppercase px-lg py-sm rounded-lg border border-outline-variant bg-surface-container hover:bg-surface-container-high text-on-surface transition-colors"
+          >
+            {t("loadNext", { count: LOAD_STEP })}
+          </button>
+          {showLoadAll ? (
+            <button
+              type="button"
+              onClick={() => setVisibleCount(matches.length)}
+              className="text-label-caps uppercase px-lg py-sm rounded-lg border border-outline-variant bg-surface-container hover:bg-surface-container-high text-on-surface-variant transition-colors"
+            >
+              {t("loadAll")}
+            </button>
+          ) : null}
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -21,6 +21,8 @@
     "points": "PUNKTE:",
     "upcomingFixtures": "ANSTEHENDE SPIELE",
     "noUpcomingFixtures": "Keine anstehenden Spiele.",
+    "loadNext": "Nächste {count} laden",
+    "loadAll": "Alle laden",
     "ranking": "RANGLISTE",
     "viewFullRanking": "GESAMTE RANGLISTE",
     "noRankingData": "Noch keine Ranglistendaten.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -21,6 +21,8 @@
     "points": "POINTS:",
     "upcomingFixtures": "UPCOMING FIXTURES",
     "noUpcomingFixtures": "No upcoming fixtures.",
+    "loadNext": "Load next {count}",
+    "loadAll": "Load all",
     "ranking": "RANKING",
     "viewFullRanking": "VIEW FULL RANKING",
     "noRankingData": "No ranking data yet.",


### PR DESCRIPTION
## Background

On the dashboard the upcoming fixtures list could become very long when there were many matches to predict, making the page unwieldy from the start.

## What this changes

When there are more than 30 upcoming fixtures, the dashboard now shows the first 20 and lets you reveal more in steps of ten, with an option to load everything at once. The 'load all' shortcut only appears when it would actually save repeated clicks; with 30 or fewer fixtures the full list is shown as before. Day grouping stays correct as more matches are revealed.