### PR TITLE
FE-049: sort, filter and paginate the profile prediction history

### DIFF
--- a/app/(app)/user/[id]/page.tsx
+++ b/app/(app)/user/[id]/page.tsx
@@ -9,6 +9,7 @@ import { ProfileHeader } from "@/components/profile/ProfileHeader";
 import { StatTiles } from "@/components/profile/StatTiles";
 import { WinnerCards } from "@/components/profile/WinnerCards";
 import { PredictionHistory } from "@/components/profile/PredictionHistory";
+import { HistoryFilterProvider } from "@/components/profile/HistoryFilterContext";
 import { isTournamentLocked } from "@/lib/tournament";
 import { displayNameFromEmail } from "@/lib/user-name";
 import { Avatar } from "@/components/Avatar";
@@ -75,35 +76,37 @@ export default async function UserProfilePage({
     <>
       <TopAppBar active={isOwnProfile ? "profile" : "dashboard"} />
       <main className="pt-4 md:pt-24 pb-24 md:pb-8 px-margin-mobile md:px-margin-desktop max-w-(--container-max-desktop) mx-auto">
-        <div className="grid grid-cols-1 md:grid-cols-12 gap-lg mb-xl">
-          <div className="md:col-span-8 flex flex-col justify-between">
-            <div className="flex items-center gap-md">
-              <Avatar
-                avatarPath={localUser.avatar}
-                email={localUser.email}
-                size={72}
-                className="shrink-0 border-2 border-outline-variant"
-              />
-              <ProfileHeader
-                username={localUser.username}
-                displayName={displayNameFromEmail(localUser.email)}
-                position={position}
-                totalPoints={totalPoints}
+        <HistoryFilterProvider>
+          <div className="grid grid-cols-1 md:grid-cols-12 gap-lg mb-xl">
+            <div className="md:col-span-8 flex flex-col justify-between">
+              <div className="flex items-center gap-md">
+                <Avatar
+                  avatarPath={localUser.avatar}
+                  email={localUser.email}
+                  size={72}
+                  className="shrink-0 border-2 border-outline-variant"
+                />
+                <ProfileHeader
+                  username={localUser.username}
+                  displayName={displayNameFromEmail(localUser.email)}
+                  position={position}
+                  totalPoints={totalPoints}
+                />
+              </div>
+              <StatTiles exact={exact} diff={diff} wins={wins} bonus={bonus} />
+            </div>
+            <div className="md:col-span-4">
+              <WinnerCards
+                winner={localUser.winner}
+                secretWinner={localUser.secretWinner}
+                userId={userId}
+                editable={editable}
               />
             </div>
-            <StatTiles exact={exact} diff={diff} wins={wins} bonus={bonus} />
           </div>
-          <div className="md:col-span-4">
-            <WinnerCards
-              winner={localUser.winner}
-              secretWinner={localUser.secretWinner}
-              userId={userId}
-              editable={editable}
-            />
-          </div>
-        </div>
 
-        <PredictionHistory status={ratingLoad.status} tips={tips} />
+          <PredictionHistory status={ratingLoad.status} tips={tips} />
+        </HistoryFilterProvider>
       </main>
       <BottomNav active={isOwnProfile ? "profile" : "dashboard"} />
     </>

--- a/components/profile/HistoryFilterContext.tsx
+++ b/components/profile/HistoryFilterContext.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { createContext, useContext, useMemo, useState } from "react";
+import type { HistoryFilter } from "@/lib/history";
+
+interface HistoryFilterContextValue {
+  filter: HistoryFilter | null;
+  setFilter: (filter: HistoryFilter | null) => void;
+  toggleFilter: (filter: HistoryFilter) => void;
+}
+
+const HistoryFilterContext = createContext<HistoryFilterContextValue | null>(
+  null,
+);
+
+export function HistoryFilterProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.ReactElement {
+  const [filter, setFilter] = useState<HistoryFilter | null>(null);
+
+  const value = useMemo<HistoryFilterContextValue>(
+    () => ({
+      filter,
+      setFilter,
+      toggleFilter: (next) =>
+        setFilter((current) => (current === next ? null : next)),
+    }),
+    [filter],
+  );
+
+  return (
+    <HistoryFilterContext.Provider value={value}>
+      {children}
+    </HistoryFilterContext.Provider>
+  );
+}
+
+export function useHistoryFilter(): HistoryFilterContextValue {
+  const ctx = useContext(HistoryFilterContext);
+  if (ctx === null) {
+    throw new Error(
+      "useHistoryFilter must be used within a HistoryFilterProvider",
+    );
+  }
+  return ctx;
+}

--- a/components/profile/PredictionHistory.tsx
+++ b/components/profile/PredictionHistory.tsx
@@ -1,9 +1,24 @@
+"use client";
+
+import { useMemo, useState } from "react";
 import Link from "next/link";
 import { useLocale, useTranslations } from "next-intl";
 import type { RatingMatchInfo } from "@/lib/rating";
 import { formatDate } from "@/lib/format";
 import { scoreColor, scoreToneClass } from "@/lib/scoring";
 import { TOURNAMENT_NAME } from "@/lib/data/tournament";
+import {
+  DEFAULT_SORT,
+  filterTips,
+  isPaginated,
+  pageCount,
+  paginate,
+  sortTips,
+  toggleSort,
+  type SortKey,
+  type SortState,
+} from "@/lib/history";
+import { useHistoryFilter } from "@/components/profile/HistoryFilterContext";
 
 type HistoryStatus = "ok" | "offline";
 
@@ -33,12 +48,39 @@ function parseDate(date: number): Date {
   return new Date(date * 1000);
 }
 
+function sortIndicator(sort: SortState, key: SortKey): string {
+  if (sort.key !== key) return "";
+  return sort.dir === "asc" ? " ↑" : " ↓";
+}
+
 export function PredictionHistory({
   status,
   tips,
 }: PredictionHistoryProps): React.ReactElement {
   const t = useTranslations("Profile");
   const locale = useLocale();
+  const { filter, setFilter } = useHistoryFilter();
+  const [sort, setSort] = useState<SortState>(DEFAULT_SORT);
+  const [page, setPage] = useState(1);
+
+  const visibleTips = useMemo(
+    () => sortTips(filterTips(tips, filter), sort),
+    [tips, filter, sort],
+  );
+
+  const total = visibleTips.length;
+  const paginated = isPaginated(total);
+  const pages = pageCount(total);
+  const currentPage = Math.min(page, pages);
+  const pageTips = paginated
+    ? paginate(visibleTips, currentPage)
+    : visibleTips;
+
+  function handleSort(key: SortKey): void {
+    setSort((current) => toggleSort(current, key));
+    setPage(1);
+  }
+
   return (
     <section className="mt-xl">
       <div className="flex justify-between items-end border-b border-outline-variant pb-md mb-lg">
@@ -65,112 +107,218 @@ export function PredictionHistory({
         </div>
       ) : (
         <>
-          <div className="hidden md:block overflow-hidden border border-outline-variant">
-            <table className="w-full text-left border-collapse">
-              <thead>
-                <tr className="bg-surface-container-high text-label-caps uppercase text-on-surface-variant border-b border-outline-variant">
-                  <th className="px-lg py-md">{t("match")}</th>
-                  <th className="px-lg py-md text-center">{t("prediction")}</th>
-                  <th className="px-lg py-md text-center">{t("result")}</th>
-                  <th className="px-lg py-md text-right">{t("points")}</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-outline-variant">
-                {tips.map((tip) => {
+          {filter !== null && (
+            <div className="flex items-center justify-between gap-md mb-md">
+              <span className="text-body-sm text-on-surface-variant">
+                {t("filteredBy", { category: t(filter) })}
+              </span>
+              <button
+                type="button"
+                onClick={() => setFilter(null)}
+                className="text-label-caps uppercase text-primary hover:underline"
+              >
+                {t("allResults")}
+              </button>
+            </div>
+          )}
+
+          <div className="md:hidden flex gap-sm mb-md">
+            <button
+              type="button"
+              onClick={() => handleSort("points")}
+              aria-pressed={sort.key === "points"}
+              className={`flex-1 px-md py-sm border text-label-caps uppercase transition-colors ${
+                sort.key === "points"
+                  ? "border-primary text-primary bg-surface-container-high"
+                  : "border-outline-variant text-on-surface-variant"
+              }`}
+            >
+              {t("sortByPoints")}
+              {sortIndicator(sort, "points")}
+            </button>
+            <button
+              type="button"
+              onClick={() => handleSort("date")}
+              aria-pressed={sort.key === "date"}
+              className={`flex-1 px-md py-sm border text-label-caps uppercase transition-colors ${
+                sort.key === "date"
+                  ? "border-primary text-primary bg-surface-container-high"
+                  : "border-outline-variant text-on-surface-variant"
+              }`}
+            >
+              {t("sortByDate")}
+              {sortIndicator(sort, "date")}
+            </button>
+          </div>
+
+          {total === 0 ? (
+            <div className="bg-surface-container-low border border-outline-variant rounded-lg p-xl text-center text-body-sm text-on-surface-variant">
+              {t("noPredictions")}
+            </div>
+          ) : (
+            <>
+              <div className="hidden md:block overflow-hidden border border-outline-variant">
+                <table className="w-full text-left border-collapse">
+                  <thead>
+                    <tr className="bg-surface-container-high text-label-caps uppercase text-on-surface-variant border-b border-outline-variant">
+                      <th className="px-lg py-md">
+                        <button
+                          type="button"
+                          onClick={() => handleSort("date")}
+                          aria-pressed={sort.key === "date"}
+                          className="uppercase hover:text-on-surface transition-colors"
+                        >
+                          {t("match")}
+                          {sortIndicator(sort, "date")}
+                        </button>
+                      </th>
+                      <th className="px-lg py-md text-center">
+                        {t("prediction")}
+                      </th>
+                      <th className="px-lg py-md text-center">{t("result")}</th>
+                      <th className="px-lg py-md text-right">
+                        <button
+                          type="button"
+                          onClick={() => handleSort("points")}
+                          aria-pressed={sort.key === "points"}
+                          className="uppercase hover:text-on-surface transition-colors"
+                        >
+                          {t("points")}
+                          {sortIndicator(sort, "points")}
+                        </button>
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-outline-variant">
+                    {pageTips.map((tip) => {
+                      const points = clampPerMatchPoints(tip.score);
+                      const toneClass = scoreToneClass(scoreColor(points));
+                      const matchDate = parseDate(tip.date);
+                      return (
+                        <tr
+                          key={tip.match_id}
+                          className="bg-surface hover:bg-surface-container-lowest transition-colors"
+                        >
+                          <td className="px-lg py-lg">
+                            <Link
+                              href={`/match/${tip.match_id}`}
+                              className="flex flex-col hover:underline"
+                            >
+                              <span className="text-body-lg font-bold text-on-background">
+                                {tip.team1.tla} vs {tip.team2.tla}
+                              </span>
+                              <span className="text-label-caps uppercase text-on-surface-variant font-mono">
+                                {formatDate(matchDate, locale)}
+                              </span>
+                            </Link>
+                          </td>
+                          <td className="px-lg py-lg text-center">
+                            <span className="bg-surface-container-highest px-md py-xs rounded-sm font-mono text-data-mono text-on-background border border-outline-variant">
+                              {formatScorePair(tip.tip_home, tip.tip_away)}
+                            </span>
+                          </td>
+                          <td className="px-lg py-lg text-center">
+                            <span className="bg-surface-variant text-on-surface px-md py-xs rounded-sm font-mono text-data-mono">
+                              {formatScorePair(tip.score_home, tip.score_away)}
+                            </span>
+                          </td>
+                          <td className="px-lg py-lg text-right">
+                            <span
+                              className={`text-headline-md font-mono font-bold ${toneClass}`}
+                            >
+                              {formatPoints(points)}
+                            </span>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+
+              <ul className="md:hidden border border-outline-variant divide-y divide-outline-variant">
+                {pageTips.map((tip) => {
                   const points = clampPerMatchPoints(tip.score);
                   const toneClass = scoreToneClass(scoreColor(points));
                   const matchDate = parseDate(tip.date);
                   return (
-                    <tr
-                      key={tip.match_id}
-                      className="bg-surface hover:bg-surface-container-lowest transition-colors"
-                    >
-                      <td className="px-lg py-lg">
-                        <Link
-                          href={`/match/${tip.match_id}`}
-                          className="flex flex-col hover:underline"
-                        >
-                          <span className="text-body-lg font-bold text-on-background">
-                            {tip.team1.tla} vs {tip.team2.tla}
+                    <li key={tip.match_id} className="bg-surface">
+                      <Link
+                        href={`/match/${tip.match_id}`}
+                        className="block p-md hover:bg-surface-container-lowest transition-colors"
+                      >
+                        <div className="flex justify-between items-start gap-md mb-sm">
+                          <div className="flex flex-col min-w-0">
+                            <span className="text-body-lg font-bold text-on-background">
+                              {tip.team1.tla} vs {tip.team2.tla}
+                            </span>
+                            <span className="text-label-caps uppercase text-on-surface-variant font-mono">
+                              {formatDate(matchDate, locale)}
+                            </span>
+                          </div>
+                          <span
+                            className={`text-headline-md font-mono font-bold shrink-0 ${toneClass}`}
+                          >
+                            {formatPoints(points)}
                           </span>
-                          <span className="text-label-caps uppercase text-on-surface-variant font-mono">
-                            {formatDate(matchDate, locale)}
-                          </span>
-                        </Link>
-                      </td>
-                      <td className="px-lg py-lg text-center">
-                        <span className="bg-surface-container-highest px-md py-xs rounded-sm font-mono text-data-mono text-on-background border border-outline-variant">
-                          {formatScorePair(tip.tip_home, tip.tip_away)}
-                        </span>
-                      </td>
-                      <td className="px-lg py-lg text-center">
-                        <span className="bg-surface-variant text-on-surface px-md py-xs rounded-sm font-mono text-data-mono">
-                          {formatScorePair(tip.score_home, tip.score_away)}
-                        </span>
-                      </td>
-                      <td className="px-lg py-lg text-right">
-                        <span
-                          className={`text-headline-md font-mono font-bold ${toneClass}`}
-                        >
-                          {formatPoints(points)}
-                        </span>
-                      </td>
-                    </tr>
+                        </div>
+                        <div className="grid grid-cols-2 gap-sm">
+                          <div className="flex flex-col items-start">
+                            <span className="text-label-caps uppercase text-on-surface-variant">
+                              {t("prediction")}
+                            </span>
+                            <span className="bg-surface-container-highest px-md py-xs rounded-sm font-mono text-data-mono text-on-background border border-outline-variant">
+                              {formatScorePair(tip.tip_home, tip.tip_away)}
+                            </span>
+                          </div>
+                          <div className="flex flex-col items-start">
+                            <span className="text-label-caps uppercase text-on-surface-variant">
+                              {t("result")}
+                            </span>
+                            <span className="bg-surface-variant text-on-surface px-md py-xs rounded-sm font-mono text-data-mono">
+                              {formatScorePair(tip.score_home, tip.score_away)}
+                            </span>
+                          </div>
+                        </div>
+                      </Link>
+                    </li>
                   );
                 })}
-              </tbody>
-            </table>
-          </div>
+              </ul>
 
-          <ul className="md:hidden border border-outline-variant divide-y divide-outline-variant">
-            {tips.map((tip) => {
-              const points = clampPerMatchPoints(tip.score);
-              const toneClass = scoreToneClass(scoreColor(points));
-              const matchDate = parseDate(tip.date);
-              return (
-                <li key={tip.match_id} className="bg-surface">
-                  <Link
-                    href={`/match/${tip.match_id}`}
-                    className="block p-md hover:bg-surface-container-lowest transition-colors"
-                  >
-                    <div className="flex justify-between items-start gap-md mb-sm">
-                      <div className="flex flex-col min-w-0">
-                        <span className="text-body-lg font-bold text-on-background">
-                          {tip.team1.tla} vs {tip.team2.tla}
-                        </span>
-                        <span className="text-label-caps uppercase text-on-surface-variant font-mono">
-                          {formatDate(matchDate, locale)}
-                        </span>
-                      </div>
-                      <span
-                        className={`text-headline-md font-mono font-bold shrink-0 ${toneClass}`}
-                      >
-                        {formatPoints(points)}
-                      </span>
-                    </div>
-                    <div className="grid grid-cols-2 gap-sm">
-                      <div className="flex flex-col items-start">
-                        <span className="text-label-caps uppercase text-on-surface-variant">
-                          {t("prediction")}
-                        </span>
-                        <span className="bg-surface-container-highest px-md py-xs rounded-sm font-mono text-data-mono text-on-background border border-outline-variant">
-                          {formatScorePair(tip.tip_home, tip.tip_away)}
-                        </span>
-                      </div>
-                      <div className="flex flex-col items-start">
-                        <span className="text-label-caps uppercase text-on-surface-variant">
-                          {t("result")}
-                        </span>
-                        <span className="bg-surface-variant text-on-surface px-md py-xs rounded-sm font-mono text-data-mono">
-                          {formatScorePair(tip.score_home, tip.score_away)}
-                        </span>
-                      </div>
-                    </div>
-                  </Link>
-                </li>
-              );
-            })}
-          </ul>
+              {paginated && (
+                <div className="flex items-center justify-between gap-md mt-lg">
+                  <span className="text-body-sm text-on-surface-variant">
+                    {t("showingCount", {
+                      shown: pageTips.length,
+                      total,
+                    })}
+                  </span>
+                  <div className="flex items-center gap-md">
+                    <button
+                      type="button"
+                      onClick={() => setPage(Math.max(1, currentPage - 1))}
+                      disabled={currentPage <= 1}
+                      className="px-md py-sm border border-outline-variant text-label-caps uppercase text-on-surface-variant transition-colors hover:bg-surface-container-high disabled:opacity-40 disabled:cursor-not-allowed"
+                    >
+                      {t("previous")}
+                    </button>
+                    <span className="text-label-caps uppercase text-on-surface-variant font-mono">
+                      {t("pageOf", { current: currentPage, total: pages })}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => setPage(Math.min(pages, currentPage + 1))}
+                      disabled={currentPage >= pages}
+                      className="px-md py-sm border border-outline-variant text-label-caps uppercase text-on-surface-variant transition-colors hover:bg-surface-container-high disabled:opacity-40 disabled:cursor-not-allowed"
+                    >
+                      {t("next")}
+                    </button>
+                  </div>
+                </div>
+              )}
+            </>
+          )}
         </>
       )}
     </section>

--- a/components/profile/StatTiles.tsx
+++ b/components/profile/StatTiles.tsx
@@ -1,4 +1,8 @@
+"use client";
+
 import { useTranslations } from "next-intl";
+import type { HistoryFilter } from "@/lib/history";
+import { useHistoryFilter } from "@/components/profile/HistoryFilterContext";
 
 interface StatTilesProps {
   exact: number | null;
@@ -7,14 +11,13 @@ interface StatTilesProps {
   bonus: number | null;
 }
 
-const TILES: {
-  key: keyof StatTilesProps;
-  labelKey: "exact" | "diff" | "wins" | "bonus";
+const FILTER_TILES: {
+  key: "exact" | "diff" | "wins";
+  filter: HistoryFilter;
 }[] = [
-  { key: "exact", labelKey: "exact" },
-  { key: "diff", labelKey: "diff" },
-  { key: "wins", labelKey: "wins" },
-  { key: "bonus", labelKey: "bonus" },
+  { key: "exact", filter: "exact" },
+  { key: "diff", filter: "diff" },
+  { key: "wins", filter: "wins" },
 ];
 
 function display(value: number | null): string {
@@ -24,21 +27,40 @@ function display(value: number | null): string {
 
 export function StatTiles(props: StatTilesProps): React.ReactElement {
   const t = useTranslations("Profile");
+  const { filter, toggleFilter } = useHistoryFilter();
   return (
     <div className="grid grid-cols-2 lg:grid-cols-4 gap-md mt-lg">
-      {TILES.map((tile) => (
-        <div
-          key={tile.key}
-          className="p-md border border-outline-variant bg-surface-container-low"
-        >
-          <span className="text-label-caps uppercase text-on-surface-variant block">
-            {t(tile.labelKey)}
-          </span>
-          <span className="text-headline-md font-mono text-on-background">
-            {display(props[tile.key])}
-          </span>
-        </div>
-      ))}
+      {FILTER_TILES.map((tile) => {
+        const active = filter === tile.filter;
+        return (
+          <button
+            key={tile.key}
+            type="button"
+            onClick={() => toggleFilter(tile.filter)}
+            aria-pressed={active}
+            className={`p-md border text-left transition-colors hover:bg-surface-container-high ${
+              active
+                ? "border-primary ring-2 ring-primary bg-surface-container-high"
+                : "border-outline-variant bg-surface-container-low"
+            }`}
+          >
+            <span className="text-label-caps uppercase text-on-surface-variant block">
+              {t(tile.key)}
+            </span>
+            <span className="text-headline-md font-mono text-on-background">
+              {display(props[tile.key])}
+            </span>
+          </button>
+        );
+      })}
+      <div className="p-md border border-outline-variant bg-surface-container-low">
+        <span className="text-label-caps uppercase text-on-surface-variant block">
+          {t("bonus")}
+        </span>
+        <span className="text-headline-md font-mono text-on-background">
+          {display(props.bonus)}
+        </span>
+      </div>
     </div>
   );
 }

--- a/lib/history.ts
+++ b/lib/history.ts
@@ -1,0 +1,84 @@
+import type { RatingMatchInfo } from "@/lib/rating";
+
+export type TipCategory = "exact" | "diff" | "wins" | "none";
+export type HistoryFilter = "exact" | "diff" | "wins";
+export type SortKey = "points" | "date";
+export type SortDir = "asc" | "desc";
+
+export interface SortState {
+  key: SortKey;
+  dir: SortDir;
+}
+
+export const DEFAULT_SORT: SortState = { key: "date", dir: "desc" };
+
+export const PAGE_SIZE = 20;
+export const PAGINATION_THRESHOLD = 30;
+
+export function tipCategory(score: number): TipCategory {
+  if (score === 5) return "exact";
+  if (score === 3) return "diff";
+  if (score === 2) return "wins";
+  return "none";
+}
+
+export function matchesFilter(
+  tip: RatingMatchInfo,
+  filter: HistoryFilter | null,
+): boolean {
+  if (filter === null) return true;
+  return tipCategory(tip.score) === filter;
+}
+
+export function filterTips(
+  tips: RatingMatchInfo[],
+  filter: HistoryFilter | null,
+): RatingMatchInfo[] {
+  if (filter === null) return tips;
+  return tips.filter((tip) => matchesFilter(tip, filter));
+}
+
+export function compareTips(
+  a: RatingMatchInfo,
+  b: RatingMatchInfo,
+  sort: SortState,
+): number {
+  const raw =
+    sort.key === "points" ? a.score - b.score : a.date - b.date;
+  return sort.dir === "asc" ? raw : -raw;
+}
+
+export function sortTips(
+  tips: RatingMatchInfo[],
+  sort: SortState,
+): RatingMatchInfo[] {
+  return [...tips].sort((a, b) => compareTips(a, b, sort));
+}
+
+export function toggleSort(current: SortState, key: SortKey): SortState {
+  if (current.key === key) {
+    return { key, dir: current.dir === "asc" ? "desc" : "asc" };
+  }
+  return { key, dir: "desc" };
+}
+
+export function pageCount(totalItems: number, pageSize = PAGE_SIZE): number {
+  if (totalItems <= 0) return 1;
+  return Math.ceil(totalItems / pageSize);
+}
+
+export function isPaginated(
+  totalItems: number,
+  threshold = PAGINATION_THRESHOLD,
+): boolean {
+  return totalItems > threshold;
+}
+
+export function paginate<T>(
+  items: T[],
+  page: number,
+  pageSize = PAGE_SIZE,
+): T[] {
+  const start = (page - 1) * pageSize;
+  return items.slice(start, start + pageSize);
+}

--- a/messages/de.json
+++ b/messages/de.json
@@ -100,7 +100,15 @@
     "match": "Spiel",
     "prediction": "Tipp",
     "result": "Ergebnis",
-    "points": "Punkte"
+    "points": "Punkte",
+    "sortByPoints": "Punkte",
+    "sortByDate": "Datum",
+    "previous": "Zurück",
+    "next": "Weiter",
+    "pageOf": "Seite {current} / {total}",
+    "showingCount": "{shown} von {total}",
+    "allResults": "Alle anzeigen",
+    "filteredBy": "Gefiltert nach: {category}"
   },
   "Match": {
     "live": "LIVE",

--- a/messages/en.json
+++ b/messages/en.json
@@ -100,7 +100,15 @@
     "match": "Match",
     "prediction": "Prediction",
     "result": "Result",
-    "points": "Points"
+    "points": "Points",
+    "sortByPoints": "Points",
+    "sortByDate": "Date",
+    "previous": "Previous",
+    "next": "Next",
+    "pageOf": "Page {current} / {total}",
+    "showingCount": "{shown} of {total}",
+    "allResults": "Show all",
+    "filteredBy": "Filtered by: {category}"
   },
   "Match": {
     "live": "LIVE",

--- a/tests/unit/history.test.ts
+++ b/tests/unit/history.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+import type { RatingMatchInfo } from "@/lib/rating";
+import {
+  compareTips,
+  DEFAULT_SORT,
+  filterTips,
+  isPaginated,
+  matchesFilter,
+  PAGE_SIZE,
+  pageCount,
+  paginate,
+  sortTips,
+  tipCategory,
+  toggleSort,
+  type SortState,
+} from "@/lib/history";
+
+function makeTip(
+  overrides: Partial<RatingMatchInfo> & { score: number; date: number },
+): RatingMatchInfo {
+  return {
+    match_id: `m${overrides.date}-${overrides.score}`,
+    user: "u",
+    user_id: 1,
+    team1: { name: "Alpha", tla: "ALP" },
+    team2: { name: "Beta", tla: "BET" },
+    tip_home: 1,
+    tip_away: 0,
+    score_home: 1,
+    score_away: 0,
+    ...overrides,
+  };
+}
+
+describe("tipCategory", () => {
+  it("maps 5 to exact", () => {
+    expect(tipCategory(5)).toBe("exact");
+  });
+  it("maps 3 to diff", () => {
+    expect(tipCategory(3)).toBe("diff");
+  });
+  it("maps 2 to wins", () => {
+    expect(tipCategory(2)).toBe("wins");
+  });
+  it("maps 0 to none", () => {
+    expect(tipCategory(0)).toBe("none");
+  });
+  it("maps any other score to none", () => {
+    expect(tipCategory(1)).toBe("none");
+    expect(tipCategory(4)).toBe("none");
+    expect(tipCategory(-1)).toBe("none");
+  });
+});
+
+describe("matchesFilter / filterTips", () => {
+  const tips = [
+    makeTip({ score: 5, date: 100 }),
+    makeTip({ score: 3, date: 200 }),
+    makeTip({ score: 2, date: 300 }),
+    makeTip({ score: 0, date: 400 }),
+  ];
+
+  it("returns true for any tip when filter is null", () => {
+    expect(matchesFilter(tips[0], null)).toBe(true);
+    expect(matchesFilter(tips[3], null)).toBe(true);
+  });
+
+  it("matches only the requested category", () => {
+    expect(matchesFilter(tips[0], "exact")).toBe(true);
+    expect(matchesFilter(tips[1], "exact")).toBe(false);
+    expect(matchesFilter(tips[1], "diff")).toBe(true);
+    expect(matchesFilter(tips[2], "wins")).toBe(true);
+  });
+
+  it("returns all tips unchanged when filter is null", () => {
+    expect(filterTips(tips, null)).toEqual(tips);
+  });
+
+  it("filters to exact only", () => {
+    expect(filterTips(tips, "exact").map((t) => t.score)).toEqual([5]);
+  });
+
+  it("filters to wins only (score 2)", () => {
+    expect(filterTips(tips, "wins").map((t) => t.score)).toEqual([2]);
+  });
+
+  it("excludes none-category tips from any filter", () => {
+    expect(filterTips(tips, "exact")).not.toContain(tips[3]);
+  });
+});
+
+describe("compareTips / sortTips", () => {
+  const a = makeTip({ score: 2, date: 100 });
+  const b = makeTip({ score: 5, date: 300 });
+  const c = makeTip({ score: 3, date: 200 });
+
+  it("sorts by points ascending", () => {
+    const sorted = sortTips([b, a, c], { key: "points", dir: "asc" });
+    expect(sorted.map((t) => t.score)).toEqual([2, 3, 5]);
+  });
+
+  it("sorts by points descending", () => {
+    const sorted = sortTips([a, c, b], { key: "points", dir: "desc" });
+    expect(sorted.map((t) => t.score)).toEqual([5, 3, 2]);
+  });
+
+  it("sorts by date ascending", () => {
+    const sorted = sortTips([b, a, c], { key: "date", dir: "asc" });
+    expect(sorted.map((t) => t.date)).toEqual([100, 200, 300]);
+  });
+
+  it("sorts by date descending", () => {
+    const sorted = sortTips([a, c, b], { key: "date", dir: "desc" });
+    expect(sorted.map((t) => t.date)).toEqual([300, 200, 100]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [b, a, c];
+    sortTips(input, { key: "points", dir: "asc" });
+    expect(input).toEqual([b, a, c]);
+  });
+
+  it("compareTips returns expected sign for points desc", () => {
+    expect(compareTips(b, a, { key: "points", dir: "desc" })).toBeLessThan(0);
+  });
+
+  it("default sort is date descending", () => {
+    expect(DEFAULT_SORT).toEqual({ key: "date", dir: "desc" });
+    const sorted = sortTips([a, c, b], DEFAULT_SORT);
+    expect(sorted.map((t) => t.date)).toEqual([300, 200, 100]);
+  });
+});
+
+describe("toggleSort", () => {
+  it("flips direction when key is unchanged", () => {
+    const start: SortState = { key: "date", dir: "desc" };
+    expect(toggleSort(start, "date")).toEqual({ key: "date", dir: "asc" });
+    expect(toggleSort({ key: "date", dir: "asc" }, "date")).toEqual({
+      key: "date",
+      dir: "desc",
+    });
+  });
+
+  it("switches to a new key defaulting to desc", () => {
+    expect(toggleSort({ key: "date", dir: "asc" }, "points")).toEqual({
+      key: "points",
+      dir: "desc",
+    });
+  });
+});
+
+describe("pagination helpers", () => {
+  it("isPaginated is true only above 30 entries", () => {
+    expect(isPaginated(30)).toBe(false);
+    expect(isPaginated(31)).toBe(true);
+    expect(isPaginated(0)).toBe(false);
+  });
+
+  it("pageCount computes ceil over page size", () => {
+    expect(pageCount(0)).toBe(1);
+    expect(pageCount(20)).toBe(1);
+    expect(pageCount(21)).toBe(2);
+    expect(pageCount(40)).toBe(2);
+    expect(pageCount(41)).toBe(3);
+  });
+
+  it("paginate slices the requested page", () => {
+    const items = Array.from({ length: 45 }, (_, i) => i);
+    expect(paginate(items, 1)).toEqual(items.slice(0, PAGE_SIZE));
+    expect(paginate(items, 2)).toEqual(items.slice(PAGE_SIZE, PAGE_SIZE * 2));
+    expect(paginate(items, 3)).toEqual(items.slice(PAGE_SIZE * 2));
+  });
+
+  it("paginate returns empty for out-of-range page", () => {
+    expect(paginate([1, 2, 3], 5)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Background

On a user's profile the prediction history listed every match at once, which became long and hard to scan for users with many predictions.

## What this changes

The prediction history can now be sorted by points or by date (newest first by default, click to flip direction), filtered by tapping the Exact / Difference / Winner stat tiles, and is paged when there are more than 30 entries. Filtering, sorting and paging work together, and the active filter is clearly marked with a one-tap way to clear it.