### PR TITLE
FE-046: auto-refresh while matches are live

### DIFF
--- a/app/(app)/match/[id]/page.tsx
+++ b/app/(app)/match/[id]/page.tsx
@@ -5,6 +5,7 @@ import { getMatchById } from "@/lib/match";
 import { fetchApi } from "@/lib/api";
 import { TopAppBar } from "@/components/dashboard/TopAppBar";
 import { BottomNav } from "@/components/dashboard/BottomNav";
+import { LiveRefresher } from "@/components/dashboard/LiveRefresher";
 import { MatchHeader } from "@/components/match/MatchHeader";
 import {
   PredictionsTable,
@@ -128,11 +129,17 @@ export default async function MatchDetailPage({
   const predictions = await loadPredictions(matchId);
   const status = match.status;
   const isScheduled = status !== "IN_PLAY" && status !== "FINISHED";
+  const isLive = status === "IN_PLAY" || status === "PAUSED";
+  const nextKickoff =
+    !isLive && status !== "FINISHED" && match.utcDate.getTime() > Date.now()
+      ? match.utcDate.getTime()
+      : null;
   const t = await getTranslations("Match");
 
   return (
     <>
       <TopAppBar active="dashboard" />
+      <LiveRefresher isLive={isLive} nextKickoff={nextKickoff} />
       <main className="pt-4 md:pt-24 pb-24 md:pb-8 px-margin-mobile md:px-margin-desktop max-w-(--container-max-desktop) mx-auto">
         <MatchHeader match={match} liveMinute={null} />
 

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from "next/navigation";
 import { getCurrentSession } from "@/lib/session";
-import { getLiveMatches, getUpcomingMatches } from "@/lib/match";
+import { getLiveMatches, getUpcomingMatches, getLiveState } from "@/lib/match";
 import { getTipByUserAndMatchIds, type TipRow } from "@/lib/tip";
 import { getUserAvatarsByIds } from "@/lib/user";
 import { fetchApi } from "@/lib/api";
@@ -10,6 +10,7 @@ import { UpcomingList } from "@/components/dashboard/UpcomingList";
 import { RankingSidebar } from "@/components/dashboard/RankingSidebar";
 import { BottomNav } from "@/components/dashboard/BottomNav";
 import { TopAppBar } from "@/components/dashboard/TopAppBar";
+import { LiveRefresher } from "@/components/dashboard/LiveRefresher";
 
 async function loadRating(): Promise<RatingResponse | null> {
   try {
@@ -30,10 +31,11 @@ export default async function DashboardPage(): Promise<React.ReactElement> {
   }
   const userId = Number(user.id);
 
-  const [liveMatches, upcomingMatches, rating] = await Promise.all([
+  const [liveMatches, upcomingMatches, rating, liveState] = await Promise.all([
     getLiveMatches(),
     getUpcomingMatches(),
     loadRating(),
+    getLiveState(),
   ]);
 
   const allMatchIds = [
@@ -62,6 +64,10 @@ export default async function DashboardPage(): Promise<React.ReactElement> {
   return (
     <>
       <TopAppBar active="dashboard" />
+      <LiveRefresher
+        isLive={liveState.isLive}
+        nextKickoff={liveState.nextKickoff}
+      />
       <main className="pt-4 md:pt-24 pb-24 md:pb-8 px-margin-mobile md:px-margin-desktop max-w-(--container-max-desktop) mx-auto grid grid-cols-12 gap-lg">
         <div className="col-span-12 min-[980px]:col-span-8 space-y-lg">
           <LiveBlock matches={liveMatches} tipsByMatchId={tipsByMatchId} />

--- a/components/dashboard/LiveRefresher.tsx
+++ b/components/dashboard/LiveRefresher.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+interface LiveRefresherProps {
+  isLive: boolean;
+  nextKickoff: number | null;
+  intervalMs?: number;
+}
+
+const DEFAULT_INTERVAL_MS = 60000;
+
+export function LiveRefresher({
+  isLive,
+  nextKickoff,
+  intervalMs = DEFAULT_INTERVAL_MS,
+}: LiveRefresherProps): React.ReactElement | null {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isLive && nextKickoff === null) {
+      return;
+    }
+
+    let pollId: ReturnType<typeof setInterval> | null = null;
+    let kickoffTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const startPolling = (): void => {
+      if (pollId === null) {
+        pollId = setInterval(() => router.refresh(), intervalMs);
+      }
+    };
+
+    if (isLive) {
+      startPolling();
+    } else if (nextKickoff !== null) {
+      const delay = nextKickoff - Date.now();
+      if (delay <= 0) {
+        router.refresh();
+      } else {
+        kickoffTimer = setTimeout(() => {
+          startPolling();
+          router.refresh();
+        }, delay);
+      }
+    }
+
+    const onActive = (): void => {
+      if (document.visibilityState === "visible") {
+        router.refresh();
+      }
+    };
+
+    document.addEventListener("visibilitychange", onActive);
+    window.addEventListener("focus", onActive);
+
+    return () => {
+      if (pollId !== null) clearInterval(pollId);
+      if (kickoffTimer !== null) clearTimeout(kickoffTimer);
+      document.removeEventListener("visibilitychange", onActive);
+      window.removeEventListener("focus", onActive);
+    };
+  }, [isLive, nextKickoff, intervalMs, router]);
+
+  return null;
+}

--- a/lib/match.ts
+++ b/lib/match.ts
@@ -1,4 +1,4 @@
-import { and, eq, gte } from "drizzle-orm";
+import { and, asc, eq, gte, inArray } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { match } from "@/db/schema";
 import { formatDateKey } from "@/lib/format";
@@ -57,6 +57,29 @@ export async function getUpcomingMatches(): Promise<MatchRow[]> {
     .map(rowToMatch)
     .filter((m): m is MatchRow => m !== null)
     .sort((a, b) => a.utcDate.getTime() - b.utcDate.getTime());
+}
+
+export interface LiveState {
+  isLive: boolean;
+  nextKickoff: number | null;
+}
+
+export async function getLiveState(): Promise<LiveState> {
+  const liveRows = await db
+    .select({ id: match.id })
+    .from(match)
+    .where(inArray(match.status, ["IN_PLAY", "PAUSED"]));
+  const now = new Date();
+  const upcoming = await db
+    .select({ utcDate: match.utcDate })
+    .from(match)
+    .where(and(eq(match.status, "SCHEDULED"), gte(match.utcDate, now)))
+    .orderBy(asc(match.utcDate))
+    .limit(1);
+  return {
+    isLive: liveRows.length > 0,
+    nextKickoff: upcoming[0] ? upcoming[0].utcDate.getTime() : null,
+  };
 }
 
 export async function getMatchById(id: number): Promise<MatchRow | null> {


### PR DESCRIPTION
## Background

While a match is in play the score and the resulting ranking points change roughly every minute. Until now users had to reload the page themselves to see updated scores and standings.

## What this changes

The dashboard ranking and the match detail page now refresh on their own while at least one match is live, so scores and points update without any manual reload. When nothing is live there is no background activity; if a match is about to kick off the page starts updating automatically at kickoff, and bringing the app back to the foreground refreshes it immediately. This works both in the browser and in the installed app.