### PR TITLE
FE-056: pointer cursor on clickable elements

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -129,6 +129,18 @@ body {
   outline-offset: 2px;
 }
 
+/* Tailwind v4 defaults buttons to cursor:default — restore a pointer for
+   interactive elements (links already use a pointer). */
+@layer base {
+  button:not(:disabled),
+  [role="button"]:not(:disabled),
+  select:not(:disabled),
+  summary,
+  label[for] {
+    cursor: pointer;
+  }
+}
+
 .material-symbols-outlined {
   font-family: "Material Symbols Outlined";
   font-weight: normal;


### PR DESCRIPTION
## Background

After the move to Tailwind CSS v4, buttons no longer showed a hand (pointer) cursor on hover — the framework changed their default cursor — so clickable controls felt unresponsive.

## What this changes

Interactive elements (buttons, role-button elements, selects, summaries and labels) show the pointer cursor again on hover, while disabled controls intentionally do not. This is handled centrally so every clickable control across the app is covered.