### PR TITLE
FE-057: fix department spelling (Maintz to Mainz)

### DIFF
--- a/app/(app)/ranking/page.tsx
+++ b/app/(app)/ranking/page.tsx
@@ -18,7 +18,7 @@ const TAB_BY_PARAM: Record<string, string> = {
   global: "global",
   langenfeld: "Langenfeld",
   mannheim: "Mannheim",
-  mainz: "Maintz",
+  mainz: "Mainz",
 };
 
 async function loadRating(): Promise<RatingResponse | null> {

--- a/lib/data/departments.ts
+++ b/lib/data/departments.ts
@@ -1,7 +1,7 @@
-export const DEPARTMENTS = ["Langenfeld", "Mannheim", "Maintz"] as const;
+export const DEPARTMENTS = ["Langenfeld", "Mannheim", "Mainz"] as const;
 
 export type Department = (typeof DEPARTMENTS)[number];
 
 export function displayDepartment(db: string): string {
-  return db === "Maintz" ? "Mainz" : db;
+  return db;
 }

--- a/scripts/demo_data.ts
+++ b/scripts/demo_data.ts
@@ -45,14 +45,14 @@ const USERS: SeedUser[] = [
   {
     email: "ada.lovelace@local.dev",
     username: "AdaLovelace",
-    department: "Maintz",
+    department: "Mainz",
     winner: "DEU",
     secretWinner: "ESP",
   },
   {
     email: "alan.turing@local.dev",
     username: "AlanTuring",
-    department: "Maintz",
+    department: "Mainz",
     winner: "ENG",
     secretWinner: "FRA",
   },

--- a/tests/unit/departments.test.ts
+++ b/tests/unit/departments.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 import { displayDepartment } from "@/lib/data/departments";
 
 describe("displayDepartment", () => {
-  it("rewrites the misspelled 'Maintz' to 'Mainz'", () => {
-    expect(displayDepartment("Maintz")).toBe("Mainz");
+  it("returns Mainz unchanged", () => {
+    expect(displayDepartment("Mainz")).toBe("Mainz");
   });
 
   it("returns Mannheim unchanged", () => {

--- a/tests/unit/tip-upsert.test.ts
+++ b/tests/unit/tip-upsert.test.ts
@@ -72,7 +72,7 @@ beforeEach(() => {
   sqlite
     .prepare(
       `INSERT INTO user (id, email, password, username, department, winner, secretWinner)
-       VALUES (1, 'u@dev.local', 'x', 'User', 'Maintz', 'DEU', 'ESP')`,
+       VALUES (1, 'u@dev.local', 'x', 'User', 'Mainz', 'DEU', 'ESP')`,
     )
     .run();
   sqlite


### PR DESCRIPTION
## Background

The Mainz department was stored and handled internally under the misspelling "Maintz", a legacy database typo that was only patched at display time. The misspelling could still surface anywhere the raw value was shown.

## What this changes

The department is now consistently named "Mainz" — in the department list, the seed data and the ranking tab routing — and the display-time spelling patch is removed. After reseeding the database, the value reads "Mainz" everywhere.