### PR TITLE
FE-058: app footer with feature overview

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { getCurrentSession } from "@/lib/session";
 import { PageBackground } from "@/components/PageBackground";
+import { Footer } from "@/components/Footer";
 
 export default async function AppLayout({
   children,
@@ -15,6 +16,7 @@ export default async function AppLayout({
     <>
       <PageBackground />
       {children}
+      <Footer />
     </>
   );
 }

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,67 @@
+import { useTranslations } from "next-intl";
+import packageJson from "@/package.json";
+
+const GITHUB_URL = "https://github.com/football-betting";
+
+const FEATURE_KEYS = [
+  "liveScoring",
+  "predicting",
+  "rankings",
+  "pwaOffline",
+  "i18n",
+  "passwordReset",
+  "avatars",
+] as const;
+
+export function Footer(): React.ReactElement {
+  const t = useTranslations("Footer");
+  const tNav = useTranslations("Nav");
+  const year = new Date().getFullYear();
+
+  return (
+    <footer className="w-full bg-surface-container border-t border-outline-variant py-lg mt-xl">
+      <div className="max-w-(--container-max-desktop) mx-auto px-margin-mobile md:px-margin-desktop">
+        <div className="flex flex-col md:flex-row md:items-start justify-between gap-lg">
+          <div className="flex flex-col items-center md:items-start gap-xs">
+            <div className="text-label-caps uppercase text-on-surface-variant">
+              © {year} {tNav("title")}
+            </div>
+            <div className="text-body-sm text-on-surface-variant/60 font-mono">
+              v{packageJson.version}
+            </div>
+          </div>
+
+          <div className="flex flex-col items-center md:items-start gap-xs min-w-0">
+            <div className="text-label-caps uppercase text-on-surface-variant">
+              {t("featuresHeading")}
+            </div>
+            <ul className="flex flex-wrap justify-center md:justify-start gap-x-md gap-y-xs text-body-sm text-on-surface-variant/80">
+              {FEATURE_KEYS.map((key) => (
+                <li key={key}>{t(`features.${key}`)}</li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="flex items-center gap-md">
+            <a
+              aria-label="GitHub"
+              href={GITHUB_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-on-surface-variant hover:text-primary transition-colors"
+            >
+              <svg
+                className="w-6 h-6 fill-current"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.43.372.823 1.102.823 2.222 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+              </svg>
+            </a>
+          </div>
+        </div>
+        <div className="h-16 md:hidden" />
+      </div>
+    </footer>
+  );
+}

--- a/messages/de.json
+++ b/messages/de.json
@@ -7,6 +7,18 @@
     "logout": "Abmelden",
     "settings": "Einstellungen"
   },
+  "Footer": {
+    "featuresHeading": "Funktionen",
+    "features": {
+      "liveScoring": "Live-Scoring",
+      "predicting": "Tippen & Wertung (5/3/2)",
+      "rankings": "Ranglisten (global + Abteilungen)",
+      "pwaOffline": "PWA / Offline",
+      "i18n": "DE / EN",
+      "passwordReset": "Passwort-Reset",
+      "avatars": "Avatare"
+    }
+  },
   "Common": {
     "you": "DU",
     "youParen": " (Du)",

--- a/messages/en.json
+++ b/messages/en.json
@@ -7,6 +7,18 @@
     "logout": "Logout",
     "settings": "Settings"
   },
+  "Footer": {
+    "featuresHeading": "Features",
+    "features": {
+      "liveScoring": "Live scoring",
+      "predicting": "Predictions & scoring (5/3/2)",
+      "rankings": "Rankings (global + departments)",
+      "pwaOffline": "PWA / offline",
+      "i18n": "DE / EN",
+      "passwordReset": "Password reset",
+      "avatars": "Avatars"
+    }
+  },
   "Common": {
     "you": "YOU",
     "youParen": " (You)",


### PR DESCRIPTION
## Background

A footer was designed for the app but not yet built into it. Standard legal/support links (privacy, terms, support) don't apply to this internal tournament tool.

## What this changes

Every signed-in page now has a shared, localized footer showing the app name and version, a short overview of what the app can do (live scoring, predictions, rankings, PWA/offline, languages, password reset, avatars) and a link to the source. The feature overview makes the app's capabilities visible at a glance.