### PR TITLE
FE-059: email reminders for un-predicted matches

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,10 @@ SMTP_SECURE=false
 SMTP_USER=
 SMTP_PASS=
 SMTP_FROM=
+
+# Server-only secret that gates the tip-reminder cron endpoint
+# (/api/cron/notifications, FE-059). The external scheduler must send it as
+# `Authorization: Bearer <secret>` or `X-Cron-Secret: <secret>`. If unset, the
+# endpoint returns 401 for every request — there is no unauthenticated trigger.
+# Real value lives ONLY in the gitignored .env, never commit it.
+CRON_SECRET=

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -6,6 +6,8 @@ import { TopAppBar } from "@/components/dashboard/TopAppBar";
 import { BottomNav } from "@/components/dashboard/BottomNav";
 import { PasswordChangeForm } from "@/components/settings/PasswordChangeForm";
 import { AvatarUpload } from "@/components/settings/AvatarUpload";
+import { ReminderSettings } from "@/components/settings/ReminderSettings";
+import { getEnabledLeadMinutes } from "@/lib/reminder-store";
 
 function LogoutButton({ label }: { label: string }): React.ReactElement {
   return (
@@ -26,6 +28,7 @@ export default async function SettingsPage(): Promise<React.ReactElement> {
     redirect("/login");
   }
   const localUser = await getUserById(Number(user.id));
+  const enabledLeadMinutes = await getEnabledLeadMinutes(Number(user.id));
   const t = await getTranslations("Settings");
 
   return (
@@ -101,12 +104,19 @@ export default async function SettingsPage(): Promise<React.ReactElement> {
             </section>
           </div>
 
-          <div className="lg:col-span-7">
-            <section className="bg-surface-container rounded-lg p-lg border border-outline-variant h-full">
+          <div className="lg:col-span-7 space-y-lg">
+            <section className="bg-surface-container rounded-lg p-lg border border-outline-variant">
               <h2 className="text-label-caps uppercase tracking-widest text-primary mb-lg">
                 {t("security")}
               </h2>
               <PasswordChangeForm />
+            </section>
+
+            <section className="bg-surface-container rounded-lg p-lg border border-outline-variant">
+              <h2 className="text-label-caps uppercase tracking-widest text-primary mb-lg">
+                {t("reminders")}
+              </h2>
+              <ReminderSettings initialLeadMinutes={enabledLeadMinutes} />
             </section>
           </div>
         </div>

--- a/app/api/cron/notifications/route.ts
+++ b/app/api/cron/notifications/route.ts
@@ -1,0 +1,144 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { getUpcomingMatches } from "@/lib/match";
+import {
+  getAllReminderSettings,
+  getSentKeysForMatches,
+  markReminderSent,
+} from "@/lib/reminder-store";
+import { getTipByUserAndMatchIds } from "@/lib/tip";
+import { getUserEmailsByIds } from "@/lib/user";
+import { sendTipReminderEmail } from "@/lib/mail";
+import { dueLeadMinutes, isValidLeadMinutes } from "@/lib/reminders";
+
+export const dynamic = "force-dynamic";
+
+function resolveOrigin(request: NextRequest): string {
+  const configured = process.env.APP_BASE_URL;
+  if (configured) {
+    return configured.replace(/\/+$/, "");
+  }
+  return request.nextUrl.origin;
+}
+
+// The cron endpoint is gated by CRON_SECRET. If the secret is unset OR the
+// request does not present it, return 401 — there is no unauthenticated path.
+function isAuthorized(request: NextRequest): boolean {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) return false;
+  const auth = request.headers.get("authorization");
+  if (auth === `Bearer ${secret}`) return true;
+  const header = request.headers.get("x-cron-secret");
+  return header === secret;
+}
+
+function formatKickoff(utcDate: Date): string {
+  return (
+    utcDate.toLocaleString("de-DE", {
+      weekday: "long",
+      day: "numeric",
+      month: "long",
+      hour: "2-digit",
+      minute: "2-digit",
+      timeZone: "Europe/Berlin",
+    }) + " Uhr"
+  );
+}
+
+async function run(request: NextRequest): Promise<Response> {
+  if (!isAuthorized(request)) {
+    return new Response(JSON.stringify({ error: "unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const now = new Date();
+  const matches = await getUpcomingMatches();
+  if (matches.length === 0) {
+    return NextResponse.json({ sent: 0 });
+  }
+
+  const settings = await getAllReminderSettings();
+  if (settings.length === 0) {
+    return NextResponse.json({ sent: 0 });
+  }
+
+  const matchById = new Map(matches.map((m) => [m.id, m]));
+  const matchIds = matches.map((m) => m.id);
+
+  // Group enabled lead times per user (valid set only).
+  const leadsByUser = new Map<number, number[]>();
+  for (const s of settings) {
+    if (!isValidLeadMinutes(s.leadMinutes)) continue;
+    const list = leadsByUser.get(s.userId) ?? [];
+    list.push(s.leadMinutes);
+    leadsByUser.set(s.userId, list);
+  }
+
+  const userIds = Array.from(leadsByUser.keys());
+  const emailById = await getUserEmailsByIds(userIds);
+  const sentKeys = await getSentKeysForMatches(matchIds);
+
+  const origin = resolveOrigin(request);
+  let sent = 0;
+
+  for (const [userId, leads] of leadsByUser) {
+    const email = emailById.get(userId);
+    if (!email) continue;
+
+    const tips = await getTipByUserAndMatchIds(userId, matchIds);
+    const tippedMatchIds = new Set<number>();
+    for (const t of tips) {
+      if (t.matchId !== null) tippedMatchIds.add(t.matchId);
+    }
+
+    for (const m of matches) {
+      // Scope the dedup keys this user has already consumed.
+      const userSentKeys = new Set<string>();
+      for (const lead of leads) {
+        if (sentKeys.has(`${userId}:${m.id}:${lead}`)) {
+          userSentKeys.add(`${m.id}:${lead}`);
+        }
+      }
+
+      const due = dueLeadMinutes({
+        now,
+        match: { id: m.id, utcDate: m.utcDate, status: m.status },
+        enabledLeadMinutes: leads,
+        tippedMatchIds,
+        sentKeys: userSentKeys,
+      });
+
+      for (const lead of due) {
+        // Reserve the slot first: the unique index makes this the single
+        // source of truth for dedup, so a concurrent run cannot double-send.
+        const reserved = await markReminderSent(userId, m.id, lead, now);
+        if (!reserved) continue;
+
+        const match = matchById.get(m.id);
+        if (!match) continue;
+        const label = `${match.homeTeam.name} – ${match.awayTeam.name}`;
+        try {
+          await sendTipReminderEmail(email, {
+            matchLabel: label,
+            kickoff: formatKickoff(match.utcDate),
+            predictUrl: `${origin}/match/${m.id}`,
+          });
+          sent += 1;
+        } catch (error) {
+          console.error("[cron/notifications] send failed", error);
+        }
+      }
+    }
+  }
+
+  return NextResponse.json({ sent });
+}
+
+export async function POST(request: NextRequest): Promise<Response> {
+  return run(request);
+}
+
+export async function GET(request: NextRequest): Promise<Response> {
+  return run(request);
+}

--- a/app/api/user/reminders/route.ts
+++ b/app/api/user/reminders/route.ts
@@ -1,0 +1,79 @@
+import { getCurrentSession } from "@/lib/session";
+import { replaceLeadMinutes } from "@/lib/reminder-store";
+import { remindersSchema } from "@/lib/validation/reminders";
+import { checkRateLimit, getClientIp } from "@/lib/rate-limit";
+
+function jsonError(message: string, status: number): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+async function readBody(
+  request: Request,
+): Promise<{ leadMinutes: unknown } | null> {
+  try {
+    const body = (await request.json()) as Record<string, unknown>;
+    return { leadMinutes: body.leadMinutes };
+  } catch {
+    return null;
+  }
+}
+
+export async function PUT(request: Request): Promise<Response> {
+  const { user: sessionUser } = await getCurrentSession();
+  if (!sessionUser) {
+    return jsonError("notLoggedIn", 401);
+  }
+
+  const userId = Number(sessionUser.id);
+  if (!Number.isFinite(userId) || userId <= 0) {
+    return jsonError("notLoggedIn", 401);
+  }
+
+  const ip = getClientIp(request.headers);
+  const limit = checkRateLimit(ip, "reminders");
+  if (!limit.ok) {
+    return new Response(JSON.stringify({ error: "tooManyRequests" }), {
+      status: 429,
+      headers: {
+        "Content-Type": "application/json",
+        ...(limit.retryAfter
+          ? { "Retry-After": String(limit.retryAfter) }
+          : {}),
+      },
+    });
+  }
+
+  const raw = await readBody(request);
+  if (!raw) {
+    return jsonError("invalidRequestBody", 400);
+  }
+
+  const parsed = remindersSchema.safeParse(raw);
+  if (!parsed.success) {
+    const first = parsed.error.issues[0];
+    const message = first?.message ?? "invalidInput";
+    return jsonError(message, 400);
+  }
+
+  try {
+    await replaceLeadMinutes(userId, parsed.data.leadMinutes);
+  } catch (error) {
+    console.error("[reminders] update failed", error);
+    return jsonError("failedToUpdateReminders", 500);
+  }
+
+  return new Response(
+    JSON.stringify({ success: true, leadMinutes: parsed.data.leadMinutes }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+}
+
+export function GET(): Response {
+  return new Response(null, { status: 405, headers: { Allow: "PUT" } });
+}

--- a/components/settings/ReminderSettings.tsx
+++ b/components/settings/ReminderSettings.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { REMINDER_LEAD_MINUTES } from "@/lib/reminders";
+import { extractErrorKey } from "@/lib/error-message";
+
+interface ReminderSettingsProps {
+  initialLeadMinutes: number[];
+}
+
+export function ReminderSettings({
+  initialLeadMinutes,
+}: ReminderSettingsProps): React.ReactElement {
+  const t = useTranslations("Settings");
+  const tErrors = useTranslations("Errors");
+  const [selected, setSelected] = useState<Set<number>>(
+    () => new Set(initialLeadMinutes),
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+  const [pending, setPending] = useState(false);
+
+  function toggle(lead: number): void {
+    setSuccess(false);
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(lead)) {
+        next.delete(lead);
+      } else {
+        next.add(lead);
+      }
+      return next;
+    });
+  }
+
+  async function onSave(): Promise<void> {
+    setError(null);
+    setSuccess(false);
+    setPending(true);
+    const leadMinutes = REMINDER_LEAD_MINUTES.filter((l) => selected.has(l));
+    try {
+      const res = await fetch("/api/user/reminders", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify({ leadMinutes }),
+      });
+      if (res.ok) {
+        setSuccess(true);
+        return;
+      }
+      let message = t("updateFailed");
+      try {
+        const key = extractErrorKey(await res.json());
+        if (key !== null && tErrors.has(key)) {
+          message = tErrors(key);
+        }
+      } catch {
+        // ignore JSON parse error, fall back to default
+      }
+      setError(message);
+    } catch {
+      setError(t("networkError"));
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <div className="space-y-lg">
+      <p className="text-body-sm text-on-surface-variant">
+        {t("reminderHint")}
+      </p>
+
+      <ul className="space-y-sm">
+        {REMINDER_LEAD_MINUTES.map((lead) => {
+          const checked = selected.has(lead);
+          return (
+            <li key={lead}>
+              <label className="flex items-center justify-between gap-md p-md bg-surface-container-highest border border-outline-variant rounded-lg cursor-pointer">
+                <span className="text-body-lg text-on-surface">
+                  {t(`reminderLead.${lead}`)}
+                </span>
+                <input
+                  type="checkbox"
+                  className="h-5 w-5 accent-primary"
+                  checked={checked}
+                  onChange={() => toggle(lead)}
+                  disabled={pending}
+                />
+              </label>
+            </li>
+          );
+        })}
+      </ul>
+
+      {error ? (
+        <p
+          aria-live="polite"
+          className="text-body-sm text-error border border-error/40 bg-error-container/20 px-md py-sm rounded-lg"
+        >
+          {error}
+        </p>
+      ) : null}
+      {success ? (
+        <p
+          aria-live="polite"
+          className="text-body-sm text-secondary border border-secondary/40 bg-secondary/10 px-md py-sm rounded-lg"
+        >
+          {t("reminderSaved")}
+        </p>
+      ) : null}
+
+      <button
+        type="button"
+        onClick={onSave}
+        disabled={pending}
+        className="w-full bg-primary-container text-on-primary-container font-bold uppercase tracking-tight py-4 rounded-lg hover:brightness-110 active:scale-[0.98] transition-all disabled:opacity-60"
+      >
+        {pending ? (
+          <span className="material-symbols-outlined animate-spin text-[20px] align-middle">
+            progress_activity
+          </span>
+        ) : (
+          t("reminderSave")
+        )}
+      </button>
+    </div>
+  );
+}

--- a/db/migrations/0001_remarkable_living_lightning.sql
+++ b/db/migrations/0001_remarkable_living_lightning.sql
@@ -1,1 +1,20 @@
-CREATE UNIQUE INDEX `tip_user_match_unique` ON `tip` (`user_id`,`match_id`);
+CREATE UNIQUE INDEX `tip_user_match_unique` ON `tip` (`user_id`,`match_id`);--> statement-breakpoint
+CREATE TABLE `reminder_setting` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`user_id` integer NOT NULL,
+	`lead_minutes` integer NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `reminder_setting_user_lead_unique` ON `reminder_setting` (`user_id`,`lead_minutes`);--> statement-breakpoint
+CREATE TABLE `reminder_sent` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`user_id` integer NOT NULL,
+	`match_id` integer NOT NULL,
+	`lead_minutes` integer NOT NULL,
+	`sent_at` integer NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`match_id`) REFERENCES `match`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `reminder_sent_user_match_lead_unique` ON `reminder_sent` (`user_id`,`match_id`,`lead_minutes`);

--- a/db/migrations/meta/0001_snapshot.json
+++ b/db/migrations/meta/0001_snapshot.json
@@ -283,6 +283,142 @@
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "checkConstraints": {}
+    },
+    "reminder_setting": {
+      "name": "reminder_setting",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lead_minutes": {
+          "name": "lead_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reminder_setting_user_lead_unique": {
+          "name": "reminder_setting_user_lead_unique",
+          "columns": [
+            "user_id",
+            "lead_minutes"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "reminder_setting_user_id_user_id_fk": {
+          "name": "reminder_setting_user_id_user_id_fk",
+          "tableFrom": "reminder_setting",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reminder_sent": {
+      "name": "reminder_sent",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lead_minutes": {
+          "name": "lead_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reminder_sent_user_match_lead_unique": {
+          "name": "reminder_sent_user_match_lead_unique",
+          "columns": [
+            "user_id",
+            "match_id",
+            "lead_minutes"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "reminder_sent_user_id_user_id_fk": {
+          "name": "reminder_sent_user_id_user_id_fk",
+          "tableFrom": "reminder_sent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reminder_sent_match_id_match_id_fk": {
+          "name": "reminder_sent_match_id_match_id_fk",
+          "tableFrom": "reminder_sent",
+          "tableTo": "match",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
     }
   },
   "views": {},

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -59,3 +59,39 @@ export const tip = sqliteTable(
     ),
   }),
 );
+
+export const reminderSetting = sqliteTable(
+  "reminder_setting",
+  {
+    id: integer("id", { mode: "number" }).primaryKey({ autoIncrement: true }),
+    userId: integer("user_id")
+      .notNull()
+      .references(() => user.id),
+    leadMinutes: integer("lead_minutes", { mode: "number" }).notNull(),
+  },
+  (table) => ({
+    reminderSettingUserLeadUnique: uniqueIndex(
+      "reminder_setting_user_lead_unique",
+    ).on(table.userId, table.leadMinutes),
+  }),
+);
+
+export const reminderSent = sqliteTable(
+  "reminder_sent",
+  {
+    id: integer("id", { mode: "number" }).primaryKey({ autoIncrement: true }),
+    userId: integer("user_id")
+      .notNull()
+      .references(() => user.id),
+    matchId: integer("match_id")
+      .notNull()
+      .references(() => match.id),
+    leadMinutes: integer("lead_minutes", { mode: "number" }).notNull(),
+    sentAt: integer("sent_at", { mode: "timestamp" }).notNull(),
+  },
+  (table) => ({
+    reminderSentUserMatchLeadUnique: uniqueIndex(
+      "reminder_sent_user_match_lead_unique",
+    ).on(table.userId, table.matchId, table.leadMinutes),
+  }),
+);

--- a/lib/mail.ts
+++ b/lib/mail.ts
@@ -104,6 +104,31 @@ export async function sendMail(message: MailMessage): Promise<void> {
   }
 }
 
+export interface TipReminderDetails {
+  matchLabel: string;
+  kickoff: string;
+  predictUrl: string;
+}
+
+// v1: German email only. Honoring per-user locale is a future enhancement —
+// the active locale lives in a cookie, not on the user row (see FE-059).
+export async function sendTipReminderEmail(
+  to: string,
+  details: TipReminderDetails,
+): Promise<void> {
+  const { matchLabel, kickoff, predictUrl } = details;
+  const subject = `Tipp-Erinnerung: ${matchLabel}`;
+  const text =
+    `Du hast dieses Spiel noch nicht getippt:\n\n` +
+    `${matchLabel}\nAnpfiff: ${kickoff}\n\n` +
+    `Jetzt tippen:\n${predictUrl}\n`;
+  const html =
+    `<p>Du hast dieses Spiel noch nicht getippt:</p>` +
+    `<p><strong>${matchLabel}</strong><br>Anpfiff: ${kickoff}</p>` +
+    `<p><a href="${predictUrl}">Jetzt tippen</a></p>`;
+  await sendMail({ to, subject, text, html });
+}
+
 export async function sendPasswordResetEmail(
   to: string,
   resetUrl: string,

--- a/lib/reminder-store.ts
+++ b/lib/reminder-store.ts
@@ -1,0 +1,108 @@
+import "server-only";
+import { and, eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { reminderSent, reminderSetting } from "@/db/schema";
+
+export interface ReminderSettingRow {
+  userId: number;
+  leadMinutes: number;
+}
+
+export async function getEnabledLeadMinutes(userId: number): Promise<number[]> {
+  const rows = await db
+    .select({ leadMinutes: reminderSetting.leadMinutes })
+    .from(reminderSetting)
+    .where(eq(reminderSetting.userId, userId));
+  return rows.map((r) => r.leadMinutes);
+}
+
+// Replace a user's enabled lead times with the given set (full overwrite).
+export async function replaceLeadMinutes(
+  userId: number,
+  leadMinutes: number[],
+): Promise<void> {
+  const unique = Array.from(new Set(leadMinutes));
+  await db.transaction((tx) => {
+    tx.delete(reminderSetting)
+      .where(eq(reminderSetting.userId, userId))
+      .run();
+    for (const lead of unique) {
+      tx.insert(reminderSetting)
+        .values({ userId, leadMinutes: lead })
+        .run();
+    }
+  });
+}
+
+export async function getAllReminderSettings(): Promise<ReminderSettingRow[]> {
+  const rows = await db
+    .select({
+      userId: reminderSetting.userId,
+      leadMinutes: reminderSetting.leadMinutes,
+    })
+    .from(reminderSetting);
+  return rows.map((r) => ({ userId: r.userId, leadMinutes: r.leadMinutes }));
+}
+
+export async function getSentKeysForMatches(
+  matchIds: number[],
+): Promise<Set<string>> {
+  if (matchIds.length === 0) return new Set();
+  const rows = await db
+    .select({
+      userId: reminderSent.userId,
+      matchId: reminderSent.matchId,
+      leadMinutes: reminderSent.leadMinutes,
+    })
+    .from(reminderSent);
+  const wanted = new Set(matchIds);
+  const keys = new Set<string>();
+  for (const r of rows) {
+    if (wanted.has(r.matchId)) {
+      keys.add(`${r.userId}:${r.matchId}:${r.leadMinutes}`);
+    }
+  }
+  return keys;
+}
+
+// Idempotent insert: the unique index `(user_id, match_id, lead_minutes)` is
+// the dedup safety net. Returns true when a new row was written, false when it
+// already existed (so a concurrent cron run never double-sends).
+export async function markReminderSent(
+  userId: number,
+  matchId: number,
+  leadMinutes: number,
+  sentAt: Date,
+): Promise<boolean> {
+  const inserted = await db
+    .insert(reminderSent)
+    .values({ userId, matchId, leadMinutes, sentAt })
+    .onConflictDoNothing({
+      target: [
+        reminderSent.userId,
+        reminderSent.matchId,
+        reminderSent.leadMinutes,
+      ],
+    })
+    .returning({ id: reminderSent.id });
+  return inserted.length > 0;
+}
+
+export async function hasReminderBeenSent(
+  userId: number,
+  matchId: number,
+  leadMinutes: number,
+): Promise<boolean> {
+  const rows = await db
+    .select({ id: reminderSent.id })
+    .from(reminderSent)
+    .where(
+      and(
+        eq(reminderSent.userId, userId),
+        eq(reminderSent.matchId, matchId),
+        eq(reminderSent.leadMinutes, leadMinutes),
+      ),
+    )
+    .limit(1);
+  return rows.length > 0;
+}

--- a/lib/reminders.ts
+++ b/lib/reminders.ts
@@ -1,0 +1,62 @@
+// Pure, DB-free reminder logic. Kept free of `@/lib/db` / `server-only` so it
+// can be unit-tested and its lead-time constants reused in client components
+// without dragging server-only code into a client bundle.
+
+export const REMINDER_LEAD_MINUTES = [1440, 720, 360, 180, 60] as const;
+
+export type ReminderLeadMinutes = (typeof REMINDER_LEAD_MINUTES)[number];
+
+const LEAD_SET: ReadonlySet<number> = new Set(REMINDER_LEAD_MINUTES);
+
+export function isValidLeadMinutes(value: number): value is ReminderLeadMinutes {
+  return LEAD_SET.has(value);
+}
+
+const SCHEDULED_STATUS = "SCHEDULED";
+
+export interface EligibleMatch {
+  id: number;
+  utcDate: Date;
+  status: string;
+}
+
+export interface EligibilityInput {
+  now: Date;
+  match: EligibleMatch;
+  enabledLeadMinutes: Iterable<number>;
+  tippedMatchIds: ReadonlySet<number>;
+  sentKeys: ReadonlySet<string>;
+}
+
+// Stable key for the `(match_id, lead_minutes)` dedup set the cron passes in,
+// mirroring the `reminder_sent` unique index.
+export function sentKey(matchId: number, leadMinutes: number): string {
+  return `${matchId}:${leadMinutes}`;
+}
+
+// Returns which of the user's enabled lead times are DUE to send now for this
+// match. A lead L is due iff:
+//   - the match is SCHEDULED, and
+//   - now is within the window: utcDate - L <= now < utcDate, and
+//   - the user has NOT tipped the match, and
+//   - (match, L) has not already been sent.
+export function dueLeadMinutes(input: EligibilityInput): number[] {
+  const { now, match, enabledLeadMinutes, tippedMatchIds, sentKeys } = input;
+
+  if (match.status !== SCHEDULED_STATUS) return [];
+  if (tippedMatchIds.has(match.id)) return [];
+
+  const nowMs = now.getTime();
+  const kickoffMs = match.utcDate.getTime();
+  if (nowMs >= kickoffMs) return [];
+
+  const due: number[] = [];
+  for (const lead of enabledLeadMinutes) {
+    if (!isValidLeadMinutes(lead)) continue;
+    const windowStartMs = kickoffMs - lead * 60_000;
+    if (nowMs < windowStartMs) continue;
+    if (sentKeys.has(sentKey(match.id, lead))) continue;
+    due.push(lead);
+  }
+  return due;
+}

--- a/lib/user.ts
+++ b/lib/user.ts
@@ -27,6 +27,23 @@ export async function getUserAvatarsByIds(
   return map;
 }
 
+export async function getUserEmailsByIds(
+  ids: number[],
+): Promise<Map<number, string>> {
+  const map = new Map<number, string>();
+  if (ids.length === 0) {
+    return map;
+  }
+  const rows = await db
+    .select({ id: user.id, email: user.email })
+    .from(user)
+    .where(inArray(user.id, ids));
+  for (const row of rows) {
+    map.set(row.id, row.email);
+  }
+  return map;
+}
+
 export async function getUserByEmail(
   email: string,
 ): Promise<DatabaseUser | undefined> {

--- a/lib/validation/reminders.ts
+++ b/lib/validation/reminders.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+import { REMINDER_LEAD_MINUTES, isValidLeadMinutes } from "@/lib/reminders";
+
+export const remindersSchema = z.object({
+  leadMinutes: z
+    .array(
+      z
+        .number()
+        .int()
+        .refine(isValidLeadMinutes, { message: "invalidInput" }),
+    )
+    .max(REMINDER_LEAD_MINUTES.length, { message: "invalidInput" }),
+});
+
+export type RemindersInput = z.infer<typeof remindersSchema>;

--- a/messages/de.json
+++ b/messages/de.json
@@ -208,7 +208,18 @@
     "networkError": "Netzwerkfehler. Bitte erneut versuchen.",
     "logout": "Abmelden",
     "logoutHeading": "Von diesem Gerät abmelden",
-    "logoutHint": "Deine aktuelle Sitzung wird sofort beendet."
+    "logoutHint": "Deine aktuelle Sitzung wird sofort beendet.",
+    "reminders": "Erinnerungen",
+    "reminderHint": "Wir erinnern dich per E-Mail an Spiele, die du noch nicht getippt hast. Wähle, wie lange vor Anpfiff.",
+    "reminderLead": {
+      "1440": "1 Tag vorher",
+      "720": "12 Stunden vorher",
+      "360": "6 Stunden vorher",
+      "180": "3 Stunden vorher",
+      "60": "1 Stunde vorher"
+    },
+    "reminderSave": "Erinnerungen speichern",
+    "reminderSaved": "Erinnerungen gespeichert."
   },
   "Errors": {
     "invalidEmail": "Ungültige E-Mail-Adresse",
@@ -236,6 +247,7 @@
     "failedToUpdatePassword": "Passwort konnte nicht aktualisiert werden.",
     "picksLocked": "Das Turnier hat bereits begonnen — die Auswahl ist gesperrt.",
     "failedToUpdateWinners": "Sieger konnten nicht aktualisiert werden.",
+    "failedToUpdateReminders": "Erinnerungen konnten nicht aktualisiert werden.",
     "noFileProvided": "Keine Datei ausgewählt.",
     "imageTooLarge": "Bild ist zu groß.",
     "unsupportedImageType": "Nicht unterstützter Bildtyp.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -208,7 +208,18 @@
     "networkError": "Network error. Try again.",
     "logout": "Logout",
     "logoutHeading": "Logout from this device",
-    "logoutHint": "Your current session will be terminated immediately."
+    "logoutHint": "Your current session will be terminated immediately.",
+    "reminders": "Reminders",
+    "reminderHint": "We email you about matches you have not predicted yet. Choose how long before kickoff.",
+    "reminderLead": {
+      "1440": "1 day before",
+      "720": "12 hours before",
+      "360": "6 hours before",
+      "180": "3 hours before",
+      "60": "1 hour before"
+    },
+    "reminderSave": "Save reminders",
+    "reminderSaved": "Reminders saved."
   },
   "Errors": {
     "invalidEmail": "Invalid email",
@@ -236,6 +247,7 @@
     "failedToUpdatePassword": "Failed to update password.",
     "picksLocked": "Tournament has already started — picks are locked.",
     "failedToUpdateWinners": "Failed to update winners.",
+    "failedToUpdateReminders": "Failed to update reminders.",
     "noFileProvided": "No file provided.",
     "imageTooLarge": "Image too large.",
     "unsupportedImageType": "Unsupported image type.",

--- a/tests/unit/reminders.test.ts
+++ b/tests/unit/reminders.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import {
+  REMINDER_LEAD_MINUTES,
+  dueLeadMinutes,
+  isValidLeadMinutes,
+  sentKey,
+} from "@/lib/reminders";
+
+const KICKOFF = new Date("2026-06-01T20:00:00.000Z");
+
+function matchAt(date: Date, status = "SCHEDULED") {
+  return { id: 42, utcDate: date, status };
+}
+
+describe("isValidLeadMinutes", () => {
+  it("accepts only members of the fixed lead set", () => {
+    for (const lead of REMINDER_LEAD_MINUTES) {
+      expect(isValidLeadMinutes(lead)).toBe(true);
+    }
+    expect(isValidLeadMinutes(15)).toBe(false);
+    expect(isValidLeadMinutes(0)).toBe(false);
+  });
+});
+
+describe("dueLeadMinutes", () => {
+  const enabled = [720, 60];
+  const noTips = new Set<number>();
+  const noSent = new Set<string>();
+
+  it("returns leads whose window has opened (due)", () => {
+    // 90 min before kickoff: the 720 (12h) window is open, the 60 is not yet.
+    const now = new Date(KICKOFF.getTime() - 90 * 60_000);
+    const due = dueLeadMinutes({
+      now,
+      match: matchAt(KICKOFF),
+      enabledLeadMinutes: enabled,
+      tippedMatchIds: noTips,
+      sentKeys: noSent,
+    });
+    expect(due).toEqual([720]);
+  });
+
+  it("opens a lead window exactly at utcDate - lead (inclusive)", () => {
+    const now = new Date(KICKOFF.getTime() - 60 * 60_000);
+    const due = dueLeadMinutes({
+      now,
+      match: matchAt(KICKOFF),
+      enabledLeadMinutes: [60],
+      tippedMatchIds: noTips,
+      sentKeys: noSent,
+    });
+    expect(due).toEqual([60]);
+  });
+
+  it("returns nothing before any window opens (not yet in window)", () => {
+    // 13h before kickoff: even the 12h window has not opened.
+    const now = new Date(KICKOFF.getTime() - 13 * 60 * 60_000);
+    const due = dueLeadMinutes({
+      now,
+      match: matchAt(KICKOFF),
+      enabledLeadMinutes: enabled,
+      tippedMatchIds: noTips,
+      sentKeys: noSent,
+    });
+    expect(due).toEqual([]);
+  });
+
+  it("returns nothing once the match has started (now >= utcDate)", () => {
+    const now = new Date(KICKOFF.getTime());
+    const due = dueLeadMinutes({
+      now,
+      match: matchAt(KICKOFF),
+      enabledLeadMinutes: enabled,
+      tippedMatchIds: noTips,
+      sentKeys: noSent,
+    });
+    expect(due).toEqual([]);
+  });
+
+  it("returns nothing for a non-SCHEDULED match", () => {
+    const now = new Date(KICKOFF.getTime() - 90 * 60_000);
+    const due = dueLeadMinutes({
+      now,
+      match: matchAt(KICKOFF, "IN_PLAY"),
+      enabledLeadMinutes: enabled,
+      tippedMatchIds: noTips,
+      sentKeys: noSent,
+    });
+    expect(due).toEqual([]);
+  });
+
+  it("returns nothing if the user already tipped the match", () => {
+    const now = new Date(KICKOFF.getTime() - 90 * 60_000);
+    const due = dueLeadMinutes({
+      now,
+      match: matchAt(KICKOFF),
+      enabledLeadMinutes: enabled,
+      tippedMatchIds: new Set([42]),
+      sentKeys: noSent,
+    });
+    expect(due).toEqual([]);
+  });
+
+  it("skips a lead that was already sent (dedup)", () => {
+    const now = new Date(KICKOFF.getTime() - 90 * 60_000);
+    const due = dueLeadMinutes({
+      now,
+      match: matchAt(KICKOFF),
+      enabledLeadMinutes: enabled,
+      tippedMatchIds: noTips,
+      sentKeys: new Set([sentKey(42, 720)]),
+    });
+    expect(due).toEqual([]);
+  });
+
+  it("ignores lead values outside the fixed set", () => {
+    const now = new Date(KICKOFF.getTime() - 90 * 60_000);
+    const due = dueLeadMinutes({
+      now,
+      match: matchAt(KICKOFF),
+      enabledLeadMinutes: [720, 15],
+      tippedMatchIds: noTips,
+      sentKeys: noSent,
+    });
+    expect(due).toEqual([720]);
+  });
+});


### PR DESCRIPTION
## Background

Players had no way to be reminded about matches they had not predicted yet, so it was easy to miss the deadline before kickoff.

## What this changes

In settings, each player can switch on one or more reminder times before kickoff (for example one day, twelve hours, or one hour before). A scheduled background check then emails a player when a match they have not predicted is approaching within one of their chosen windows. Each reminder is sent at most once per match and time window, matches that have already been predicted never trigger one, and the background check can only be run with a configured secret.