### PR TITLE
FE-060: web push reminders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,17 @@ SMTP_FROM=
 # endpoint returns 401 for every request — there is no unauthenticated trigger.
 # Real value lives ONLY in the gitignored .env, never commit it.
 CRON_SECRET=
+
+# Web Push / VAPID (FE-060). Generate the key pair ONCE with:
+#   npx web-push generate-vapid-keys
+# Then store the values in the gitignored .env — never commit the private key.
+#
+# VAPID_PRIVATE_KEY is a SERVER-ONLY SECRET. It must never be prefixed with
+# NEXT_PUBLIC_, never logged, never sent to the browser.
+VAPID_PRIVATE_KEY=
+# Server-only contact subject required by the Web Push spec, e.g. mailto:you@example.com
+VAPID_SUBJECT=
+# The VAPID PUBLIC key. This one is intentionally exposed to the browser — the
+# client needs it as `applicationServerKey` for pushManager.subscribe — so the
+# NEXT_PUBLIC_ prefix is correct and deliberate here (it is NOT a secret).
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -7,7 +7,11 @@ import { BottomNav } from "@/components/dashboard/BottomNav";
 import { PasswordChangeForm } from "@/components/settings/PasswordChangeForm";
 import { AvatarUpload } from "@/components/settings/AvatarUpload";
 import { ReminderSettings } from "@/components/settings/ReminderSettings";
-import { getEnabledLeadMinutes } from "@/lib/reminder-store";
+import { PushToggle } from "@/components/settings/PushToggle";
+import {
+  getEnabledChannels,
+  getEnabledLeadMinutes,
+} from "@/lib/reminder-store";
 
 function LogoutButton({ label }: { label: string }): React.ReactElement {
   return (
@@ -29,6 +33,8 @@ export default async function SettingsPage(): Promise<React.ReactElement> {
   }
   const localUser = await getUserById(Number(user.id));
   const enabledLeadMinutes = await getEnabledLeadMinutes(Number(user.id));
+  const enabledChannels = await getEnabledChannels(Number(user.id));
+  const pushEnabled = enabledChannels.includes("push");
   const t = await getTranslations("Settings");
 
   return (
@@ -117,6 +123,12 @@ export default async function SettingsPage(): Promise<React.ReactElement> {
                 {t("reminders")}
               </h2>
               <ReminderSettings initialLeadMinutes={enabledLeadMinutes} />
+              <div className="mt-lg pt-lg border-t border-outline-variant">
+                <h3 className="text-label-caps uppercase tracking-widest text-on-surface-variant mb-md">
+                  {t("pushHeading")}
+                </h3>
+                <PushToggle initialEnabled={pushEnabled} />
+              </div>
             </section>
           </div>
         </div>

--- a/app/api/cron/notifications/route.ts
+++ b/app/api/cron/notifications/route.ts
@@ -1,14 +1,24 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { getUpcomingMatches } from "@/lib/match";
 import {
+  getAllReminderChannels,
   getAllReminderSettings,
   getSentKeysForMatches,
   markReminderSent,
 } from "@/lib/reminder-store";
+import {
+  deletePushSubscriptionByEndpoint,
+  getPushSubscriptionsByUserIds,
+} from "@/lib/push-store";
 import { getTipByUserAndMatchIds } from "@/lib/tip";
 import { getUserEmailsByIds } from "@/lib/user";
 import { sendTipReminderEmail } from "@/lib/mail";
-import { dueLeadMinutes, isValidLeadMinutes } from "@/lib/reminders";
+import { buildPushPayload, sendPush } from "@/lib/push";
+import {
+  channelsForUser,
+  dueLeadMinutes,
+  isValidLeadMinutes,
+} from "@/lib/reminders";
 
 export const dynamic = "force-dynamic";
 
@@ -79,54 +89,107 @@ async function run(request: NextRequest): Promise<Response> {
   const emailById = await getUserEmailsByIds(userIds);
   const sentKeys = await getSentKeysForMatches(matchIds);
 
+  // Per-channel preferences: email is the default for users with no explicit
+  // channel rows (preserves FE-059 behavior). Push fans out to every stored
+  // device subscription.
+  const channelRows = await getAllReminderChannels();
+  const channelsByUser = new Map<number, string[]>();
+  for (const row of channelRows) {
+    const list = channelsByUser.get(row.userId) ?? [];
+    list.push(row.channel);
+    channelsByUser.set(row.userId, list);
+  }
+  const pushSubsByUser = await getPushSubscriptionsByUserIds(userIds);
+
   const origin = resolveOrigin(request);
   let sent = 0;
 
   for (const [userId, leads] of leadsByUser) {
-    const email = emailById.get(userId);
-    if (!email) continue;
-
     const tips = await getTipByUserAndMatchIds(userId, matchIds);
     const tippedMatchIds = new Set<number>();
     for (const t of tips) {
       if (t.matchId !== null) tippedMatchIds.add(t.matchId);
     }
 
-    for (const m of matches) {
-      // Scope the dedup keys this user has already consumed.
-      const userSentKeys = new Set<string>();
-      for (const lead of leads) {
-        if (sentKeys.has(`${userId}:${m.id}:${lead}`)) {
-          userSentKeys.add(`${m.id}:${lead}`);
+    const channels = channelsForUser(channelsByUser.get(userId) ?? []);
+
+    for (const channel of channels) {
+      // Dedup is per channel: an email send and a push send for the same slot
+      // are tracked independently via the `(user, match, lead, channel)` key.
+      for (const m of matches) {
+        const userSentKeys = new Set<string>();
+        for (const lead of leads) {
+          if (sentKeys.has(`${userId}:${m.id}:${lead}:${channel}`)) {
+            userSentKeys.add(`${m.id}:${lead}`);
+          }
         }
-      }
 
-      const due = dueLeadMinutes({
-        now,
-        match: { id: m.id, utcDate: m.utcDate, status: m.status },
-        enabledLeadMinutes: leads,
-        tippedMatchIds,
-        sentKeys: userSentKeys,
-      });
+        const due = dueLeadMinutes({
+          now,
+          match: { id: m.id, utcDate: m.utcDate, status: m.status },
+          enabledLeadMinutes: leads,
+          tippedMatchIds,
+          sentKeys: userSentKeys,
+        });
 
-      for (const lead of due) {
-        // Reserve the slot first: the unique index makes this the single
-        // source of truth for dedup, so a concurrent run cannot double-send.
-        const reserved = await markReminderSent(userId, m.id, lead, now);
-        if (!reserved) continue;
+        for (const lead of due) {
+          // Reserve the slot first: the unique index makes this the single
+          // source of truth for dedup, so a concurrent run cannot double-send.
+          const reserved = await markReminderSent(
+            userId,
+            m.id,
+            lead,
+            channel,
+            now,
+          );
+          if (!reserved) continue;
 
-        const match = matchById.get(m.id);
-        if (!match) continue;
-        const label = `${match.homeTeam.name} – ${match.awayTeam.name}`;
-        try {
-          await sendTipReminderEmail(email, {
-            matchLabel: label,
-            kickoff: formatKickoff(match.utcDate),
-            predictUrl: `${origin}/match/${m.id}`,
-          });
-          sent += 1;
-        } catch (error) {
-          console.error("[cron/notifications] send failed", error);
+          const match = matchById.get(m.id);
+          if (!match) continue;
+          const label = `${match.homeTeam.name} – ${match.awayTeam.name}`;
+          const kickoff = formatKickoff(match.utcDate);
+          const predictUrl = `${origin}/match/${m.id}`;
+
+          // One channel failing must not halt the batch.
+          if (channel === "email") {
+            const email = emailById.get(userId);
+            if (!email) continue;
+            try {
+              await sendTipReminderEmail(email, {
+                matchLabel: label,
+                kickoff,
+                predictUrl,
+              });
+              sent += 1;
+            } catch (error) {
+              console.error("[cron/notifications] email send failed", error);
+            }
+          } else if (channel === "push") {
+            const subs = pushSubsByUser.get(userId) ?? [];
+            const payload = buildPushPayload({
+              title: "Tipp-Erinnerung",
+              // v1: German push text only, mirroring the email. Per-locale push
+              // copy is a future enhancement (locale lives in a cookie, not on
+              // the user row — see FE-059).
+              body: `Du hast dieses Spiel noch nicht getippt: ${label} — Anpfiff ${kickoff}.`,
+              url: predictUrl,
+            });
+            let delivered = false;
+            for (const sub of subs) {
+              const result = await sendPush(sub, payload);
+              if (result.ok) {
+                delivered = true;
+              } else if (result.gone) {
+                await deletePushSubscriptionByEndpoint(sub.endpoint);
+              } else {
+                console.error(
+                  "[cron/notifications] push send failed",
+                  result.statusCode,
+                );
+              }
+            }
+            if (delivered) sent += 1;
+          }
         }
       }
     }

--- a/app/api/user/push-subscription/route.ts
+++ b/app/api/user/push-subscription/route.ts
@@ -1,0 +1,109 @@
+import { getCurrentSession } from "@/lib/session";
+import {
+  deletePushSubscriptionForUser,
+  savePushSubscription,
+} from "@/lib/push-store";
+import {
+  pushSubscriptionSchema,
+  pushUnsubscribeSchema,
+} from "@/lib/validation/push-subscription";
+import { checkRateLimit, getClientIp } from "@/lib/rate-limit";
+
+function jsonError(message: string, status: number): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function rateLimited(retryAfter?: number): Response {
+  return new Response(JSON.stringify({ error: "tooManyRequests" }), {
+    status: 429,
+    headers: {
+      "Content-Type": "application/json",
+      ...(retryAfter ? { "Retry-After": String(retryAfter) } : {}),
+    },
+  });
+}
+
+async function readJson(request: Request): Promise<unknown> {
+  try {
+    return await request.json();
+  } catch {
+    return null;
+  }
+}
+
+async function requireUserId(): Promise<number | null> {
+  const { user: sessionUser } = await getCurrentSession();
+  if (!sessionUser) return null;
+  const userId = Number(sessionUser.id);
+  if (!Number.isFinite(userId) || userId <= 0) return null;
+  return userId;
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const userId = await requireUserId();
+  if (userId === null) return jsonError("notLoggedIn", 401);
+
+  const ip = getClientIp(request.headers);
+  const limit = checkRateLimit(ip, "push-subscription");
+  if (!limit.ok) return rateLimited(limit.retryAfter);
+
+  const body = await readJson(request);
+  if (body === null) return jsonError("invalidRequestBody", 400);
+
+  const parsed = pushSubscriptionSchema.safeParse(body);
+  if (!parsed.success) {
+    return jsonError(parsed.error.issues[0]?.message ?? "invalidInput", 400);
+  }
+
+  try {
+    await savePushSubscription(
+      userId,
+      {
+        endpoint: parsed.data.endpoint,
+        p256dh: parsed.data.keys.p256dh,
+        auth: parsed.data.keys.auth,
+      },
+      new Date(),
+    );
+  } catch (error) {
+    console.error("[push-subscription] save failed", error);
+    return jsonError("failedToUpdateReminders", 500);
+  }
+
+  return new Response(JSON.stringify({ success: true }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export async function DELETE(request: Request): Promise<Response> {
+  const userId = await requireUserId();
+  if (userId === null) return jsonError("notLoggedIn", 401);
+
+  const ip = getClientIp(request.headers);
+  const limit = checkRateLimit(ip, "push-subscription");
+  if (!limit.ok) return rateLimited(limit.retryAfter);
+
+  const body = await readJson(request);
+  if (body === null) return jsonError("invalidRequestBody", 400);
+
+  const parsed = pushUnsubscribeSchema.safeParse(body);
+  if (!parsed.success) {
+    return jsonError(parsed.error.issues[0]?.message ?? "invalidInput", 400);
+  }
+
+  try {
+    await deletePushSubscriptionForUser(userId, parsed.data.endpoint);
+  } catch (error) {
+    console.error("[push-subscription] delete failed", error);
+    return jsonError("failedToUpdateReminders", 500);
+  }
+
+  return new Response(JSON.stringify({ success: true }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/app/api/user/reminder-channels/route.ts
+++ b/app/api/user/reminder-channels/route.ts
@@ -1,0 +1,67 @@
+import { getCurrentSession } from "@/lib/session";
+import { setChannelEnabled } from "@/lib/reminder-store";
+import { reminderChannelSchema } from "@/lib/validation/reminder-channels";
+import { checkRateLimit, getClientIp } from "@/lib/rate-limit";
+
+function jsonError(message: string, status: number): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+async function readJson(request: Request): Promise<unknown> {
+  try {
+    return await request.json();
+  } catch {
+    return null;
+  }
+}
+
+export async function PUT(request: Request): Promise<Response> {
+  const { user: sessionUser } = await getCurrentSession();
+  if (!sessionUser) return jsonError("notLoggedIn", 401);
+
+  const userId = Number(sessionUser.id);
+  if (!Number.isFinite(userId) || userId <= 0) {
+    return jsonError("notLoggedIn", 401);
+  }
+
+  const ip = getClientIp(request.headers);
+  const limit = checkRateLimit(ip, "reminders");
+  if (!limit.ok) {
+    return new Response(JSON.stringify({ error: "tooManyRequests" }), {
+      status: 429,
+      headers: {
+        "Content-Type": "application/json",
+        ...(limit.retryAfter
+          ? { "Retry-After": String(limit.retryAfter) }
+          : {}),
+      },
+    });
+  }
+
+  const body = await readJson(request);
+  if (body === null) return jsonError("invalidRequestBody", 400);
+
+  const parsed = reminderChannelSchema.safeParse(body);
+  if (!parsed.success) {
+    return jsonError(parsed.error.issues[0]?.message ?? "invalidInput", 400);
+  }
+
+  try {
+    await setChannelEnabled(userId, parsed.data.channel, parsed.data.enabled);
+  } catch (error) {
+    console.error("[reminder-channels] update failed", error);
+    return jsonError("failedToUpdateReminders", 500);
+  }
+
+  return new Response(JSON.stringify({ success: true }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export function GET(): Response {
+  return new Response(null, { status: 405, headers: { Allow: "PUT" } });
+}

--- a/app/sw.ts
+++ b/app/sw.ts
@@ -37,3 +37,73 @@ const serwist = new Serwist({
 });
 
 serwist.addEventListeners();
+
+// Web Push (FE-060). Custom listeners coexist with Serwist's own. The cron
+// sends a JSON body of `{ title, body, url }` (see lib/push.ts).
+interface PushPayload {
+  title: string;
+  body: string;
+  url: string;
+}
+
+function parsePushPayload(data: PushEvent["data"]): PushPayload {
+  const fallback: PushPayload = {
+    title: "Tipp-Erinnerung",
+    body: "",
+    url: "/",
+  };
+  if (!data) return fallback;
+  try {
+    const raw: unknown = data.json();
+    if (raw && typeof raw === "object") {
+      const obj = raw as Record<string, unknown>;
+      return {
+        title: typeof obj.title === "string" ? obj.title : fallback.title,
+        body: typeof obj.body === "string" ? obj.body : fallback.body,
+        url: typeof obj.url === "string" ? obj.url : fallback.url,
+      };
+    }
+  } catch {
+    // Non-JSON payload: fall back to plain text body if present.
+    const text = data.text();
+    if (text) return { ...fallback, body: text };
+  }
+  return fallback;
+}
+
+self.addEventListener("push", (event: PushEvent) => {
+  const payload = parsePushPayload(event.data);
+  event.waitUntil(
+    self.registration.showNotification(payload.title, {
+      body: payload.body,
+      data: { url: payload.url },
+      icon: "/icon/icon-192.png",
+      badge: "/icon/icon-192.png",
+    }),
+  );
+});
+
+self.addEventListener("notificationclick", (event: NotificationEvent) => {
+  event.notification.close();
+  const data = event.notification.data as { url?: unknown } | null;
+  const targetUrl =
+    data && typeof data.url === "string" && data.url.length > 0
+      ? data.url
+      : "/";
+  event.waitUntil(
+    (async () => {
+      const target = new URL(targetUrl, self.location.origin);
+      const clientList = await self.clients.matchAll({
+        type: "window",
+        includeUncontrolled: true,
+      });
+      for (const client of clientList) {
+        if (new URL(client.url).href === target.href && "focus" in client) {
+          await client.focus();
+          return;
+        }
+      }
+      await self.clients.openWindow(target.href);
+    })(),
+  );
+});

--- a/components/settings/PushToggle.tsx
+++ b/components/settings/PushToggle.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { arrayBufferToBase64, urlBase64ToUint8Array } from "@/lib/push-client";
+import { extractErrorKey } from "@/lib/error-message";
+
+interface PushToggleProps {
+  initialEnabled: boolean;
+}
+
+type PushState = "idle" | "working" | "enabled" | "disabled";
+
+function pushSupported(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    "serviceWorker" in navigator &&
+    "PushManager" in window &&
+    "Notification" in window
+  );
+}
+
+export function PushToggle({
+  initialEnabled,
+}: PushToggleProps): React.ReactElement {
+  const t = useTranslations("Settings");
+  const tErrors = useTranslations("Errors");
+  const [enabled, setEnabled] = useState(initialEnabled);
+  const [state, setState] = useState<PushState>(
+    initialEnabled ? "enabled" : "disabled",
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  const vapidKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+
+  function showError(messageOrKey: string): void {
+    const message = tErrors.has(messageOrKey)
+      ? tErrors(messageOrKey)
+      : messageOrKey;
+    setError(message);
+  }
+
+  async function setChannel(enabledValue: boolean): Promise<boolean> {
+    const res = await fetch("/api/user/reminder-channels", {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({ channel: "push", enabled: enabledValue }),
+    });
+    if (res.ok) return true;
+    try {
+      const key = extractErrorKey(await res.json());
+      if (key !== null && tErrors.has(key)) {
+        setError(tErrors(key));
+        return false;
+      }
+    } catch {
+      // fall through
+    }
+    setError(t("pushError"));
+    return false;
+  }
+
+  async function enable(): Promise<void> {
+    setError(null);
+    if (!pushSupported()) {
+      showError(t("pushUnsupported"));
+      return;
+    }
+    if (!vapidKey) {
+      showError(t("pushUnsupported"));
+      return;
+    }
+    setPending(true);
+    setState("working");
+    try {
+      const permission = await Notification.requestPermission();
+      if (permission !== "granted") {
+        setState("disabled");
+        showError(t("pushPermissionDenied"));
+        return;
+      }
+      const reg = await navigator.serviceWorker.ready;
+      const subscription = await reg.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToUint8Array(vapidKey),
+      });
+
+      const json = subscription.toJSON();
+      const res = await fetch("/api/user/push-subscription", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify({
+          endpoint: subscription.endpoint,
+          keys: {
+            p256dh: json.keys?.p256dh ?? arrayBufferToBase64(
+              subscription.getKey("p256dh"),
+            ),
+            auth: json.keys?.auth ?? arrayBufferToBase64(
+              subscription.getKey("auth"),
+            ),
+          },
+        }),
+      });
+      if (!res.ok) {
+        await subscription.unsubscribe().catch(() => undefined);
+        try {
+          const key = extractErrorKey(await res.json());
+          showError(key ?? "pushError");
+        } catch {
+          showError(t("pushError"));
+        }
+        setState("disabled");
+        return;
+      }
+
+      const channelOk = await setChannel(true);
+      if (!channelOk) {
+        setState("disabled");
+        return;
+      }
+      setEnabled(true);
+      setState("enabled");
+    } catch {
+      setState("disabled");
+      showError(t("pushError"));
+    } finally {
+      setPending(false);
+    }
+  }
+
+  async function disable(): Promise<void> {
+    setError(null);
+    setPending(true);
+    setState("working");
+    try {
+      if (pushSupported()) {
+        const reg = await navigator.serviceWorker.ready;
+        const subscription = await reg.pushManager.getSubscription();
+        if (subscription) {
+          await fetch("/api/user/push-subscription", {
+            method: "DELETE",
+            headers: {
+              "Content-Type": "application/json",
+              Accept: "application/json",
+            },
+            body: JSON.stringify({ endpoint: subscription.endpoint }),
+          });
+          await subscription.unsubscribe().catch(() => undefined);
+        }
+      }
+      await setChannel(false);
+      setEnabled(false);
+      setState("disabled");
+    } catch {
+      showError(t("pushError"));
+    } finally {
+      setPending(false);
+    }
+  }
+
+  function onToggle(): void {
+    if (pending) return;
+    if (enabled) {
+      void disable();
+    } else {
+      void enable();
+    }
+  }
+
+  return (
+    <div className="space-y-sm">
+      <label className="flex items-center justify-between gap-md p-md bg-surface-container-highest border border-outline-variant rounded-lg cursor-pointer">
+        <span className="text-body-lg text-on-surface">
+          {t("pushChannel")}
+        </span>
+        <input
+          type="checkbox"
+          className="h-5 w-5 accent-primary"
+          checked={enabled}
+          onChange={onToggle}
+          disabled={pending}
+        />
+      </label>
+      <p className="text-[11px] text-on-surface-variant">{t("pushHint")}</p>
+      {state === "working" ? (
+        <p aria-live="polite" className="text-body-sm text-on-surface-variant">
+          {t("pushWorking")}
+        </p>
+      ) : null}
+      {error ? (
+        <p
+          aria-live="polite"
+          className="text-body-sm text-error border border-error/40 bg-error-container/20 px-md py-sm rounded-lg"
+        >
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/db/migrations/0001_remarkable_living_lightning.sql
+++ b/db/migrations/0001_remarkable_living_lightning.sql
@@ -12,9 +12,29 @@ CREATE TABLE `reminder_sent` (
 	`user_id` integer NOT NULL,
 	`match_id` integer NOT NULL,
 	`lead_minutes` integer NOT NULL,
+	`channel` text NOT NULL,
 	`sent_at` integer NOT NULL,
 	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE no action,
 	FOREIGN KEY (`match_id`) REFERENCES `match`(`id`) ON UPDATE no action ON DELETE no action
 );
 --> statement-breakpoint
-CREATE UNIQUE INDEX `reminder_sent_user_match_lead_unique` ON `reminder_sent` (`user_id`,`match_id`,`lead_minutes`);
+CREATE UNIQUE INDEX `reminder_sent_user_match_lead_channel_unique` ON `reminder_sent` (`user_id`,`match_id`,`lead_minutes`,`channel`);--> statement-breakpoint
+CREATE TABLE `reminder_channel` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`user_id` integer NOT NULL,
+	`channel` text NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `reminder_channel_user_channel_unique` ON `reminder_channel` (`user_id`,`channel`);--> statement-breakpoint
+CREATE TABLE `push_subscription` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`user_id` integer NOT NULL,
+	`endpoint` text NOT NULL,
+	`p256dh` text NOT NULL,
+	`auth` text NOT NULL,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `push_subscription_endpoint_unique` ON `push_subscription` (`endpoint`);

--- a/db/migrations/meta/0001_snapshot.json
+++ b/db/migrations/meta/0001_snapshot.json
@@ -369,6 +369,13 @@
           "notNull": true,
           "autoincrement": false
         },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
         "sent_at": {
           "name": "sent_at",
           "type": "integer",
@@ -378,12 +385,13 @@
         }
       },
       "indexes": {
-        "reminder_sent_user_match_lead_unique": {
-          "name": "reminder_sent_user_match_lead_unique",
+        "reminder_sent_user_match_lead_channel_unique": {
+          "name": "reminder_sent_user_match_lead_channel_unique",
           "columns": [
             "user_id",
             "match_id",
-            "lead_minutes"
+            "lead_minutes",
+            "channel"
           ],
           "isUnique": true
         }
@@ -408,6 +416,134 @@
           "tableTo": "match",
           "columnsFrom": [
             "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reminder_channel": {
+      "name": "reminder_channel",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reminder_channel_user_channel_unique": {
+          "name": "reminder_channel_user_channel_unique",
+          "columns": [
+            "user_id",
+            "channel"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "reminder_channel_user_id_user_id_fk": {
+          "name": "reminder_channel_user_id_user_id_fk",
+          "tableFrom": "reminder_channel",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "push_subscription": {
+      "name": "push_subscription",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "push_subscription_endpoint_unique": {
+          "name": "push_subscription_endpoint_unique",
+          "columns": [
+            "endpoint"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "push_subscription_user_id_user_id_fk": {
+          "name": "push_subscription_user_id_user_id_fk",
+          "tableFrom": "push_subscription",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
           ],
           "columnsTo": [
             "id"

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -87,11 +87,42 @@ export const reminderSent = sqliteTable(
       .notNull()
       .references(() => match.id),
     leadMinutes: integer("lead_minutes", { mode: "number" }).notNull(),
+    channel: text("channel").notNull(),
     sentAt: integer("sent_at", { mode: "timestamp" }).notNull(),
   },
   (table) => ({
-    reminderSentUserMatchLeadUnique: uniqueIndex(
-      "reminder_sent_user_match_lead_unique",
-    ).on(table.userId, table.matchId, table.leadMinutes),
+    reminderSentUserMatchLeadChannelUnique: uniqueIndex(
+      "reminder_sent_user_match_lead_channel_unique",
+    ).on(table.userId, table.matchId, table.leadMinutes, table.channel),
   }),
+);
+
+export const reminderChannel = sqliteTable(
+  "reminder_channel",
+  {
+    id: integer("id", { mode: "number" }).primaryKey({ autoIncrement: true }),
+    userId: integer("user_id")
+      .notNull()
+      .references(() => user.id),
+    channel: text("channel").notNull(),
+  },
+  (table) => ({
+    reminderChannelUserChannelUnique: uniqueIndex(
+      "reminder_channel_user_channel_unique",
+    ).on(table.userId, table.channel),
+  }),
+);
+
+export const pushSubscription = sqliteTable(
+  "push_subscription",
+  {
+    id: integer("id", { mode: "number" }).primaryKey({ autoIncrement: true }),
+    userId: integer("user_id")
+      .notNull()
+      .references(() => user.id),
+    endpoint: text("endpoint").notNull().unique(),
+    p256dh: text("p256dh").notNull(),
+    auth: text("auth").notNull(),
+    createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  },
 );

--- a/lib/push-client.ts
+++ b/lib/push-client.ts
@@ -1,0 +1,28 @@
+// Browser-safe helpers for the push subscribe flow. No server-only imports —
+// this is bundled into the client.
+
+// VAPID public keys are URL-safe base64; `pushManager.subscribe` needs the raw
+// bytes as a Uint8Array for `applicationServerKey`.
+export function urlBase64ToUint8Array(
+  base64String: string,
+): Uint8Array<ArrayBuffer> {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const raw = atob(base64);
+  const buffer = new ArrayBuffer(raw.length);
+  const output = new Uint8Array(buffer);
+  for (let i = 0; i < raw.length; i += 1) {
+    output[i] = raw.charCodeAt(i);
+  }
+  return output;
+}
+
+export function arrayBufferToBase64(buffer: ArrayBuffer | null): string {
+  if (!buffer) return "";
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += 1) {
+    binary += String.fromCharCode(bytes[i] as number);
+  }
+  return btoa(binary);
+}

--- a/lib/push-store.ts
+++ b/lib/push-store.ts
@@ -1,0 +1,83 @@
+import "server-only";
+import { and, eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { pushSubscription } from "@/db/schema";
+
+export interface PushSubscriptionRecord {
+  endpoint: string;
+  p256dh: string;
+  auth: string;
+}
+
+// Upsert by endpoint: a device re-subscribing (e.g. after key rotation) keeps a
+// single row. The endpoint is globally unique, so we also re-tie it to the
+// current session user.
+export async function savePushSubscription(
+  userId: number,
+  sub: PushSubscriptionRecord,
+  createdAt: Date,
+): Promise<void> {
+  await db
+    .insert(pushSubscription)
+    .values({
+      userId,
+      endpoint: sub.endpoint,
+      p256dh: sub.p256dh,
+      auth: sub.auth,
+      createdAt,
+    })
+    .onConflictDoUpdate({
+      target: pushSubscription.endpoint,
+      set: { userId, p256dh: sub.p256dh, auth: sub.auth },
+    })
+    .run();
+}
+
+export async function deletePushSubscriptionForUser(
+  userId: number,
+  endpoint: string,
+): Promise<void> {
+  await db
+    .delete(pushSubscription)
+    .where(
+      and(
+        eq(pushSubscription.userId, userId),
+        eq(pushSubscription.endpoint, endpoint),
+      ),
+    )
+    .run();
+}
+
+// Cron cleanup of a dead endpoint (push service returned 404/410). Not scoped
+// to a user: the endpoint is gone for whoever owned it.
+export async function deletePushSubscriptionByEndpoint(
+  endpoint: string,
+): Promise<void> {
+  await db
+    .delete(pushSubscription)
+    .where(eq(pushSubscription.endpoint, endpoint))
+    .run();
+}
+
+export async function getPushSubscriptionsByUserIds(
+  userIds: number[],
+): Promise<Map<number, PushSubscriptionRecord[]>> {
+  const result = new Map<number, PushSubscriptionRecord[]>();
+  if (userIds.length === 0) return result;
+  const wanted = new Set(userIds);
+  const rows = await db
+    .select({
+      userId: pushSubscription.userId,
+      endpoint: pushSubscription.endpoint,
+      p256dh: pushSubscription.p256dh,
+      auth: pushSubscription.auth,
+    })
+    .from(pushSubscription);
+  for (const r of rows) {
+    if (!wanted.has(r.userId)) continue;
+    const list = result.get(r.userId) ?? [];
+    list.push({ endpoint: r.endpoint, p256dh: r.p256dh, auth: r.auth });
+    result.set(r.userId, list);
+  }
+  return result;
+}

--- a/lib/push.ts
+++ b/lib/push.ts
@@ -1,0 +1,109 @@
+import "server-only";
+import webpush from "web-push";
+import type { PushSubscriptionRecord } from "@/lib/push-store";
+
+export interface PushPayload {
+  title: string;
+  body: string;
+  url: string;
+}
+
+// Pure payload builder — unit-testable without VAPID config or a network. The
+// service worker parses exactly this shape (see app/sw.ts).
+export function buildPushPayload(payload: PushPayload): string {
+  return JSON.stringify({
+    title: payload.title,
+    body: payload.body,
+    url: payload.url,
+  });
+}
+
+interface VapidConfig {
+  subject: string;
+  publicKey: string;
+  privateKey: string;
+}
+
+function readVapidConfig(): VapidConfig {
+  const subject = process.env.VAPID_SUBJECT;
+  const publicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+  const privateKey = process.env.VAPID_PRIVATE_KEY;
+
+  const missing: string[] = [];
+  if (!subject) missing.push("VAPID_SUBJECT");
+  if (!publicKey) missing.push("NEXT_PUBLIC_VAPID_PUBLIC_KEY");
+  if (!privateKey) missing.push("VAPID_PRIVATE_KEY");
+  if (missing.length > 0) {
+    throw new Error(`Web push is not configured: missing ${missing.join(", ")}`);
+  }
+
+  return {
+    subject: subject as string,
+    publicKey: publicKey as string,
+    privateKey: privateKey as string,
+  };
+}
+
+let vapidConfigured = false;
+
+function ensureVapidConfigured(): void {
+  if (vapidConfigured) return;
+  const { subject, publicKey, privateKey } = readVapidConfig();
+  webpush.setVapidDetails(subject, publicKey, privateKey);
+  vapidConfigured = true;
+}
+
+// A push service responds 404/410 when a subscription is permanently gone, so
+// the caller should prune that endpoint from the store.
+export function isGoneStatus(status: number): boolean {
+  return status === 404 || status === 410;
+}
+
+function extractStatusCode(error: unknown): number | null {
+  if (
+    error &&
+    typeof error === "object" &&
+    "statusCode" in error &&
+    typeof (error as { statusCode: unknown }).statusCode === "number"
+  ) {
+    return (error as { statusCode: number }).statusCode;
+  }
+  return null;
+}
+
+export type SendPushResult =
+  | { ok: true }
+  | { ok: false; gone: boolean; statusCode: number | null };
+
+// Sends a single push. Never throws: failures are returned so the cron can keep
+// going through the rest of the batch and prune dead endpoints.
+export async function sendPush(
+  subscription: PushSubscriptionRecord,
+  payload: string,
+): Promise<SendPushResult> {
+  try {
+    ensureVapidConfigured();
+    await webpush.sendNotification(
+      {
+        endpoint: subscription.endpoint,
+        keys: { p256dh: subscription.p256dh, auth: subscription.auth },
+      },
+      payload,
+    );
+    return { ok: true };
+  } catch (error) {
+    const statusCode = extractStatusCode(error);
+    return {
+      ok: false,
+      gone: statusCode !== null && isGoneStatus(statusCode),
+      statusCode,
+    };
+  }
+}
+
+export const _internal = {
+  readVapidConfig,
+  resetVapidConfigured(): void {
+    vapidConfigured = false;
+  },
+};

--- a/lib/reminder-store.ts
+++ b/lib/reminder-store.ts
@@ -1,11 +1,17 @@
 import "server-only";
 import { and, eq } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { reminderSent, reminderSetting } from "@/db/schema";
+import { reminderChannel, reminderSent, reminderSetting } from "@/db/schema";
+import { isValidChannel, type ReminderChannel } from "@/lib/reminders";
 
 export interface ReminderSettingRow {
   userId: number;
   leadMinutes: number;
+}
+
+export interface ReminderChannelRow {
+  userId: number;
+  channel: ReminderChannel;
 }
 
 export async function getEnabledLeadMinutes(userId: number): Promise<number[]> {
@@ -44,6 +50,9 @@ export async function getAllReminderSettings(): Promise<ReminderSettingRow[]> {
   return rows.map((r) => ({ userId: r.userId, leadMinutes: r.leadMinutes }));
 }
 
+// Dedup keys are now scoped per channel: `${user}:${match}:${lead}:${channel}`
+// mirrors the unique index, so an email send and a push send for the same slot
+// are tracked independently.
 export async function getSentKeysForMatches(
   matchIds: number[],
 ): Promise<Set<string>> {
@@ -53,35 +62,39 @@ export async function getSentKeysForMatches(
       userId: reminderSent.userId,
       matchId: reminderSent.matchId,
       leadMinutes: reminderSent.leadMinutes,
+      channel: reminderSent.channel,
     })
     .from(reminderSent);
   const wanted = new Set(matchIds);
   const keys = new Set<string>();
   for (const r of rows) {
     if (wanted.has(r.matchId)) {
-      keys.add(`${r.userId}:${r.matchId}:${r.leadMinutes}`);
+      keys.add(`${r.userId}:${r.matchId}:${r.leadMinutes}:${r.channel}`);
     }
   }
   return keys;
 }
 
-// Idempotent insert: the unique index `(user_id, match_id, lead_minutes)` is
-// the dedup safety net. Returns true when a new row was written, false when it
-// already existed (so a concurrent cron run never double-sends).
+// Idempotent insert: the unique index `(user_id, match_id, lead_minutes,
+// channel)` is the dedup safety net. Returns true when a new row was written,
+// false when it already existed (so a concurrent cron run never double-sends,
+// and email vs push for the same slot dedup independently).
 export async function markReminderSent(
   userId: number,
   matchId: number,
   leadMinutes: number,
+  channel: ReminderChannel,
   sentAt: Date,
 ): Promise<boolean> {
   const inserted = await db
     .insert(reminderSent)
-    .values({ userId, matchId, leadMinutes, sentAt })
+    .values({ userId, matchId, leadMinutes, channel, sentAt })
     .onConflictDoNothing({
       target: [
         reminderSent.userId,
         reminderSent.matchId,
         reminderSent.leadMinutes,
+        reminderSent.channel,
       ],
     })
     .returning({ id: reminderSent.id });
@@ -92,6 +105,7 @@ export async function hasReminderBeenSent(
   userId: number,
   matchId: number,
   leadMinutes: number,
+  channel: ReminderChannel,
 ): Promise<boolean> {
   const rows = await db
     .select({ id: reminderSent.id })
@@ -101,8 +115,65 @@ export async function hasReminderBeenSent(
         eq(reminderSent.userId, userId),
         eq(reminderSent.matchId, matchId),
         eq(reminderSent.leadMinutes, leadMinutes),
+        eq(reminderSent.channel, channel),
       ),
     )
     .limit(1);
   return rows.length > 0;
+}
+
+// Channels a user has explicitly enabled. Email stays the default elsewhere
+// (see `channelsForUser` in the cron) — this returns only stored rows.
+export async function getEnabledChannels(
+  userId: number,
+): Promise<ReminderChannel[]> {
+  const rows = await db
+    .select({ channel: reminderChannel.channel })
+    .from(reminderChannel)
+    .where(eq(reminderChannel.userId, userId));
+  return rows
+    .map((r) => r.channel)
+    .filter((c): c is ReminderChannel => isValidChannel(c));
+}
+
+export async function getAllReminderChannels(): Promise<ReminderChannelRow[]> {
+  const rows = await db
+    .select({
+      userId: reminderChannel.userId,
+      channel: reminderChannel.channel,
+    })
+    .from(reminderChannel);
+  const out: ReminderChannelRow[] = [];
+  for (const r of rows) {
+    if (isValidChannel(r.channel)) {
+      out.push({ userId: r.userId, channel: r.channel });
+    }
+  }
+  return out;
+}
+
+export async function setChannelEnabled(
+  userId: number,
+  channel: ReminderChannel,
+  enabled: boolean,
+): Promise<void> {
+  if (enabled) {
+    await db
+      .insert(reminderChannel)
+      .values({ userId, channel })
+      .onConflictDoNothing({
+        target: [reminderChannel.userId, reminderChannel.channel],
+      })
+      .run();
+  } else {
+    await db
+      .delete(reminderChannel)
+      .where(
+        and(
+          eq(reminderChannel.userId, userId),
+          eq(reminderChannel.channel, channel),
+        ),
+      )
+      .run();
+  }
 }

--- a/lib/reminders.ts
+++ b/lib/reminders.ts
@@ -12,6 +12,33 @@ export function isValidLeadMinutes(value: number): value is ReminderLeadMinutes 
   return LEAD_SET.has(value);
 }
 
+// Delivery channels for a reminder. A lead time decides WHEN to notify; a
+// channel decides HOW. Forward-compatible: adding e.g. "sms" only needs a new
+// member here. "email" is the historical default (FE-059).
+export const REMINDER_CHANNELS = ["email", "push"] as const;
+
+export type ReminderChannel = (typeof REMINDER_CHANNELS)[number];
+
+const CHANNEL_SET: ReadonlySet<string> = new Set(REMINDER_CHANNELS);
+
+export function isValidChannel(value: string): value is ReminderChannel {
+  return CHANNEL_SET.has(value);
+}
+
+// Channels to fan a reminder out to for one user. Email is the historical
+// default (FE-059): a user with lead times but no explicit channel rows still
+// gets email, so existing behavior is preserved. Once the user opts into
+// channels explicitly, exactly those (validated) channels are used.
+export function channelsForUser(
+  enabledChannels: Iterable<string>,
+): ReminderChannel[] {
+  const explicit: ReminderChannel[] = [];
+  for (const c of enabledChannels) {
+    if (isValidChannel(c) && !explicit.includes(c)) explicit.push(c);
+  }
+  return explicit.length > 0 ? explicit : ["email"];
+}
+
 const SCHEDULED_STATUS = "SCHEDULED";
 
 export interface EligibleMatch {

--- a/lib/validation/push-subscription.ts
+++ b/lib/validation/push-subscription.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const pushSubscriptionSchema = z.object({
+  endpoint: z.string().url().max(2048),
+  keys: z.object({
+    p256dh: z.string().min(1).max(512),
+    auth: z.string().min(1).max(512),
+  }),
+});
+
+export type PushSubscriptionInput = z.infer<typeof pushSubscriptionSchema>;
+
+export const pushUnsubscribeSchema = z.object({
+  endpoint: z.string().url().max(2048),
+});
+
+export type PushUnsubscribeInput = z.infer<typeof pushUnsubscribeSchema>;

--- a/lib/validation/reminder-channels.ts
+++ b/lib/validation/reminder-channels.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+import { REMINDER_CHANNELS } from "@/lib/reminders";
+
+export const reminderChannelSchema = z.object({
+  channel: z.enum(REMINDER_CHANNELS),
+  enabled: z.boolean(),
+});
+
+export type ReminderChannelInput = z.infer<typeof reminderChannelSchema>;

--- a/messages/de.json
+++ b/messages/de.json
@@ -219,7 +219,14 @@
       "60": "1 Stunde vorher"
     },
     "reminderSave": "Erinnerungen speichern",
-    "reminderSaved": "Erinnerungen gespeichert."
+    "reminderSaved": "Erinnerungen gespeichert.",
+    "pushHeading": "Push-Benachrichtigungen",
+    "pushChannel": "Push im Browser aktivieren",
+    "pushHint": "Erhalte Erinnerungen als Browser-Benachrichtigung, auch wenn die App nicht geöffnet ist. Funktioniert nur in der installierten App (pnpm build && pnpm start), nicht im Entwicklungsmodus.",
+    "pushWorking": "Wird eingerichtet …",
+    "pushUnsupported": "Push wird von diesem Browser nicht unterstützt.",
+    "pushPermissionDenied": "Benachrichtigungen wurden abgelehnt. Bitte erlaube sie in den Browser-Einstellungen.",
+    "pushError": "Push konnte nicht aktiviert werden. Bitte erneut versuchen."
   },
   "Errors": {
     "invalidEmail": "Ungültige E-Mail-Adresse",

--- a/messages/en.json
+++ b/messages/en.json
@@ -219,7 +219,14 @@
       "60": "1 hour before"
     },
     "reminderSave": "Save reminders",
-    "reminderSaved": "Reminders saved."
+    "reminderSaved": "Reminders saved.",
+    "pushHeading": "Push notifications",
+    "pushChannel": "Enable push in this browser",
+    "pushHint": "Get reminders as a browser notification, even when the app is not open. Works only in the installed app (pnpm build && pnpm start), not in development mode.",
+    "pushWorking": "Setting up …",
+    "pushUnsupported": "Push is not supported by this browser.",
+    "pushPermissionDenied": "Notifications were denied. Please allow them in your browser settings.",
+    "pushError": "Could not enable push. Please try again."
   },
   "Errors": {
     "invalidEmail": "Invalid email",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-dom": "^19.2.6",
     "serwist": "^9.5.11",
     "sharp": "^0.34.5",
+    "web-push": "^3.6.7",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -48,6 +49,7 @@
     "@types/nodemailer": "^8.0.0",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
+    "@types/web-push": "^3.6.4",
     "@vitest/coverage-v8": "^4.1.7",
     "drizzle-kit": "^0.31.10",
     "eslint": "^9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
+      web-push:
+        specifier: ^3.6.7
+        version: 3.6.7
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -72,6 +75,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.0
         version: 19.2.3(@types/react@19.2.15)
+      '@types/web-push':
+        specifier: ^3.6.4
+        version: 3.6.4
       '@vitest/coverage-v8':
         specifier: ^4.1.7
         version: 4.1.7(vitest@4.1.7)
@@ -1653,6 +1659,9 @@ packages:
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
+  '@types/web-push@3.6.4':
+    resolution: {integrity: sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==}
+
   '@typescript-eslint/eslint-plugin@8.60.0':
     resolution: {integrity: sha512-QYb/sa74/s7OKMbACMjrYnGspj9Hs5YI5aaffSL65UfeBUzVzBJfVo3oWSpbzPurvm7yaCCo2Lk7lVj610HqKw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1880,6 +1889,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
@@ -1925,6 +1938,9 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
+
+  asn1.js@5.4.1:
+    resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -1977,6 +1993,9 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  bn.js@4.12.3:
+    resolution: {integrity: sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==}
+
   brace-expansion@1.1.15:
     resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
 
@@ -1992,6 +2011,9 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -2214,6 +2236,9 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   electron-to-chromium@1.5.362:
     resolution: {integrity: sha512-PUY2DrLvkjkUuWqq+KPL2iWshrJsZOcIojzRQ7eXFacc9dWga7MGMJAa15VbiejSZB1PAXaRLAiKgruHP8LB1w==}
@@ -2590,6 +2615,14 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  http_ece@1.2.0:
+    resolution: {integrity: sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==}
+    engines: {node: '>=16'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
   icu-minify@4.13.0:
     resolution: {integrity: sha512-SIFMeUHZJjzS5RvIGvybKvWoHjDm9cGVEs2EpJ8PmywOdJLWyblPm7TdPLLoUtkJtwQD7iGhl2WMptZ+N0on+w==}
 
@@ -2794,6 +2827,12 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -2942,6 +2981,9 @@ packages:
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
+
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -3245,6 +3287,9 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -3614,6 +3659,11 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  web-push@3.6.7:
+    resolution: {integrity: sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==}
+    engines: {node: '>= 16'}
+    hasBin: true
 
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
@@ -4783,6 +4833,10 @@ snapshots:
 
   '@types/trusted-types@2.0.7': {}
 
+  '@types/web-push@3.6.4':
+    dependencies:
+      '@types/node': 22.19.19
+
   '@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -5005,6 +5059,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -5087,6 +5143,13 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  asn1.js@5.4.1:
+    dependencies:
+      bn.js: 4.12.3
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      safer-buffer: 2.1.2
+
   assertion-error@2.0.1: {}
 
   ast-types-flow@0.0.8: {}
@@ -5130,6 +5193,8 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  bn.js@4.12.3: {}
+
   brace-expansion@1.1.15:
     dependencies:
       balanced-match: 1.0.2
@@ -5150,6 +5215,8 @@ snapshots:
       electron-to-chromium: 1.5.362
       node-releases: 2.0.46
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
 
@@ -5281,6 +5348,10 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   electron-to-chromium@1.5.362: {}
 
@@ -5863,6 +5934,15 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  http_ece@1.2.0: {}
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   icu-minify@4.13.0:
     dependencies:
       '@formatjs/icu-messageformat-parser': 3.5.10
@@ -6066,6 +6146,17 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -6189,6 +6280,8 @@ snapshots:
       picomatch: 2.3.2
 
   mimic-response@3.1.0: {}
+
+  minimalistic-assert@1.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -6536,6 +6629,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  safer-buffer@2.1.2: {}
 
   scheduler@0.27.0: {}
 
@@ -6962,6 +7057,16 @@ snapshots:
       '@vitest/coverage-v8': 4.1.7(vitest@4.1.7)
     transitivePeerDependencies:
       - msw
+
+  web-push@3.6.7:
+    dependencies:
+      asn1.js: 5.4.1
+      http_ece: 1.2.0
+      https-proxy-agent: 7.0.6
+      jws: 4.0.1
+      minimist: 1.2.8
+    transitivePeerDependencies:
+      - supports-color
 
   webidl-conversions@4.0.2: {}
 

--- a/tests/unit/push.test.ts
+++ b/tests/unit/push.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { buildPushPayload, isGoneStatus } from "@/lib/push";
+
+describe("buildPushPayload", () => {
+  it("serializes exactly title, body and url for the service worker", () => {
+    const json = buildPushPayload({
+      title: "Tipp-Erinnerung",
+      body: "Du hast dieses Spiel noch nicht getippt.",
+      url: "https://example.com/match/42",
+    });
+    expect(JSON.parse(json)).toEqual({
+      title: "Tipp-Erinnerung",
+      body: "Du hast dieses Spiel noch nicht getippt.",
+      url: "https://example.com/match/42",
+    });
+  });
+});
+
+describe("isGoneStatus", () => {
+  it("treats 404 and 410 as a dead subscription", () => {
+    expect(isGoneStatus(404)).toBe(true);
+    expect(isGoneStatus(410)).toBe(true);
+  });
+
+  it("does not treat other statuses as gone", () => {
+    expect(isGoneStatus(429)).toBe(false);
+    expect(isGoneStatus(500)).toBe(false);
+    expect(isGoneStatus(201)).toBe(false);
+  });
+});

--- a/tests/unit/reminder-channels.test.ts
+++ b/tests/unit/reminder-channels.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  REMINDER_CHANNELS,
+  channelsForUser,
+  isValidChannel,
+} from "@/lib/reminders";
+
+describe("isValidChannel", () => {
+  it("accepts only known channels", () => {
+    for (const c of REMINDER_CHANNELS) {
+      expect(isValidChannel(c)).toBe(true);
+    }
+    expect(isValidChannel("sms")).toBe(false);
+    expect(isValidChannel("")).toBe(false);
+  });
+});
+
+describe("channelsForUser", () => {
+  it("defaults to email when no channels are stored (FE-059 behavior)", () => {
+    expect(channelsForUser([])).toEqual(["email"]);
+  });
+
+  it("returns exactly the explicitly enabled channels", () => {
+    expect(channelsForUser(["push"]).sort()).toEqual(["push"]);
+    expect(channelsForUser(["email", "push"]).sort()).toEqual([
+      "email",
+      "push",
+    ]);
+  });
+
+  it("ignores unknown channels and dedups", () => {
+    expect(channelsForUser(["push", "sms", "push"])).toEqual(["push"]);
+  });
+
+  it("falls back to email if only invalid channels are stored", () => {
+    expect(channelsForUser(["sms"])).toEqual(["email"]);
+  });
+});


### PR DESCRIPTION
## Background

Reminders for un-predicted matches were email-only. Players also wanted to be notified directly on their device, even when the app isn't open.

## What this changes

Players can now turn on push notifications in settings, in addition to email. When a match they haven't predicted is approaching within one of their chosen reminder times, they receive a push notification on their subscribed devices that opens the prediction page when tapped. Email and push are tracked independently, so each reminder is sent at most once per channel, existing email reminders are unaffected, and devices that are no longer reachable are cleaned up automatically.