### PR TITLE
FE-062: invalidate sessions on password reset/change

### DIFF
--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -1,4 +1,5 @@
 import { Argon2id } from "oslo/password";
+import { lucia } from "@/lib/auth";
 import { getClientIp, checkRateLimit } from "@/lib/rate-limit";
 import { updateUserPassword } from "@/lib/user";
 import { resetPasswordSchema } from "@/lib/validation/password";
@@ -87,6 +88,7 @@ export async function POST(request: Request): Promise<Response> {
     const hash = await argon2id.hash(newPassword);
     await updateUserPassword(record.userId, hash);
     await deletePasswordResetTokensForUser(record.userId);
+    await lucia.invalidateUserSessions(String(record.userId));
   } catch (error) {
     console.error("[reset-password] update failed", error);
     return jsonError("failedToUpdatePassword", 500);

--- a/app/api/user/password/route.ts
+++ b/app/api/user/password/route.ts
@@ -1,4 +1,6 @@
+import { cookies } from "next/headers";
 import { Argon2id } from "oslo/password";
+import { lucia, REMEMBER_COOKIE } from "@/lib/auth";
 import { getCurrentSession } from "@/lib/session";
 import { getUserById, updateUserPassword } from "@/lib/user";
 import { changePasswordSchema } from "@/lib/validation/password";
@@ -99,6 +101,18 @@ export async function POST(request: Request): Promise<Response> {
   try {
     const hash = await argon2id.hash(newPassword);
     await updateUserPassword(userId, hash);
+    await lucia.invalidateUserSessions(sessionUser.id);
+
+    const session = await lucia.createSession(sessionUser.id, {});
+    const sessionCookie = lucia.createSessionCookie(session.id);
+    const cookieStore = await cookies();
+    const remembered = cookieStore.get(REMEMBER_COOKIE)?.value === "1";
+    const attributes = { ...sessionCookie.attributes };
+    if (!remembered) {
+      delete attributes.maxAge;
+      delete attributes.expires;
+    }
+    cookieStore.set(sessionCookie.name, sessionCookie.value, attributes);
   } catch (error) {
     console.error("[password] update failed", error);
     return jsonError("failedToUpdatePassword", 500);


### PR DESCRIPTION
## Background

Resetting or changing a password did not end existing logins, so a stolen or hijacked session survived the very action meant to recover the account.

## What this changes

After a password reset, all of that account's sessions are invalidated, so any previously stolen session is forced out and the user signs in fresh. After a self-service password change, other sessions are invalidated while the person making the change stays signed in. This makes password recovery and change actually evict an intruder.