### PR TITLE
FE-063: add HSTS security header

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -30,6 +30,7 @@ const SECURITY_HEADERS: Record<string, string> = {
   "Referrer-Policy": "strict-origin-when-cross-origin",
   "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
   "X-Content-Type-Options": "nosniff",
+  "Strict-Transport-Security": "max-age=63072000; includeSubDomains",
 };
 
 function withSecurityHeaders(res: NextResponse): NextResponse {


### PR DESCRIPTION
## Background

The app already sends a strong set of security headers (a content security policy, anti-clickjacking, no-sniff, referrer and permissions policies) from its edge middleware. The one missing piece was HTTP Strict Transport Security.

## What this changes

Responses now also send a Strict-Transport-Security header, so browsers stick to HTTPS for the site. This completes the security-header set; the existing policies (including the anti-clickjacking frame-ancestors rule) were already in place.