### PR TITLE
FE-064: auth and config hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,23 +1,35 @@
 DATABASE_URL=../shared/db/database.db
 RUST_API_URL=http://localhost:8080
 
-# When set (1 / true / yes), the rate-limiter trusts the first IP in
-# X-Forwarded-For / X-Real-IP as the client address. Leave unset in
-# direct-public deploys — otherwise an attacker can rotate the header
-# per request and bypass the limit. Set only when a trusted reverse
-# proxy strips client-supplied X-Forwarded-For headers.
+# When set (1 / true / yes), the rate-limiter trusts X-Forwarded-For /
+# X-Real-IP for the client address. With a trusted proxy the client IP is
+# taken from the RIGHT of the XFF chain (the entries our own proxies append),
+# never the spoofable leftmost value. Set only behind a reverse proxy that
+# appends a trustworthy X-Forwarded-For. When unset, forwarding headers are
+# treated as best-effort, non-authoritative per-client keys (spoofable, but
+# they avoid collapsing every request into one shared bucket that a single
+# attacker could use to lock out all users).
 TRUST_PROXY=
+
+# Number of trusted reverse-proxy hops in front of the app (default 1). The
+# client IP is read as the Nth X-Forwarded-For entry counted from the right.
+# Only applies when TRUST_PROXY is enabled.
+TRUSTED_PROXY_HOPS=
 
 # DEV / TEST ONLY. When set (1 / true / yes), the rate-limiter
 # disables itself completely. Used by the Playwright suite so the
-# 5/10min/IP limit does not trip after 5 login specs. The server logs
-# a warning if this is ever seen with NODE_ENV=production.
+# 5/10min/IP limit does not trip after 5 login specs. In
+# NODE_ENV=production this flag is IGNORED entirely (rate limiting is
+# always on) and the server logs a warning if it is seen.
 DISABLE_RATE_LIMIT=
 
-# Absolute base URL used to build password-reset links in emails
-# (FE-041). Set this in every real deploy, e.g.
-# https://predictor.example.com — it is the trusted source of the link
-# origin. In local dev it falls back to the request origin.
+# Absolute base URL used to build security-sensitive links: password-reset
+# emails (FE-041) and tip-reminder predict links (FE-059/060). It is the
+# trusted source of the link origin, e.g. https://predictor.example.com. In
+# NODE_ENV=production this is REQUIRED — the app never falls back to the
+# request Host (which is attacker-controllable and would poison the links);
+# reset emails / cron runs fail closed if it is unset. In local dev it falls
+# back to the request origin.
 APP_BASE_URL=
 
 # SMTP mailer for password-reset emails (FE-041). Real values live ONLY

--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -9,18 +9,11 @@ import {
 } from "@/lib/password-reset";
 import { createPasswordResetToken } from "@/lib/password-reset-store";
 import { sendPasswordResetEmail } from "@/lib/mail";
+import { resolveAppOrigin } from "@/lib/app-origin";
 
 const forgotPasswordSchema = z.object({
   email: z.string().email(),
 });
-
-function resolveOrigin(request: NextRequest): string {
-  const configured = process.env.APP_BASE_URL;
-  if (configured) {
-    return configured.replace(/\/+$/, "");
-  }
-  return request.nextUrl.origin;
-}
 
 function genericResponse(): Response {
   return NextResponse.json({ ok: true }, { status: 200 });
@@ -65,25 +58,46 @@ export async function POST(request: NextRequest): Promise<Response> {
 
   const user = await getUserByEmail(parsed.data.email);
 
-  const token = generateResetToken();
-  const tokenHash = hashResetToken(token);
-  const expiresAt = resetTokenExpiry();
+  if (user) {
+    const token = generateResetToken();
+    const tokenHash = hashResetToken(token);
+    const expiresAt = resetTokenExpiry();
+    const origin = resolveAppOrigin(request);
 
-  if (!user) {
-    return genericResponse();
-  }
-
-  try {
-    await createPasswordResetToken(user.id, tokenHash, expiresAt);
-
-    const origin = resolveOrigin(request);
-    const resetUrl = `${origin}/reset-password?token=${token}`;
-    await sendPasswordResetEmail(user.email, resetUrl);
-  } catch (error) {
-    console.error("[forgot-password] failed to issue reset", error);
+    // Decouple the reset issuance from the response: do NOT await it. The
+    // response time is then constant whether or not the user exists, closing
+    // the timing-enumeration side channel. issueReset wraps its whole body in a
+    // try/catch, so the fire-and-forget promise never rejects (no unhandled
+    // rejection).
+    void issueReset(user.id, user.email, token, tokenHash, expiresAt, origin);
   }
 
   return genericResponse();
+}
+
+async function issueReset(
+  userId: number,
+  email: string,
+  token: string,
+  tokenHash: string,
+  expiresAt: Date,
+  origin: string | null,
+): Promise<void> {
+  try {
+    await createPasswordResetToken(userId, tokenHash, expiresAt);
+
+    if (origin === null) {
+      // Production without APP_BASE_URL: do not build a Host-derived link.
+      console.error(
+        "[forgot-password] APP_BASE_URL is unset in production; skipping reset email",
+      );
+      return;
+    }
+    const resetUrl = `${origin}/reset-password?token=${token}`;
+    await sendPasswordResetEmail(email, resetUrl);
+  } catch (error) {
+    console.error("[forgot-password] failed to issue reset", error);
+  }
 }
 
 export function GET(): Response {

--- a/app/api/cron/notifications/route.ts
+++ b/app/api/cron/notifications/route.ts
@@ -1,5 +1,8 @@
+import { createHash, timingSafeEqual } from "node:crypto";
 import { type NextRequest, NextResponse } from "next/server";
 import { getUpcomingMatches } from "@/lib/match";
+import { checkRateLimit } from "@/lib/rate-limit";
+import { resolveAppOrigin } from "@/lib/app-origin";
 import {
   getAllReminderChannels,
   getAllReminderSettings,
@@ -22,12 +25,13 @@ import {
 
 export const dynamic = "force-dynamic";
 
-function resolveOrigin(request: NextRequest): string {
-  const configured = process.env.APP_BASE_URL;
-  if (configured) {
-    return configured.replace(/\/+$/, "");
-  }
-  return request.nextUrl.origin;
+// Constant-time secret comparison. Both sides are SHA-256-hashed first so the
+// buffers are always equal length (32 bytes), avoiding both the early-return
+// timing leak of `===` and the length leak of comparing raw strings.
+function secretMatches(presented: string, secret: string): boolean {
+  const a = createHash("sha256").update(presented).digest();
+  const b = createHash("sha256").update(secret).digest();
+  return timingSafeEqual(a, b);
 }
 
 // The cron endpoint is gated by CRON_SECRET. If the secret is unset OR the
@@ -36,9 +40,12 @@ function isAuthorized(request: NextRequest): boolean {
   const secret = process.env.CRON_SECRET;
   if (!secret) return false;
   const auth = request.headers.get("authorization");
-  if (auth === `Bearer ${secret}`) return true;
+  if (auth?.startsWith("Bearer ")) {
+    return secretMatches(auth.slice("Bearer ".length), secret);
+  }
   const header = request.headers.get("x-cron-secret");
-  return header === secret;
+  if (header) return secretMatches(header, secret);
+  return false;
 }
 
 function formatKickoff(utcDate: Date): string {
@@ -58,6 +65,32 @@ async function run(request: NextRequest): Promise<Response> {
   if (!isAuthorized(request)) {
     return new Response(JSON.stringify({ error: "unauthorized" }), {
       status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  // Coarse guard so a leaked secret cannot hammer the job. The scheduler runs
+  // roughly every ~10 min, well under MAX_ATTEMPTS per window.
+  const limit = checkRateLimit("cron", "cron-notifications");
+  if (!limit.ok) {
+    return new Response(JSON.stringify({ error: "tooManyRequests" }), {
+      status: 429,
+      headers: {
+        "Content-Type": "application/json",
+        ...(limit.retryAfter ? { "Retry-After": String(limit.retryAfter) } : {}),
+      },
+    });
+  }
+
+  const origin = resolveAppOrigin(request);
+  if (origin === null) {
+    // Production without APP_BASE_URL: predict links would be Host-derived.
+    // Fail closed rather than emit poisoned links.
+    console.error(
+      "[cron/notifications] APP_BASE_URL is unset in production; aborting",
+    );
+    return new Response(JSON.stringify({ error: "appBaseUrlUnset" }), {
+      status: 500,
       headers: { "Content-Type": "application/json" },
     });
   }
@@ -101,7 +134,6 @@ async function run(request: NextRequest): Promise<Response> {
   }
   const pushSubsByUser = await getPushSubscriptionsByUserIds(userIds);
 
-  const origin = resolveOrigin(request);
   let sent = 0;
 
   for (const [userId, leads] of leadsByUser) {
@@ -202,6 +234,8 @@ export async function POST(request: NextRequest): Promise<Response> {
   return run(request);
 }
 
-export async function GET(request: NextRequest): Promise<Response> {
-  return run(request);
+// POST-only: a GET would expose the secret in URLs/referrers/logs if a caller
+// ever appended it to the query string.
+export function GET(): Response {
+  return new Response(null, { status: 405, headers: { Allow: "POST" } });
 }

--- a/lib/app-origin.ts
+++ b/lib/app-origin.ts
@@ -1,0 +1,19 @@
+import type { NextRequest } from "next/server";
+
+// Resolve the trusted base URL for building security-sensitive links
+// (password-reset emails, cron predict links). APP_BASE_URL is the single
+// source of truth. In production it is REQUIRED — we never fall back to the
+// request Host, which is attacker-controllable and enables host-poisoning of
+// the generated links. In dev/test the request origin is an acceptable
+// convenience fallback. Returns null when no trusted origin is available
+// (prod without APP_BASE_URL) so callers can fail closed.
+export function resolveAppOrigin(request: NextRequest): string | null {
+  const configured = process.env.APP_BASE_URL;
+  if (configured) {
+    return configured.replace(/\/+$/, "");
+  }
+  if (process.env.NODE_ENV === "production") {
+    return null;
+  }
+  return request.nextUrl.origin;
+}

--- a/lib/push-store.ts
+++ b/lib/push-store.ts
@@ -9,14 +9,32 @@ export interface PushSubscriptionRecord {
   auth: string;
 }
 
-// Upsert by endpoint: a device re-subscribing (e.g. after key rotation) keeps a
-// single row. The endpoint is globally unique, so we also re-tie it to the
-// current session user.
+// Upsert by endpoint. The endpoint is globally unique. A device re-subscribing
+// under the SAME user (e.g. after key rotation) updates its keys in place. If a
+// DIFFERENT user presents an endpoint already owned by someone else, we must
+// NOT silently re-tie it to the caller — that would let an attacker hijack
+// another user's subscription. For the rare genuine device hand-off we drop the
+// old row and insert a fresh one owned by the authenticated caller, so the
+// endpoint is always tied to exactly one (verified) owner.
 export async function savePushSubscription(
   userId: number,
   sub: PushSubscriptionRecord,
   createdAt: Date,
 ): Promise<void> {
+  const existing = await db
+    .select({ userId: pushSubscription.userId })
+    .from(pushSubscription)
+    .where(eq(pushSubscription.endpoint, sub.endpoint))
+    .limit(1);
+
+  const owner = existing[0]?.userId;
+  if (owner !== undefined && owner !== userId) {
+    await db
+      .delete(pushSubscription)
+      .where(eq(pushSubscription.endpoint, sub.endpoint))
+      .run();
+  }
+
   await db
     .insert(pushSubscription)
     .values({
@@ -26,9 +44,13 @@ export async function savePushSubscription(
       auth: sub.auth,
       createdAt,
     })
+    // Scope the conflict update to the caller's own row: an endpoint owned by a
+    // different user was already removed above, so this only ever refreshes the
+    // caller's keys — it never moves ownership.
     .onConflictDoUpdate({
       target: pushSubscription.endpoint,
-      set: { userId, p256dh: sub.p256dh, auth: sub.auth },
+      set: { p256dh: sub.p256dh, auth: sub.auth },
+      setWhere: eq(pushSubscription.userId, userId),
     })
     .run();
 }

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -27,27 +27,32 @@ export interface RateLimitResult {
   retryAfter?: number;
 }
 
-function isRateLimitDisabled(): boolean {
-  const value = process.env.DISABLE_RATE_LIMIT;
-  if (!value) return false;
-  const normalized = value.toLowerCase();
-  return normalized === "1" || normalized === "true" || normalized === "yes";
-}
-
 let warnedAboutProdBypass = false;
 
-export function checkRateLimit(ip: string, bucket: string): RateLimitResult {
-  if (isRateLimitDisabled()) {
-    if (
-      process.env.NODE_ENV === "production" &&
-      !warnedAboutProdBypass
-    ) {
+function isRateLimitDisabled(): boolean {
+  const value = process.env.DISABLE_RATE_LIMIT;
+  const enabled =
+    !!value &&
+    ["1", "true", "yes"].includes(value.toLowerCase());
+
+  // In production the bypass is ignored entirely: rate limiting is always on,
+  // regardless of the env var. The dev/test bypass still works elsewhere.
+  if (process.env.NODE_ENV === "production") {
+    if (enabled && !warnedAboutProdBypass) {
       console.warn(
-        "[rate-limit] DISABLE_RATE_LIMIT is set in NODE_ENV=production. " +
-          "This is a dev/test bypass and MUST NOT be enabled in production.",
+        "[rate-limit] DISABLE_RATE_LIMIT is set in NODE_ENV=production and " +
+          "is being IGNORED. This is a dev/test-only bypass.",
       );
       warnedAboutProdBypass = true;
     }
+    return false;
+  }
+
+  return enabled;
+}
+
+export function checkRateLimit(ip: string, bucket: string): RateLimitResult {
+  if (isRateLimitDisabled()) {
     return { ok: true };
   }
 
@@ -93,16 +98,51 @@ function isTrustProxy(): boolean {
   return normalized === "1" || normalized === "true" || normalized === "yes";
 }
 
+// Number of trusted reverse-proxy hops in front of the app. With N trusted
+// hops, the client IP is the Nth entry counted from the RIGHT of
+// X-Forwarded-For (the rightmost entries are appended by our own proxies and
+// cannot be spoofed; everything to the left is client-supplied). Defaults to 1
+// (a single trusted proxy → the last XFF entry is the real client).
+function trustedProxyHops(): number {
+  const raw = process.env.TRUSTED_PROXY_HOPS;
+  if (!raw) return 1;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n >= 1 ? n : 1;
+}
+
+function parseXff(headers: Headers): string[] {
+  const xff = headers.get("x-forwarded-for");
+  if (!xff) return [];
+  return xff
+    .split(",")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+}
+
 export function getClientIp(headers: Headers): string {
   if (isTrustProxy()) {
-    const xff = headers.get("x-forwarded-for");
-    if (xff) {
-      const first = xff.split(",")[0]?.trim();
-      if (first) return first;
+    const chain = parseXff(headers);
+    if (chain.length > 0) {
+      // Take the Nth-from-the-right entry — the leftmost is spoofable.
+      const idx = chain.length - trustedProxyHops();
+      const ip = chain[Math.max(0, idx)];
+      if (ip) return ip;
     }
     const real = headers.get("x-real-ip");
     if (real) return real.trim();
+    return "unknown";
   }
+
+  // No trusted proxy: client-supplied headers are NOT authoritative, but
+  // collapsing every request into one shared "unknown" bucket would let a
+  // single attacker lock out all users (global DoS). To avoid that, derive a
+  // best-effort per-client key from whatever forwarding header is present.
+  // This is spoofable (a rate-limit is only one defense layer) but it removes
+  // the global-lockout footgun. The "untrusted:" prefix keeps these buckets
+  // from ever colliding with trusted-proxy identities.
+  const chain = parseXff(headers);
+  const candidate = chain[0] ?? headers.get("x-real-ip")?.trim();
+  if (candidate) return `untrusted:${candidate}`;
   return "unknown";
 }
 

--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -81,18 +81,23 @@ describe("getClientIp", () => {
     }
   });
 
-  it("ignores x-forwarded-for when TRUST_PROXY is unset", () => {
+  it("derives a per-client untrusted key from XFF when TRUST_PROXY is unset", () => {
     delete process.env.TRUST_PROXY;
     expect(getClientIp(headers({ "x-forwarded-for": "1.2.3.4" }))).toBe(
-      "unknown",
+      "untrusted:1.2.3.4",
     );
   });
 
-  it("ignores x-forwarded-for when TRUST_PROXY is '0'", () => {
+  it("derives a per-client untrusted key from XFF when TRUST_PROXY is '0'", () => {
     process.env.TRUST_PROXY = "0";
     expect(getClientIp(headers({ "x-forwarded-for": "1.2.3.4" }))).toBe(
-      "unknown",
+      "untrusted:1.2.3.4",
     );
+  });
+
+  it("returns 'unknown' when untrusted and no forwarding headers present", () => {
+    delete process.env.TRUST_PROXY;
+    expect(getClientIp(headers({}))).toBe("unknown");
   });
 
   it("honors x-forwarded-for when TRUST_PROXY=1", () => {
@@ -102,11 +107,22 @@ describe("getClientIp", () => {
     );
   });
 
-  it("honors x-forwarded-for when TRUST_PROXY=true", () => {
+  it("takes the rightmost (trusted) XFF entry for the default single hop", () => {
     process.env.TRUST_PROXY = "true";
+    delete process.env.TRUSTED_PROXY_HOPS;
     expect(getClientIp(headers({ "x-forwarded-for": "1.2.3.4, 5.6.7.8" }))).toBe(
-      "1.2.3.4",
+      "5.6.7.8",
     );
+  });
+
+  it("honors TRUSTED_PROXY_HOPS by counting from the right", () => {
+    process.env.TRUST_PROXY = "1";
+    process.env.TRUSTED_PROXY_HOPS = "2";
+    expect(
+      getClientIp(
+        headers({ "x-forwarded-for": "9.9.9.9, 1.2.3.4, 5.6.7.8" }),
+      ),
+    ).toBe("1.2.3.4");
   });
 
   it("falls back to x-real-ip when TRUST_PROXY=1 and no x-forwarded-for", () => {
@@ -118,9 +134,13 @@ describe("getClientIp", () => {
     process.env.TRUST_PROXY = "1";
     expect(getClientIp(headers({}))).toBe("unknown");
   });
+
+  afterEach(() => {
+    delete process.env.TRUSTED_PROXY_HOPS;
+  });
 });
 
-describe("spoofed X-Forwarded-For without TRUST_PROXY does not bypass limit", () => {
+describe("untrusted IP handling avoids a global-lockout bucket", () => {
   const originalTrustProxy = process.env.TRUST_PROXY;
 
   beforeEach(() => {
@@ -136,12 +156,21 @@ describe("spoofed X-Forwarded-For without TRUST_PROXY does not bypass limit", ()
     }
   });
 
-  it("100 requests with rotating fake XFF all bucket under 'unknown'", () => {
+  it("one client exhausting its limit does NOT lock out a different client", () => {
+    const attacker = getClientIp(headers({ "x-forwarded-for": "10.0.0.1" }));
+    for (let i = 0; i < _internal.MAX_ATTEMPTS; i += 1) {
+      checkRateLimit(attacker, "login");
+    }
+    expect(checkRateLimit(attacker, "login").ok).toBe(false);
+
+    const victim = getClientIp(headers({ "x-forwarded-for": "10.0.0.2" }));
+    expect(checkRateLimit(victim, "login").ok).toBe(true);
+  });
+
+  it("repeated requests from the same untrusted client are still limited", () => {
     let blocked = 0;
     for (let i = 0; i < 100; i += 1) {
-      const ip = getClientIp(
-        headers({ "x-forwarded-for": `10.0.${i}.${i}` }),
-      );
+      const ip = getClientIp(headers({ "x-forwarded-for": "10.0.0.5" }));
       const res = checkRateLimit(ip, "login");
       if (!res.ok) blocked += 1;
     }


### PR DESCRIPTION
## Background

A security review surfaced several defence-in-depth gaps around password reset, the reminder scheduler, rate limiting and push subscriptions — none critical on their own, but worth closing.

## What this changes

Password-reset responses now take the same time whether or not an account exists, so they no longer hint at which emails are registered. Reset and reminder links are built only from a trusted configured address in production. Rate limiting no longer lets one client lock everyone out and is harder to evade behind a proxy, and it can no longer be disabled in production. The reminder scheduler endpoint compares its secret in constant time, accepts only POST, and is itself rate-limited. Push subscriptions can no longer be re-pointed to another account.