### PR TITLE
FE-067: small cleanups

### DIFF
--- a/app/api/user/avatar/route.ts
+++ b/app/api/user/avatar/route.ts
@@ -91,7 +91,9 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   const fileName = `${userId}.${OUTPUT_EXT}`;
-  const publicPath = `/uploads/avatars/${fileName}`;
+  // Version the stored URL so a re-upload busts the browser/SW cache everywhere
+  // it is rendered (the file on disk keeps the stable {userId}.webp name).
+  const publicPath = `/uploads/avatars/${fileName}?v=${Date.now()}`;
 
   try {
     await mkdir(AVATAR_DIR, { recursive: true });

--- a/components/profile/PredictionHistory.tsx
+++ b/components/profile/PredictionHistory.tsx
@@ -27,13 +27,6 @@ interface PredictionHistoryProps {
   tips: RatingMatchInfo[];
 }
 
-function clampPerMatchPoints(score: number): number {
-  if (score === 5) return 5;
-  if (score === 3) return 3;
-  if (score === 2) return 2;
-  return 0;
-}
-
 function formatPoints(points: number): string {
   return points > 0 ? `+${points}` : "0";
 }
@@ -191,7 +184,7 @@ export function PredictionHistory({
                   </thead>
                   <tbody className="divide-y divide-outline-variant">
                     {pageTips.map((tip) => {
-                      const points = clampPerMatchPoints(tip.score);
+                      const points = tip.score;
                       const toneClass = scoreToneClass(scoreColor(points));
                       const matchDate = parseDate(tip.date);
                       return (
@@ -238,7 +231,7 @@ export function PredictionHistory({
 
               <ul className="md:hidden border border-outline-variant divide-y divide-outline-variant">
                 {pageTips.map((tip) => {
-                  const points = clampPerMatchPoints(tip.score);
+                  const points = tip.score;
                   const toneClass = scoreToneClass(scoreColor(points));
                   const matchDate = parseDate(tip.date);
                   return (

--- a/components/settings/AvatarUpload.tsx
+++ b/components/settings/AvatarUpload.tsx
@@ -60,7 +60,7 @@ export function AvatarUpload({
             "avatar" in body &&
             typeof (body as { avatar: unknown }).avatar === "string"
           ) {
-            next = `${(body as { avatar: string }).avatar}?t=${Date.now()}`;
+            next = (body as { avatar: string }).avatar;
           }
         } catch {
           // ignore parse error, fall back to router refresh

--- a/lib/reminder-store.ts
+++ b/lib/reminder-store.ts
@@ -101,27 +101,6 @@ export async function markReminderSent(
   return inserted.length > 0;
 }
 
-export async function hasReminderBeenSent(
-  userId: number,
-  matchId: number,
-  leadMinutes: number,
-  channel: ReminderChannel,
-): Promise<boolean> {
-  const rows = await db
-    .select({ id: reminderSent.id })
-    .from(reminderSent)
-    .where(
-      and(
-        eq(reminderSent.userId, userId),
-        eq(reminderSent.matchId, matchId),
-        eq(reminderSent.leadMinutes, leadMinutes),
-        eq(reminderSent.channel, channel),
-      ),
-    )
-    .limit(1);
-  return rows.length > 0;
-}
-
 // Channels a user has explicitly enabled. Email stays the default elsewhere
 // (see `channelsForUser` in the cron) — this returns only stored rows.
 export async function getEnabledChannels(


### PR DESCRIPTION
## Background

A QA pass surfaced minor cleanup items: an unused helper, a redundant scoring helper that duplicated existing logic, and avatar cache-busting that only applied to the uploader's own preview.

## What this changes

Removes the dead and redundant helpers, and versions the stored avatar URL so that after a re-upload the new picture shows everywhere immediately, not just in the uploader's preview.