### PR TITLE
FE-068: log Rust API call timing in production

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -38,25 +38,20 @@ export async function fetchApi<T>(
 
   const url = new URL(`${apiUrl}/${path}`);
 
-  // Dev-only timing visibility (incl. duplicate queries). Production stays
-  // silent to avoid log noise. Path only — never bodies, tokens, cookies or
-  // auth headers.
-  const logTiming = process.env.NODE_ENV !== "production";
+  // Log every Rust API call duration (path + ms only — never bodies, tokens,
+  // cookies or auth headers) so it is visible in the server / PM2 log,
+  // including in production.
   const start = performance.now();
   let res: Response;
   try {
     res = await fetch(url.toString());
   } catch (error) {
-    if (logTiming) {
-      const ms = Math.round(performance.now() - start);
-      console.log(`[rust-api] GET /${path} failed after ${ms}ms`);
-    }
+    const failMs = Math.round(performance.now() - start);
+    console.log(`[rust-api] GET /${path} → failed in ${failMs}ms (network error)`);
     throw error;
   }
-  if (logTiming) {
-    const ms = Math.round(performance.now() - start);
-    console.log(`[rust-api] GET /${path} ${ms}ms`);
-  }
+  const ms = Math.round(performance.now() - start);
+  console.log(`[rust-api] GET /${path} → ${res.status} in ${ms}ms`);
   if (!res.ok) {
     throw new Error(
       `fetchApi: ${res.status} ${res.statusText} for ${url.toString()}`,


### PR DESCRIPTION
## Background

The frontend already measures how long each call to the Rust API takes, but that timing was only logged in development. On the production server there was no way to see how long the Rust calls actually take.

## What this changes

Each Rust API call now logs its duration on the server in production as well, in a cleaner, easy-to-scan format (method, path, response status, milliseconds), so it shows up in the server/process logs. Only the path and timing are logged — never request bodies, tokens or cookies.