### PR TITLE
FE-071: settings as text link on desktop

### DIFF
--- a/components/dashboard/TopAppBar.tsx
+++ b/components/dashboard/TopAppBar.tsx
@@ -41,14 +41,13 @@ export function TopAppBar({ active }: TopAppBarProps): React.ReactElement {
         <div className="flex items-center gap-lg">
           <Link
             href="/settings"
-            aria-label={t("settings")}
-            className={`material-symbols-outlined transition-colors ${
+            className={`text-label-caps uppercase pb-1 transition-colors ${
               active === "settings"
-                ? "text-primary"
+                ? "text-primary border-b-2 border-primary"
                 : "text-on-surface-variant hover:text-primary"
             }`}
           >
-            settings
+            {t("settings")}
           </Link>
           <LocaleSwitcher />
           <form action="/api/auth/logout" method="POST">


### PR DESCRIPTION
## Background

On desktop the top navigation uses text labels, but the settings entry was shown as a lone gear icon, which looked inconsistent. On mobile the icon is appropriate and stays.

## What this changes

On desktop the settings entry is now a text label like the other navigation items, with the same active state. The mobile bottom navigation keeps its icon.