### PR TITLE
FE-070: sticky footer

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -15,8 +15,13 @@ export default async function AppLayout({
   return (
     <>
       <PageBackground />
-      {children}
-      <Footer />
+      {/* Sticky footer: the content area grows to fill the viewport so the
+          footer always sits at the bottom and never floats up while a page's
+          data is still loading. */}
+      <div className="flex min-h-dvh flex-col">
+        <div className="flex-1">{children}</div>
+        <Footer />
+      </div>
     </>
   );
 }


### PR DESCRIPTION
## Background

On pages whose content loads progressively (such as a profile), the footer briefly appeared high up and then slid down as the data filled in, which looked broken.

## What this changes

The content area now grows to fill the viewport, so the footer always sits at the bottom of the page and no longer floats up or jumps while a page's data is still loading.