### PR TITLE
XR-005: SQLite busy_timeout (frontend)

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -14,6 +14,9 @@ function open(): Db {
   _sqlite = new Database(dbPath);
   _sqlite.pragma("journal_mode = WAL");
   _sqlite.pragma("foreign_keys = ON");
+  // Wait (up to 5s) for the lock instead of failing immediately with SQLITE_BUSY
+  // when another service (macht-api importer, betting-api) holds the shared DB.
+  _sqlite.pragma("busy_timeout = 5000");
   _db = drizzle(_sqlite, { schema });
   return _db;
 }


### PR DESCRIPTION
## Background

The three services share one SQLite database. When the importer writes to it, another service writing at the same time could fail immediately with a database-busy error.

## What this changes

The web app now waits briefly for the database lock instead of failing immediately, so concurrent access from the importer or read API no longer causes errors.