### PR TITLE
FE-074: show TIMED matches (upcoming)

### DIFF
--- a/lib/match.ts
+++ b/lib/match.ts
@@ -2,6 +2,7 @@ import { and, asc, eq, gte, inArray } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { match } from "@/db/schema";
 import { formatDateKey } from "@/lib/format";
+import { UPCOMING_MATCH_STATUSES } from "@/lib/reminders";
 
 export interface TeamRef {
   name: string;
@@ -52,7 +53,12 @@ export async function getUpcomingMatches(): Promise<MatchRow[]> {
   const rows = await db
     .select()
     .from(match)
-    .where(and(eq(match.status, "SCHEDULED"), gte(match.utcDate, now)));
+    .where(
+      and(
+        inArray(match.status, [...UPCOMING_MATCH_STATUSES]),
+        gte(match.utcDate, now),
+      ),
+    );
   return rows
     .map(rowToMatch)
     .filter((m): m is MatchRow => m !== null)
@@ -73,7 +79,12 @@ export async function getLiveState(): Promise<LiveState> {
   const upcoming = await db
     .select({ utcDate: match.utcDate })
     .from(match)
-    .where(and(eq(match.status, "SCHEDULED"), gte(match.utcDate, now)))
+    .where(
+      and(
+        inArray(match.status, [...UPCOMING_MATCH_STATUSES]),
+        gte(match.utcDate, now),
+      ),
+    )
     .orderBy(asc(match.utcDate))
     .limit(1);
   return {

--- a/lib/reminders.ts
+++ b/lib/reminders.ts
@@ -64,7 +64,14 @@ export function shouldMarkDelivery(attempt: DeliveryAttempt): boolean {
   return attempt.delivered;
 }
 
-const SCHEDULED_STATUS = "SCHEDULED";
+// The external football API marks fixtures with a confirmed kickoff as "TIMED"
+// (not "SCHEDULED"), so both count as upcoming/scheduled across the app.
+export const UPCOMING_MATCH_STATUSES = ["SCHEDULED", "TIMED"] as const;
+const UPCOMING_STATUS_SET: ReadonlySet<string> = new Set(UPCOMING_MATCH_STATUSES);
+
+export function isUpcomingStatus(status: string): boolean {
+  return UPCOMING_STATUS_SET.has(status);
+}
 
 export interface EligibleMatch {
   id: number;
@@ -95,7 +102,7 @@ export function sentKey(matchId: number, leadMinutes: number): string {
 export function dueLeadMinutes(input: EligibilityInput): number[] {
   const { now, match, enabledLeadMinutes, tippedMatchIds, sentKeys } = input;
 
-  if (match.status !== SCHEDULED_STATUS) return [];
+  if (!isUpcomingStatus(match.status)) return [];
   if (tippedMatchIds.has(match.id)) return [];
 
   const nowMs = now.getTime();

--- a/scripts/demo_data.ts
+++ b/scripts/demo_data.ts
@@ -16,7 +16,7 @@ type SeedMatch = {
   id: number;
   homeTeam: TeamRef;
   awayTeam: TeamRef;
-  status: "FINISHED" | "IN_PLAY" | "SCHEDULED";
+  status: "FINISHED" | "IN_PLAY" | "SCHEDULED" | "TIMED";
   utcDate: number;
   homeScore: number | null;
   awayScore: number | null;
@@ -162,7 +162,7 @@ function buildMatches(now: number): SeedMatch[] {
       id: 7,
       homeTeam: TEAM.ESP,
       awayTeam: TEAM.ITA,
-      status: "SCHEDULED",
+      status: "TIMED",
       utcDate: now + 1 * DAY,
       homeScore: null,
       awayScore: null,
@@ -171,7 +171,7 @@ function buildMatches(now: number): SeedMatch[] {
       id: 8,
       homeTeam: TEAM.NED,
       awayTeam: TEAM.CRO,
-      status: "SCHEDULED",
+      status: "TIMED",
       utcDate: now + 2 * DAY,
       homeScore: null,
       awayScore: null,
@@ -180,7 +180,7 @@ function buildMatches(now: number): SeedMatch[] {
       id: 9,
       homeTeam: TEAM.GER,
       awayTeam: TEAM.POR,
-      status: "SCHEDULED",
+      status: "TIMED",
       utcDate: now + 3 * DAY,
       homeScore: null,
       awayScore: null,
@@ -189,7 +189,7 @@ function buildMatches(now: number): SeedMatch[] {
       id: 10,
       homeTeam: TEAM.FRA,
       awayTeam: TEAM.POL,
-      status: "SCHEDULED",
+      status: "TIMED",
       utcDate: now + 5 * DAY,
       homeScore: null,
       awayScore: null,
@@ -198,7 +198,7 @@ function buildMatches(now: number): SeedMatch[] {
       id: 11,
       homeTeam: TEAM.ENG,
       awayTeam: TEAM.ESP,
-      status: "SCHEDULED",
+      status: "TIMED",
       utcDate: now + 7 * DAY,
       homeScore: null,
       awayScore: null,
@@ -218,7 +218,7 @@ function buildMatches(now: number): SeedMatch[] {
       id: 13,
       homeTeam: TEAM.POR,
       awayTeam: TEAM.NED,
-      status: "SCHEDULED",
+      status: "TIMED",
       utcDate: now + 1 * DAY,
       homeScore: null,
       awayScore: null,
@@ -227,7 +227,7 @@ function buildMatches(now: number): SeedMatch[] {
       id: 14,
       homeTeam: TEAM.CRO,
       awayTeam: TEAM.POL,
-      status: "SCHEDULED",
+      status: "TIMED",
       utcDate: now + 2 * DAY,
       homeScore: null,
       awayScore: null,

--- a/tests/unit/reminders.test.ts
+++ b/tests/unit/reminders.test.ts
@@ -89,6 +89,18 @@ describe("dueLeadMinutes", () => {
     expect(due).toEqual([]);
   });
 
+  it("treats a TIMED match as upcoming (external API status)", () => {
+    const now = new Date(KICKOFF.getTime() - 90 * 60_000);
+    const due = dueLeadMinutes({
+      now,
+      match: matchAt(KICKOFF, "TIMED"),
+      enabledLeadMinutes: enabled,
+      tippedMatchIds: noTips,
+      sentKeys: noSent,
+    });
+    expect(due).toEqual([720]);
+  });
+
   it("returns nothing if the user already tipped the match", () => {
     const now = new Date(KICKOFF.getTime() - 90 * 60_000);
     const due = dueLeadMinutes({


### PR DESCRIPTION
## Background

Matches imported from the external football data source carry the status "TIMED" once they have a confirmed kickoff, but the app only treated "SCHEDULED" matches as upcoming. As a result, all the imported World Cup fixtures were invisible — they were not listed, could not be predicted, did not drive the next-kickoff auto-refresh, and never triggered reminders.

## What this changes

"TIMED" is now treated as an upcoming/scheduled status everywhere it matters: the upcoming fixtures list, the next-kickoff detection, and the reminder eligibility. The demo and test seed data now also include TIMED fixtures so this matches what the real importer produces.