### PR TITLE
FE-069: features page

### DIFF
--- a/app/(app)/features/page.tsx
+++ b/app/(app)/features/page.tsx
@@ -1,0 +1,48 @@
+import { getTranslations } from "next-intl/server";
+import { TopAppBar } from "@/components/dashboard/TopAppBar";
+import { BottomNav } from "@/components/dashboard/BottomNav";
+
+const FEATURE_KEYS = [
+  "liveScoring",
+  "predicting",
+  "rankings",
+  "history",
+  "reminders",
+  "pwaOffline",
+  "passwordReset",
+  "avatars",
+  "languages",
+] as const;
+
+export default async function FeaturesPage(): Promise<React.ReactElement> {
+  const t = await getTranslations("Features");
+
+  return (
+    <>
+      <TopAppBar active="dashboard" />
+      <main className="pt-4 md:pt-24 pb-24 md:pb-8 px-margin-mobile md:px-margin-desktop max-w-(--container-max-desktop) mx-auto">
+        <div className="mb-lg">
+          <h1 className="text-headline-lg font-bold mb-xs">{t("title")}</h1>
+          <p className="text-body-sm text-on-surface-variant">{t("intro")}</p>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-lg">
+          {FEATURE_KEYS.map((key) => (
+            <section
+              key={key}
+              className="bg-surface-container rounded-lg p-lg border border-outline-variant"
+            >
+              <h2 className="text-body-lg font-bold text-on-background mb-xs">
+                {t(`items.${key}.title`)}
+              </h2>
+              <p className="text-body-sm text-on-surface-variant">
+                {t(`items.${key}.desc`)}
+              </p>
+            </section>
+          ))}
+        </div>
+      </main>
+      <BottomNav active="dashboard" />
+    </>
+  );
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,17 +1,8 @@
+import Link from "next/link";
 import { useTranslations } from "next-intl";
 import packageJson from "@/package.json";
 
 const GITHUB_URL = "https://github.com/football-betting";
-
-const FEATURE_KEYS = [
-  "liveScoring",
-  "predicting",
-  "rankings",
-  "pwaOffline",
-  "i18n",
-  "passwordReset",
-  "avatars",
-] as const;
 
 export function Footer(): React.ReactElement {
   const t = useTranslations("Footer");
@@ -31,16 +22,12 @@ export function Footer(): React.ReactElement {
             </div>
           </div>
 
-          <div className="flex flex-col items-center md:items-start gap-xs min-w-0">
-            <div className="text-label-caps uppercase text-on-surface-variant">
-              {t("featuresHeading")}
-            </div>
-            <ul className="flex flex-wrap justify-center md:justify-start gap-x-md gap-y-xs text-body-sm text-on-surface-variant/80">
-              {FEATURE_KEYS.map((key) => (
-                <li key={key}>{t(`features.${key}`)}</li>
-              ))}
-            </ul>
-          </div>
+          <Link
+            href="/features"
+            className="self-center md:self-auto text-label-caps uppercase text-on-surface-variant hover:text-primary transition-colors"
+          >
+            {t("featuresHeading")}
+          </Link>
 
           <div className="flex items-center gap-md">
             <a

--- a/messages/de.json
+++ b/messages/de.json
@@ -8,15 +8,48 @@
     "settings": "Einstellungen"
   },
   "Footer": {
-    "featuresHeading": "Funktionen",
-    "features": {
-      "liveScoring": "Live-Scoring",
-      "predicting": "Tippen & Wertung (5/3/2)",
-      "rankings": "Ranglisten (global + Abteilungen)",
-      "pwaOffline": "PWA / Offline",
-      "i18n": "DE / EN",
-      "passwordReset": "Passwort-Reset",
-      "avatars": "Avatare"
+    "featuresHeading": "Funktionen"
+  },
+  "Features": {
+    "title": "Funktionen",
+    "intro": "Was die App kann — ein Überblick für Nutzer und Entwickler.",
+    "items": {
+      "liveScoring": {
+        "title": "Live-Scoring & Auto-Refresh",
+        "desc": "Spielstände und Ranglisten-Punkte aktualisieren sich während laufender Spiele automatisch — ohne manuelles Neuladen."
+      },
+      "predicting": {
+        "title": "Tippen & Wertung",
+        "desc": "Ein Tipp pro Spiel. Wertung: Volltreffer 5, Tordifferenz 3, Tendenz 2 Punkte — plus Bonus für den Weltmeister-Tipp."
+      },
+      "rankings": {
+        "title": "Ranglisten",
+        "desc": "Globale Rangliste und je Abteilung, mit Position, Trefferstatistik und Hervorhebung der eigenen Zeile."
+      },
+      "history": {
+        "title": "Profil & Tipp-Historie",
+        "desc": "Eigenes Profil mit Statistiken und vollständiger Tipp-Historie — sortier-, filter- und seitenweise blätterbar."
+      },
+      "reminders": {
+        "title": "Erinnerungen",
+        "desc": "Erinnerungen für noch nicht getippte Spiele — per Email und/oder Push in der installierten App, mit wählbaren Vorlaufzeiten."
+      },
+      "pwaOffline": {
+        "title": "Installierbare PWA",
+        "desc": "Als App auf Android und iOS installierbar, läuft standalone, mit Offline-Seite."
+      },
+      "passwordReset": {
+        "title": "Passwort-Reset",
+        "desc": "Passwort vergessen? Sicheres Zurücksetzen über einen zeitlich begrenzten Link per Email."
+      },
+      "avatars": {
+        "title": "Avatare",
+        "desc": "Eigenes Profilbild hochladen; sonst saubere Initialen als Fallback."
+      },
+      "languages": {
+        "title": "Mehrsprachig",
+        "desc": "Komplett auf Deutsch und Englisch, jederzeit umschaltbar."
+      }
     }
   },
   "Common": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -8,15 +8,48 @@
     "settings": "Settings"
   },
   "Footer": {
-    "featuresHeading": "Features",
-    "features": {
-      "liveScoring": "Live scoring",
-      "predicting": "Predictions & scoring (5/3/2)",
-      "rankings": "Rankings (global + departments)",
-      "pwaOffline": "PWA / offline",
-      "i18n": "DE / EN",
-      "passwordReset": "Password reset",
-      "avatars": "Avatars"
+    "featuresHeading": "Features"
+  },
+  "Features": {
+    "title": "Features",
+    "intro": "What the app can do — an overview for users and developers.",
+    "items": {
+      "liveScoring": {
+        "title": "Live scoring & auto-refresh",
+        "desc": "Scores and ranking points update automatically while matches are in play — no manual reload."
+      },
+      "predicting": {
+        "title": "Predictions & scoring",
+        "desc": "One prediction per match. Scoring: exact 5, goal difference 3, tendency 2 points — plus a bonus for the champion pick."
+      },
+      "rankings": {
+        "title": "Rankings",
+        "desc": "Global ranking and one per department, with position, hit statistics and your own row highlighted."
+      },
+      "history": {
+        "title": "Profile & prediction history",
+        "desc": "Your profile with statistics and a full prediction history — sortable, filterable and paginated."
+      },
+      "reminders": {
+        "title": "Reminders",
+        "desc": "Reminders for matches you haven't predicted yet — by email and/or push in the installed app, with selectable lead times."
+      },
+      "pwaOffline": {
+        "title": "Installable PWA",
+        "desc": "Installable as an app on Android and iOS, runs standalone, with an offline page."
+      },
+      "passwordReset": {
+        "title": "Password reset",
+        "desc": "Forgot your password? Secure reset via a time-limited email link."
+      },
+      "avatars": {
+        "title": "Avatars",
+        "desc": "Upload your own profile picture; clean initials as a fallback otherwise."
+      },
+      "languages": {
+        "title": "Multilingual",
+        "desc": "Fully available in German and English, switchable at any time."
+      }
     }
   },
   "Common": {


### PR DESCRIPTION
## Background

The footer listed the app's capabilities as a short inline list. It's more useful to describe what the app can do on a dedicated page and link to it.

## What this changes

There is now a dedicated, localized page that describes each of the app's features (live scoring, predictions and scoring, rankings, profile history, reminders, installable PWA, password reset, avatars, languages). The footer now links to this page instead of repeating a short list.