### PR TITLE
FE-075: three-state sorting in prediction history

### DIFF
--- a/components/profile/PredictionHistory.tsx
+++ b/components/profile/PredictionHistory.tsx
@@ -14,7 +14,7 @@ import {
   pageCount,
   paginate,
   sortTips,
-  toggleSort,
+  cycleSort,
   type SortKey,
   type SortState,
 } from "@/lib/history";
@@ -41,8 +41,8 @@ function parseDate(date: number): Date {
   return new Date(date * 1000);
 }
 
-function sortIndicator(sort: SortState, key: SortKey): string {
-  if (sort.key !== key) return "";
+function sortIndicator(sort: SortState | null, key: SortKey): string {
+  if (!sort || sort.key !== key) return "";
   return sort.dir === "asc" ? " ↑" : " ↓";
 }
 
@@ -53,11 +53,12 @@ export function PredictionHistory({
   const t = useTranslations("Profile");
   const locale = useLocale();
   const { filter, setFilter } = useHistoryFilter();
-  const [sort, setSort] = useState<SortState>(DEFAULT_SORT);
+  // `null` = no explicit sort → the default order (DEFAULT_SORT).
+  const [sort, setSort] = useState<SortState | null>(null);
   const [page, setPage] = useState(1);
 
   const visibleTips = useMemo(
-    () => sortTips(filterTips(tips, filter), sort),
+    () => sortTips(filterTips(tips, filter), sort ?? DEFAULT_SORT),
     [tips, filter, sort],
   );
 
@@ -70,7 +71,7 @@ export function PredictionHistory({
     : visibleTips;
 
   function handleSort(key: SortKey): void {
-    setSort((current) => toggleSort(current, key));
+    setSort((current) => cycleSort(current, key));
     setPage(1);
   }
 
@@ -119,9 +120,9 @@ export function PredictionHistory({
             <button
               type="button"
               onClick={() => handleSort("points")}
-              aria-pressed={sort.key === "points"}
+              aria-pressed={sort?.key === "points"}
               className={`flex-1 px-md py-sm border text-label-caps uppercase transition-colors ${
-                sort.key === "points"
+                sort?.key === "points"
                   ? "border-primary text-primary bg-surface-container-high"
                   : "border-outline-variant text-on-surface-variant"
               }`}
@@ -132,9 +133,9 @@ export function PredictionHistory({
             <button
               type="button"
               onClick={() => handleSort("date")}
-              aria-pressed={sort.key === "date"}
+              aria-pressed={sort?.key === "date"}
               className={`flex-1 px-md py-sm border text-label-caps uppercase transition-colors ${
-                sort.key === "date"
+                sort?.key === "date"
                   ? "border-primary text-primary bg-surface-container-high"
                   : "border-outline-variant text-on-surface-variant"
               }`}
@@ -158,7 +159,7 @@ export function PredictionHistory({
                         <button
                           type="button"
                           onClick={() => handleSort("date")}
-                          aria-pressed={sort.key === "date"}
+                          aria-pressed={sort?.key === "date"}
                           className="uppercase hover:text-on-surface transition-colors"
                         >
                           {t("match")}
@@ -173,7 +174,7 @@ export function PredictionHistory({
                         <button
                           type="button"
                           onClick={() => handleSort("points")}
-                          aria-pressed={sort.key === "points"}
+                          aria-pressed={sort?.key === "points"}
                           className="uppercase hover:text-on-surface transition-colors"
                         >
                           {t("points")}

--- a/lib/history.ts
+++ b/lib/history.ts
@@ -55,11 +55,20 @@ export function sortTips(
   return [...tips].sort((a, b) => compareTips(a, b, sort));
 }
 
-export function toggleSort(current: SortState, key: SortKey): SortState {
-  if (current.key === key) {
-    return { key, dir: current.dir === "asc" ? "desc" : "asc" };
+// Three-state click cycle for a sortable column: ascending → descending →
+// none (`null` = back to the default order). Clicking a different column
+// starts at ascending.
+export function cycleSort(
+  current: SortState | null,
+  key: SortKey,
+): SortState | null {
+  if (!current || current.key !== key) {
+    return { key, dir: "asc" };
   }
-  return { key, dir: "desc" };
+  if (current.dir === "asc") {
+    return { key, dir: "desc" };
+  }
+  return null;
 }
 
 export function pageCount(totalItems: number, pageSize = PAGE_SIZE): number {

--- a/tests/unit/history.test.ts
+++ b/tests/unit/history.test.ts
@@ -11,8 +11,7 @@ import {
   paginate,
   sortTips,
   tipCategory,
-  toggleSort,
-  type SortState,
+  cycleSort,
 } from "@/lib/history";
 
 function makeTip(
@@ -131,20 +130,23 @@ describe("compareTips / sortTips", () => {
   });
 });
 
-describe("toggleSort", () => {
-  it("flips direction when key is unchanged", () => {
-    const start: SortState = { key: "date", dir: "desc" };
-    expect(toggleSort(start, "date")).toEqual({ key: "date", dir: "asc" });
-    expect(toggleSort({ key: "date", dir: "asc" }, "date")).toEqual({
-      key: "date",
-      dir: "desc",
-    });
-  });
-
-  it("switches to a new key defaulting to desc", () => {
-    expect(toggleSort({ key: "date", dir: "asc" }, "points")).toEqual({
+describe("cycleSort", () => {
+  it("cycles a column asc → desc → none (null) over three clicks", () => {
+    // from none (null) → asc
+    expect(cycleSort(null, "points")).toEqual({ key: "points", dir: "asc" });
+    // asc → desc
+    expect(cycleSort({ key: "points", dir: "asc" }, "points")).toEqual({
       key: "points",
       dir: "desc",
+    });
+    // desc → none
+    expect(cycleSort({ key: "points", dir: "desc" }, "points")).toBeNull();
+  });
+
+  it("switches to a new column starting at asc", () => {
+    expect(cycleSort({ key: "date", dir: "desc" }, "points")).toEqual({
+      key: "points",
+      dir: "asc",
     });
   });
 });


### PR DESCRIPTION
## Background

On a profile, clicking a sortable column in the prediction history only toggled between ascending and descending, with no way to return to the default order.

## What this changes

Each sortable column now cycles through three states on click: ascending, then descending, then none — returning to the default order (newest first) with no sort indicator shown.