### PR TITLE
FE-076: GitHub Actions CI for frontend

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -10,21 +10,26 @@ concurrency:
   group: frontend-ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Run JS actions on Node 24 (covers the github-script action bundled inside
+# codecov-action, which still ships a Node 20 runtime).
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   frontend:
     name: type-check · unit tests · coverage
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 11
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,48 @@
+name: frontend-ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Cancel superseded runs on the same ref to save CI minutes.
+concurrency:
+  group: frontend-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  frontend:
+    name: type-check · unit tests · coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type-check (static analysis)
+        run: pnpm typecheck
+
+      - name: Unit tests + coverage
+        run: pnpm exec vitest run --coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: football-betting/frontend
+          flags: frontend
+          files: ./coverage/lcov.info
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # football-betting · frontend
 
+[![frontend-ci](https://github.com/football-betting/frontend/actions/workflows/frontend-ci.yml/badge.svg)](https://github.com/football-betting/frontend/actions/workflows/frontend-ci.yml)
+[![codecov](https://codecov.io/gh/football-betting/frontend/branch/main/graph/badge.svg)](https://codecov.io/gh/football-betting/frontend)
+
 Next.js 16 frontend for the office football-prediction game. Replaces the
 archived [em2024-frontend](https://github.com/football-betting/em2024-frontend).
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,7 @@
-onlyBuiltDependencies:
-  - "@parcel/watcher"
-  - "@swc/core"
-  - better-sqlite3
-  - esbuild
-  - sharp
-  - unrs-resolver
+allowBuilds:
+  "@parcel/watcher": true
+  "@swc/core": true
+  better-sqlite3: true
+  esbuild: true
+  sharp: true
+  unrs-resolver: true

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,5 +13,10 @@ export default defineConfig({
     include: ["tests/unit/**/*.test.ts"],
     globals: false,
     reporters: ["default"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      reportsDirectory: "./coverage",
+    },
   },
 });


### PR DESCRIPTION
## Background

The frontend repository had no automated check on pushes or pull requests. It already ships a unit-test suite, a clean type-check, and coverage tooling, but none of it ran on GitHub — so regressions could only be caught by hand before merge.

## What this changes

Every push to `main` and every pull request now runs an automated pipeline that type-checks the project and executes the unit-test suite. The result is visible as a build status badge in the README, so a green or red signal is immediately obvious. Test coverage is reported to Codecov and surfaced as a second badge, giving an at-a-glance view of how much of the code is exercised by tests.

Note: the `CODECOV_TOKEN` repository secret must be set for the coverage upload to succeed.
