### PR TITLE
FE-050: Playwright E2E suite (positive + negative)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 
 # Next.js
 /.next/
+/.next-e2e/
 /out/
 next-env.d.ts
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,10 @@ import withSerwistInit from "@serwist/next";
 const nextConfig: NextConfig = {
   serverExternalPackages: ["better-sqlite3"],
   poweredByHeader: false,
+  // Overridable build dir so the isolated E2E dev server can run with its own
+  // lock alongside a developer's regular `next dev` (Next allows only one dev
+  // server per build dir).
+  distDir: process.env.NEXT_DIST_DIR || ".next",
 };
 
 const withNextIntl = createNextIntlPlugin();

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,13 @@
 import { defineConfig, devices } from "@playwright/test";
 
+// Dedicated ports for the isolated E2E stand so the suite never collides with a
+// developer's running dev stack (frontend :3000 / betting-api :8080 on the
+// shared DB). Everything here runs against ../shared/db/test.db only.
+const FRONTEND_PORT = Number(process.env.E2E_FRONTEND_PORT ?? 3100);
+const RUST_PORT = Number(process.env.E2E_RUST_PORT ?? 8090);
+const BASE_URL = `http://localhost:${FRONTEND_PORT}`;
+const RUST_API_URL = `http://localhost:${RUST_PORT}`;
+
 export default defineConfig({
   testDir: "./tests/e2e",
   globalSetup: "./tests/e2e/setup.ts",
@@ -9,8 +17,25 @@ export default defineConfig({
   retries: process.env.CI ? 1 : 0,
   reporter: "list",
   use: {
-    baseURL: "http://localhost:3000",
+    baseURL: BASE_URL,
     trace: "retain-on-failure",
+    // Force English UI deterministically (app default locale is German). The
+    // i18n spec clears this cookie itself to exercise switching/persistence.
+    storageState: {
+      cookies: [
+        {
+          name: "locale",
+          value: "en",
+          domain: "localhost",
+          path: "/",
+          expires: -1,
+          httpOnly: false,
+          secure: false,
+          sameSite: "Lax",
+        },
+      ],
+      origins: [],
+    },
   },
   projects: [
     {
@@ -18,15 +43,32 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
   ],
-  webServer: {
-    command: "pnpm dev",
-    url: "http://localhost:3000/login",
-    reuseExistingServer: !process.env.CI,
-    timeout: 120_000,
-    env: {
-      DATABASE_URL: "../shared/db/test.db",
-      RUST_API_URL: process.env.RUST_API_URL ?? "http://localhost:8080",
-      DISABLE_RATE_LIMIT: "1",
+  webServer: [
+    {
+      // Read API on test.db, dedicated port. betting-api honours BIND_ADDR.
+      command: "cargo run --quiet",
+      cwd: "../betting-api",
+      url: `${RUST_API_URL}/`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 180_000,
+      env: {
+        BIND_ADDR: `127.0.0.1:${RUST_PORT}`,
+        MODE: "production",
+        DATABASE_URL: "../shared/db/test.db",
+      },
     },
-  },
+    {
+      command: `pnpm dev --port ${FRONTEND_PORT}`,
+      url: `${BASE_URL}/login`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      env: {
+        DATABASE_URL: "../shared/db/test.db",
+        RUST_API_URL,
+        DISABLE_RATE_LIMIT: "1",
+        // Own build dir so this server doesn't clash with a running `next dev`.
+        NEXT_DIST_DIR: ".next-e2e",
+      },
+    },
+  ],
 });

--- a/tests/e2e/auth-disclosure.spec.ts
+++ b/tests/e2e/auth-disclosure.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type APIResponse } from "@playwright/test";
+import { ORIGIN, TEST_USER } from "./helpers";
 
 async function attemptLogin(
   request: import("@playwright/test").APIRequestContext,
@@ -8,17 +9,14 @@ async function attemptLogin(
   const form = new URLSearchParams();
   form.set("email", email);
   form.set("password", password);
-  const res: APIResponse = await request.post(
-    "http://localhost:3000/api/auth/login",
-    {
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-        Accept: "application/json",
-        Origin: "http://localhost:3000",
-      },
-      data: form.toString(),
+  const res: APIResponse = await request.post("/api/auth/login", {
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+      Origin: ORIGIN,
     },
-  );
+    data: form.toString(),
+  });
   const body = (await res.json().catch(() => ({}))) as { error?: string };
   return { status: res.status(), body };
 }
@@ -34,7 +32,7 @@ test.describe("auth disclosure", () => {
     );
     const known = await attemptLogin(
       request,
-      "me@dev.local",
+      TEST_USER.email,
       "wrong-password-99",
     );
 

--- a/tests/e2e/auth-flow.spec.ts
+++ b/tests/e2e/auth-flow.spec.ts
@@ -30,9 +30,9 @@ test.describe("auth happy path", () => {
     await page.fill("#email", "test.user@local.dev");
     await page.fill("#password", "test1234");
     await page.click("button[type=submit]");
-    await page.waitForURL("http://localhost:3000/");
+    await page.waitForURL((url) => url.pathname === "/");
 
-    await expect(page).toHaveURL("http://localhost:3000/");
+    await expect(page).toHaveURL((url) => url.pathname === "/");
 
     const logout = page.getByRole("button", { name: "Logout" }).first();
     await logout.click();

--- a/tests/e2e/avatar.spec.ts
+++ b/tests/e2e/avatar.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "@playwright/test";
+import { login, signupNewUser, PASSWORD, ORIGIN } from "./helpers";
+
+// A minimal valid 1×1 PNG that `sharp` can decode on the server.
+const PNG_1x1 = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+async function openSettingsAsFreshUser(page: import("@playwright/test").Page) {
+  const account = await signupNewUser(page, "avatar");
+  await login(page, account.email, PASSWORD);
+  await page.goto("/settings");
+}
+
+test.describe("avatar upload", () => {
+  test("a fresh account shows the initials/icon fallback", async ({ page }) => {
+    await openSettingsAsFreshUser(page);
+    await expect(
+      page.getByRole("button", { name: "Change photo" }).getByRole("img"),
+    ).toBeVisible();
+  });
+
+  test("a valid PNG uploads successfully", async ({ page }) => {
+    await openSettingsAsFreshUser(page);
+
+    const responsePromise = page.waitForResponse(
+      (r) => r.url().includes("/api/user/avatar") && r.request().method() === "POST",
+    );
+    await page.locator('input[type="file"]').setInputFiles({
+      name: "avatar.png",
+      mimeType: "image/png",
+      buffer: PNG_1x1,
+    });
+    const response = await responsePromise;
+    expect(response.status()).toBe(200);
+
+    await expect(page.getByText("Only PNG, JPG or WebP allowed.")).toHaveCount(0);
+    await expect(page.getByText("File is too large (max 5 MB).")).toHaveCount(0);
+  });
+
+  test("an SVG file is rejected client-side", async ({ page }) => {
+    await openSettingsAsFreshUser(page);
+
+    await page.locator('input[type="file"]').setInputFiles({
+      name: "logo.svg",
+      mimeType: "image/svg+xml",
+      buffer: Buffer.from("<svg xmlns='http://www.w3.org/2000/svg'/>"),
+    });
+
+    await expect(
+      page.getByText("Only PNG, JPG or WebP allowed."),
+    ).toBeVisible();
+  });
+
+  test("an over-sized image is rejected client-side", async ({ page }) => {
+    await openSettingsAsFreshUser(page);
+
+    await page.locator('input[type="file"]').setInputFiles({
+      name: "huge.png",
+      mimeType: "image/png",
+      buffer: Buffer.alloc(6 * 1024 * 1024, 1),
+    });
+
+    await expect(
+      page.getByText("File is too large (max 5 MB)."),
+    ).toBeVisible();
+  });
+
+  test("the API rejects a request with no file (400)", async ({ page }) => {
+    await openSettingsAsFreshUser(page);
+
+    const res = await page.request.post("/api/user/avatar", {
+      headers: { Origin: ORIGIN },
+      multipart: {},
+    });
+    expect(res.status()).toBe(400);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe("noFileProvided");
+  });
+});

--- a/tests/e2e/dashboard.spec.ts
+++ b/tests/e2e/dashboard.spec.ts
@@ -1,12 +1,5 @@
 import { expect, test } from "@playwright/test";
-
-async function login(page: import("@playwright/test").Page): Promise<void> {
-  await page.goto("/login");
-  await page.fill("#email", "me@dev.local");
-  await page.fill("#password", "test1234");
-  await page.click("button[type=submit]");
-  await page.waitForURL("http://localhost:3000/");
-}
+import { login } from "./helpers";
 
 test.describe("dashboard buckets", () => {
   test("live block lists both IN_PLAY matches", async ({ page }) => {

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -1,0 +1,102 @@
+import { expect, type Page } from "@playwright/test";
+
+// Mirrors playwright.config.ts so request-context specs can send a same-origin
+// CSRF `Origin` header that matches the dynamically-chosen frontend port.
+const FRONTEND_PORT = Number(process.env.E2E_FRONTEND_PORT ?? 3100);
+export const ORIGIN = `http://localhost:${FRONTEND_PORT}`;
+
+// Canonical seeded accounts (see frontend/scripts/demo_data.ts). Every seeded
+// user shares the password below. TEST_USER is id 6 and is the account most
+// "own profile" specs assert against (/user/6); OTHER_USER (id 1) is used for
+// foreign-profile assertions.
+export const PASSWORD = "test1234";
+
+export const TEST_USER = {
+  id: 6,
+  email: "test.user@local.dev",
+  username: "TestUser",
+  password: PASSWORD,
+} as const;
+
+export const OTHER_USER = {
+  id: 1,
+  email: "ada.lovelace@local.dev",
+  username: "AdaLovelace",
+  password: PASSWORD,
+} as const;
+
+interface LoginOptions {
+  remember?: boolean;
+}
+
+/** Log in via the real form and wait until the dashboard (`/`) is reached. */
+export async function login(
+  page: Page,
+  email: string = TEST_USER.email,
+  password: string = TEST_USER.password,
+  options: LoginOptions = {},
+): Promise<void> {
+  await page.goto("/login");
+  await page.fill("#email", email);
+  await page.fill("#password", password);
+  if (options.remember) {
+    await page.check("#remember");
+  }
+  await page.click("button[type=submit]");
+  await page.waitForURL((url) => url.pathname === "/");
+}
+
+export async function logout(page: Page): Promise<void> {
+  await page
+    .getByRole("button", { name: "Logout" })
+    .first()
+    .click();
+  await page.waitForURL(/\/login(\?|$)/);
+}
+
+export async function expectOnDashboard(page: Page): Promise<void> {
+  await expect(page).toHaveURL((url) => url.pathname === "/");
+}
+
+export interface SignupFields {
+  username: string;
+  email: string;
+  password?: string;
+  rePassword?: string;
+  department?: string;
+  winner?: string;
+  secretWinner?: string;
+}
+
+/** Fill the signup form. Does not submit. */
+export async function fillSignupForm(
+  page: Page,
+  fields: SignupFields,
+): Promise<void> {
+  await page.goto("/signup");
+  await page.fill("#username", fields.username);
+  await page.fill("#email", fields.email);
+  await page.fill("#password", fields.password ?? PASSWORD);
+  await page.fill("#rePassword", fields.rePassword ?? fields.password ?? PASSWORD);
+  await page.selectOption("#department", fields.department ?? "Langenfeld");
+  await page.selectOption("#winner", fields.winner ?? "DEU");
+  await page.selectOption("#secretWinner", fields.secretWinner ?? "ESP");
+}
+
+/**
+ * Register a brand-new account and return its credentials. The globalSetup
+ * wipes test.db before every run, so a `prefix`-based unique email is stable
+ * within a run and never clashes across runs.
+ */
+export async function signupNewUser(
+  page: Page,
+  prefix: string,
+): Promise<{ email: string; username: string; password: string }> {
+  const stamp = `${prefix}-${Date.now()}`;
+  const email = `${stamp}@e2e.local`;
+  const username = stamp.replace(/[^a-zA-Z0-9]/g, "");
+  await fillSignupForm(page, { username, email });
+  await page.click("button[type=submit]");
+  await page.waitForURL(/\/login\?registered=true$/);
+  return { email, username, password: PASSWORD };
+}

--- a/tests/e2e/i18n.spec.ts
+++ b/tests/e2e/i18n.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "@playwright/test";
+
+// The suite forces locale=en globally (see playwright.config.ts). These tests
+// clear that cookie to exercise the real default + the switcher persistence.
+test.describe("i18n language switcher", () => {
+  test("defaults to German and the auth-page switcher toggles to English", async ({
+    page,
+    context,
+  }) => {
+    await context.clearCookies();
+
+    await page.goto("/login");
+    // Default locale is German → the submit button reads "Anmelden".
+    await expect(
+      page.getByRole("button", { name: "Anmelden" }),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "en", exact: true }).click();
+
+    // Now English → "Sign In".
+    await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible();
+  });
+
+  test("the chosen locale persists across reloads", async ({
+    page,
+    context,
+  }) => {
+    await context.clearCookies();
+
+    await page.goto("/login");
+    await page.getByRole("button", { name: "en", exact: true }).click();
+    await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible();
+
+    await page.reload();
+    await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Anmelden" }),
+    ).toHaveCount(0);
+  });
+});

--- a/tests/e2e/login.spec.ts
+++ b/tests/e2e/login.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "@playwright/test";
+import { login, TEST_USER } from "./helpers";
+
+test.describe("login negatives and session", () => {
+  test("a wrong password shows the generic error and stays on /login", async ({
+    page,
+  }) => {
+    await page.goto("/login");
+    await page.fill("#email", TEST_USER.email);
+    await page.fill("#password", "definitely-wrong");
+    await page.click("button[type=submit]");
+
+    await expect(page.getByText("Email or password incorrect.")).toBeVisible();
+    await expect(page).toHaveURL(/\/login(\?|$)/);
+  });
+
+  test("an unknown email shows the same generic error", async ({ page }) => {
+    await page.goto("/login");
+    await page.fill("#email", `nobody-${Date.now()}@e2e.local`);
+    await page.fill("#password", "definitely-wrong");
+    await page.click("button[type=submit]");
+
+    await expect(page.getByText("Email or password incorrect.")).toBeVisible();
+  });
+
+  test("'remember me' sets a persistent session cookie", async ({
+    page,
+    context,
+  }) => {
+    await login(page, TEST_USER.email, TEST_USER.password, { remember: true });
+
+    const cookies = await context.cookies();
+    const nowSeconds = Date.now() / 1000;
+    const persistent = cookies.some(
+      (c) => c.expires > nowSeconds + 29 * 24 * 60 * 60,
+    );
+    expect(persistent).toBe(true);
+  });
+
+  test("protected pages redirect to /login when signed out", async ({
+    page,
+  }) => {
+    for (const path of ["/", "/settings", "/ranking", "/user/1"]) {
+      await page.goto(path);
+      await page.waitForURL(/\/login(\?|$)/);
+    }
+  });
+});

--- a/tests/e2e/match-detail.spec.ts
+++ b/tests/e2e/match-detail.spec.ts
@@ -1,12 +1,5 @@
 import { expect, test } from "@playwright/test";
-
-async function login(page: import("@playwright/test").Page): Promise<void> {
-  await page.goto("/login");
-  await page.fill("#email", "me@dev.local");
-  await page.fill("#password", "test1234");
-  await page.click("button[type=submit]");
-  await page.waitForURL("http://localhost:3000/");
-}
+import { login } from "./helpers";
 
 test.describe("match detail status badges", () => {
   test("FINISHED match shows the FULL TIME badge", async ({ page }) => {
@@ -23,7 +16,7 @@ test.describe("match detail status badges", () => {
     await expect(page.getByText("LIVE", { exact: true }).first()).toBeVisible();
   });
 
-  test("SCHEDULED match shows the SCHEDULED badge and the German kickoff date", async ({
+  test("an upcoming match shows the SCHEDULED badge and a localized kickoff date", async ({
     page,
   }) => {
     await login(page);
@@ -31,7 +24,11 @@ test.describe("match detail status badges", () => {
     await expect(
       page.getByText("SCHEDULED", { exact: true }).first(),
     ).toBeVisible();
-    const germanWeekday = page.locator("text=/Montag|Dienstag|Mittwoch|Donnerstag|Freitag|Samstag|Sonntag/");
-    await expect(germanWeekday.first()).toBeVisible();
+    // Locale is forced to English for the suite, so the long weekday renders in
+    // English (formatDate uses `weekday: "long"`).
+    const weekday = page.locator(
+      "text=/Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday/",
+    );
+    await expect(weekday.first()).toBeVisible();
   });
 });

--- a/tests/e2e/mobile-smoke.spec.ts
+++ b/tests/e2e/mobile-smoke.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test, type Page } from "@playwright/test";
+import { login } from "./helpers";
+
+test.use({ viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true });
+
+async function expectNoHorizontalScroll(page: Page): Promise<void> {
+  const overflow = await page.evaluate(
+    () =>
+      document.documentElement.scrollWidth -
+      document.documentElement.clientWidth,
+  );
+  expect(overflow, "horizontal overflow in px").toBeLessThanOrEqual(1);
+}
+
+test.describe("mobile smoke", () => {
+  test("the login page fits the viewport", async ({ page }) => {
+    await page.goto("/login");
+    await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible();
+    await expectNoHorizontalScroll(page);
+  });
+
+  test("the main authenticated pages fit the viewport", async ({ page }) => {
+    await login(page);
+
+    const pages: Array<{ path: string; expect: () => Promise<void> }> = [
+      {
+        path: "/",
+        expect: async () =>
+          expect(page.getByText("UPCOMING FIXTURES")).toBeVisible(),
+      },
+      {
+        path: "/ranking",
+        expect: async () =>
+          expect(
+            page.getByRole("button", { name: "Global", exact: true }),
+          ).toBeVisible(),
+      },
+      {
+        path: "/user/6",
+        expect: async () =>
+          expect(page.getByText("SECRET WINNER").first()).toBeVisible(),
+      },
+      {
+        path: "/match/1",
+        expect: async () =>
+          expect(page.getByText("FULL TIME").first()).toBeVisible(),
+      },
+      {
+        path: "/settings",
+        expect: async () =>
+          expect(page.getByText("Profile Settings").first()).toBeVisible(),
+      },
+      {
+        path: "/features",
+        expect: async () => expect(page.locator("h1").first()).toBeVisible(),
+      },
+    ];
+
+    for (const p of pages) {
+      await page.goto(p.path);
+      await p.expect();
+      await expectNoHorizontalScroll(page);
+    }
+  });
+
+  test("logout works from the mobile settings header", async ({ page }) => {
+    await login(page);
+    await page.goto("/settings");
+
+    // BottomNav has no logout; the mobile settings header carries it. The page
+    // also has a desktop-only logout button (hidden here), so pick the visible.
+    await page
+      .locator('form[action="/api/auth/logout"] button')
+      .filter({ visible: true })
+      .first()
+      .click();
+    await page.waitForURL(/\/login(\?|$)/);
+  });
+});

--- a/tests/e2e/profile-privacy.spec.ts
+++ b/tests/e2e/profile-privacy.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+import { login, TEST_USER, OTHER_USER } from "./helpers";
+
+test.describe("profile privacy", () => {
+  test("a foreign profile never exposes the user's email", async ({ page }) => {
+    await login(page);
+    await page.goto(`/user/${OTHER_USER.id}`);
+
+    // The profile renders, but no email address is shown.
+    await expect(page.getByText("SECRET WINNER").first()).toBeVisible();
+    await expect(page.getByText(OTHER_USER.email)).toHaveCount(0);
+    await expect(page.locator("text=/@local\\.dev/")).toHaveCount(0);
+  });
+
+  test("your own profile page also hides the email", async ({ page }) => {
+    await login(page);
+    await page.goto(`/user/${TEST_USER.id}`);
+
+    await expect(page.getByText(TEST_USER.email)).toHaveCount(0);
+  });
+
+  test("your email is visible on your own settings page", async ({ page }) => {
+    await login(page);
+    await page.goto("/settings");
+
+    await expect(page.getByText(TEST_USER.email).first()).toBeVisible();
+  });
+});

--- a/tests/e2e/profile.spec.ts
+++ b/tests/e2e/profile.spec.ts
@@ -1,12 +1,5 @@
 import { expect, test } from "@playwright/test";
-
-async function login(page: import("@playwright/test").Page): Promise<void> {
-  await page.goto("/login");
-  await page.fill("#email", "me@dev.local");
-  await page.fill("#password", "test1234");
-  await page.click("button[type=submit]");
-  await page.waitForURL("http://localhost:3000/");
-}
+import { login } from "./helpers";
 
 test.describe("profile page", () => {
   test("renders four stat tiles and a history table without tournament bonuses", async ({

--- a/tests/e2e/ranking.spec.ts
+++ b/tests/e2e/ranking.spec.ts
@@ -1,12 +1,5 @@
 import { expect, test } from "@playwright/test";
-
-async function login(page: import("@playwright/test").Page): Promise<void> {
-  await page.goto("/login");
-  await page.fill("#email", "me@dev.local");
-  await page.fill("#password", "test1234");
-  await page.click("button[type=submit]");
-  await page.waitForURL("http://localhost:3000/");
-}
+import { login } from "./helpers";
 
 test.describe("ranking page", () => {
   test("renders the four tabs and the scoring legend", async ({ page }) => {

--- a/tests/e2e/settings-password.spec.ts
+++ b/tests/e2e/settings-password.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "@playwright/test";
+import { login, logout, signupNewUser, PASSWORD } from "./helpers";
+
+// Each test registers its own throwaway account so changing a password never
+// disturbs the seeded users other specs rely on.
+test.describe("password change", () => {
+  test("changing the password succeeds and the new password works", async ({
+    page,
+  }) => {
+    const account = await signupNewUser(page, "pwok");
+    await login(page, account.email, PASSWORD);
+
+    await page.goto("/settings");
+    await page.fill("#currentPassword", PASSWORD);
+    await page.fill("#newPassword", "brandnew-123");
+    await page.fill("#confirmPassword", "brandnew-123");
+    await page.getByRole("button", { name: "Update Password" }).click();
+
+    await expect(
+      page.getByText("Password updated successfully."),
+    ).toBeVisible();
+
+    await logout(page);
+    await login(page, account.email, "brandnew-123");
+    await expect(page).toHaveURL((url) => url.pathname === "/");
+  });
+
+  test("a wrong current password is rejected by the server", async ({
+    page,
+  }) => {
+    const account = await signupNewUser(page, "pwwrong");
+    await login(page, account.email, PASSWORD);
+
+    await page.goto("/settings");
+    await page.fill("#currentPassword", "not-my-password");
+    await page.fill("#newPassword", "brandnew-123");
+    await page.fill("#confirmPassword", "brandnew-123");
+    await page.getByRole("button", { name: "Update Password" }).click();
+
+    await expect(
+      page.getByText("Current password is incorrect."),
+    ).toBeVisible();
+  });
+
+  test("a too-short new password is rejected client-side", async ({ page }) => {
+    const account = await signupNewUser(page, "pwshort");
+    await login(page, account.email, PASSWORD);
+
+    await page.goto("/settings");
+    await page.fill("#currentPassword", PASSWORD);
+    await page.fill("#newPassword", "short");
+    await page.fill("#confirmPassword", "short");
+    await page.getByRole("button", { name: "Update Password" }).click();
+
+    await expect(
+      page.getByText("New password must be at least 8 characters."),
+    ).toBeVisible();
+  });
+
+  test("mismatched new passwords are rejected client-side", async ({
+    page,
+  }) => {
+    const account = await signupNewUser(page, "pwmismatch");
+    await login(page, account.email, PASSWORD);
+
+    await page.goto("/settings");
+    await page.fill("#currentPassword", PASSWORD);
+    await page.fill("#newPassword", "brandnew-123");
+    await page.fill("#confirmPassword", "brandnew-999");
+    await page.getByRole("button", { name: "Update Password" }).click();
+
+    await expect(page.getByText("Passwords do not match.")).toBeVisible();
+  });
+});

--- a/tests/e2e/signup.spec.ts
+++ b/tests/e2e/signup.spec.ts
@@ -1,0 +1,103 @@
+import { expect, test } from "@playwright/test";
+import { fillSignupForm, PASSWORD } from "./helpers";
+
+// Positive signup is covered in auth-flow.spec.ts; this file focuses on the
+// negative/validation cases.
+test.describe("signup validation", () => {
+  test("rejects mismatched passwords", async ({ page }) => {
+    await fillSignupForm(page, {
+      username: `mismatch_${Date.now()}`,
+      email: `mismatch-${Date.now()}@e2e.local`,
+      password: PASSWORD,
+      rePassword: "different-9",
+    });
+    await page.click("button[type=submit]");
+
+    await expect(page.getByText("Passwords do not match.")).toBeVisible();
+    await expect(page).toHaveURL(/\/signup$/);
+  });
+
+  test("rejects a password shorter than 8 characters", async ({ page }) => {
+    await fillSignupForm(page, {
+      username: `short_${Date.now()}`,
+      email: `short-${Date.now()}@e2e.local`,
+      password: "short",
+      rePassword: "short",
+    });
+    await page.click("button[type=submit]");
+
+    await expect(page.getByText("Invalid password")).toBeVisible();
+  });
+
+  test("rejects identical tournament winner and secret winner", async ({
+    page,
+  }) => {
+    await fillSignupForm(page, {
+      username: `samewinner_${Date.now()}`,
+      email: `samewinner-${Date.now()}@e2e.local`,
+      winner: "DEU",
+      secretWinner: "DEU",
+    });
+    await page.click("button[type=submit]");
+
+    await expect(
+      page.getByText("Winner and secret winner must differ."),
+    ).toBeVisible();
+  });
+
+  test("rejects a username that is already taken (409)", async ({ page }) => {
+    // "TestUser" is a seeded username.
+    await fillSignupForm(page, {
+      username: "TestUser",
+      email: `fresh-${Date.now()}@e2e.local`,
+    });
+    await page.click("button[type=submit]");
+
+    await expect(
+      page.getByText("This username is already taken."),
+    ).toBeVisible();
+    await expect(page).toHaveURL(/\/signup$/);
+  });
+
+  test("rejects an email that is already registered", async ({ page }) => {
+    await fillSignupForm(page, {
+      username: `dupemail_${Date.now()}`,
+      email: "test.user@local.dev",
+    });
+    await page.click("button[type=submit]");
+
+    await expect(
+      page.getByText("This email is already registered."),
+    ).toBeVisible();
+  });
+
+  test("shows the username-is-not-email and valantic-domain hints", async ({
+    page,
+  }) => {
+    await page.goto("/signup");
+    await expect(
+      page.getByText("This is not your email address."),
+    ).toBeVisible();
+    await expect(
+      page.getByText("Only valantic.com email addresses are allowed."),
+    ).toBeVisible();
+  });
+
+  // The valantic.com domain restriction is only enforced when NODE_ENV is
+  // "production"; the dev/test stand intentionally accepts any domain so the
+  // other flows can run. Verified by unit tests on isAllowedSignupEmailDomain.
+  test("rejects a non-valantic email (production only)", async ({ page }) => {
+    test.skip(
+      process.env.NODE_ENV !== "production",
+      "domain restriction is production-only",
+    );
+    await fillSignupForm(page, {
+      username: `outsider_${Date.now()}`,
+      email: `outsider-${Date.now()}@gmail.com`,
+    });
+    await page.click("button[type=submit]");
+    await expect(
+      page.getByText("Only valantic.com email addresses are allowed."),
+    ).toBeVisible();
+  });
+});

--- a/tests/e2e/tip.spec.ts
+++ b/tests/e2e/tip.spec.ts
@@ -1,45 +1,108 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Locator, type Page } from "@playwright/test";
+import { login } from "./helpers";
 
-async function login(page: import("@playwright/test").Page): Promise<void> {
-  await page.goto("/login");
-  await page.fill("#email", "me@dev.local");
-  await page.fill("#password", "test1234");
-  await page.click("button[type=submit]");
-  await page.waitForURL("http://localhost:3000/");
+// A dashboard match card (MatchRow) is the only place a tip is entered. Cards
+// are scoped by the unique pair of team abbreviations they contain. View mode
+// renders the score as "H : A"; edit mode renders number inputs + a SAVE button.
+function upcomingCard(page: Page, home: string, away: string): Locator {
+  return page
+    .locator("section")
+    .filter({ hasText: "UPCOMING FIXTURES" })
+    .locator("div.rounded-lg.p-lg")
+    .filter({ has: page.getByText(home, { exact: true }) })
+    .filter({ has: page.getByText(away, { exact: true }) })
+    .first();
+}
+
+async function submitScores(
+  card: Locator,
+  home: string,
+  away: string,
+): Promise<void> {
+  await card.getByLabel("Home score tip").fill(home);
+  const awayInput = card.getByLabel("Away score tip");
+  await awayInput.fill(away);
+  // Submitting via Enter avoids the duplicated mobile/desktop SAVE buttons.
+  await awayInput.press("Enter");
 }
 
 test.describe("tip flow", () => {
-  test("entering a tip for a SCHEDULED match persists across reload", async ({
+  test("submitting a tip on an untipped upcoming match shows view mode and persists", async ({
     page,
   }) => {
     await login(page);
 
-    const homeInput = page.getByLabel("Home score tip").first();
-    const awayInput = page.getByLabel("Away score tip").first();
-    await expect(homeInput).toBeVisible();
+    // Match 8 (NED vs CRO) is upcoming and untipped for the seeded TestUser.
+    const card = upcomingCard(page, "NED", "CRO");
+    await expect(card.getByLabel("Home score tip")).toBeVisible();
 
-    await homeInput.fill("2");
-    await awayInput.fill("1");
+    await submitScores(card, "2", "1");
 
-    const form = homeInput.locator("xpath=ancestor::form");
-    await form.getByRole("button").click();
-
-    await expect(form.getByRole("button")).toHaveText(/SAVED|EDIT/, {
-      timeout: 10_000,
-    });
+    await expect(
+      upcomingCard(page, "NED", "CRO").getByText("2 : 1"),
+    ).toBeVisible();
 
     await page.reload();
-    const homeAfter = page.getByLabel("Home score tip").first();
-    const awayAfter = page.getByLabel("Away score tip").first();
-    await expect(homeAfter).toHaveValue("2");
-    await expect(awayAfter).toHaveValue("1");
+    await expect(
+      upcomingCard(page, "NED", "CRO").getByText("2 : 1"),
+    ).toBeVisible();
   });
 
-  test("a FINISHED match exposes no editable tip input", async ({ page }) => {
+  test("an existing tip can be edited and the new value persists", async ({
+    page,
+  }) => {
+    await login(page);
+
+    // Match 7 (ESP vs ITA) is upcoming and seeded with TestUser's 2:0 tip.
+    const card = upcomingCard(page, "ESP", "ITA");
+    await expect(card.getByText("2 : 0")).toBeVisible();
+
+    // Clicking the score enters edit mode.
+    await card.getByText("2 : 0").click();
+    await submitScores(card, "3", "1");
+
+    await expect(
+      upcomingCard(page, "ESP", "ITA").getByText("3 : 1"),
+    ).toBeVisible();
+
+    await page.reload();
+    await expect(
+      upcomingCard(page, "ESP", "ITA").getByText("3 : 1"),
+    ).toBeVisible();
+  });
+
+  test("an empty score is rejected and the form stays editable", async ({
+    page,
+  }) => {
+    await login(page);
+
+    // Match 10 (FRA vs POL) is upcoming and untipped.
+    const card = upcomingCard(page, "FRA", "POL");
+    await card.getByLabel("Home score tip").fill("2");
+    const away = card.getByLabel("Away score tip");
+    await away.fill("");
+    await away.press("Enter");
+
+    // Required validation blocks the submit: still in edit mode, no view score.
+    await expect(card.getByLabel("Home score tip")).toBeVisible();
+    await expect(card.getByText(/^\d+ : \d+$/)).toHaveCount(0);
+  });
+
+  test("a live match is not tippable", async ({ page }) => {
+    await login(page);
+
+    const liveSection = page.locator("section").filter({ hasText: "LIVE NOW" });
+    await expect(liveSection).toBeVisible();
+    // Live matches render as plain links — no editable tip input.
+    await expect(liveSection.getByLabel("Home score tip")).toHaveCount(0);
+  });
+
+  test("a FINISHED match detail page exposes no editable tip input", async ({
+    page,
+  }) => {
     await login(page);
     await page.goto("/match/1");
 
-    const tipInputs = page.getByLabel("Home score tip");
-    await expect(tipInputs).toHaveCount(0);
+    await expect(page.getByLabel("Home score tip")).toHaveCount(0);
   });
 });

--- a/tests/e2e/winner-edit.spec.ts
+++ b/tests/e2e/winner-edit.spec.ts
@@ -1,12 +1,5 @@
 import { expect, test } from "@playwright/test";
-
-async function login(page: import("@playwright/test").Page): Promise<void> {
-  await page.goto("/login");
-  await page.fill("#email", "me@dev.local");
-  await page.fill("#password", "test1234");
-  await page.click("button[type=submit]");
-  await page.waitForURL("http://localhost:3000/");
-}
+import { login, ORIGIN } from "./helpers";
 
 test.describe("winner edit (locked path)", () => {
   test("own profile shows no Edit button when tournament has started", async ({
@@ -44,7 +37,7 @@ test.describe("winner edit (locked path)", () => {
 
     const res = await page.request.post("/api/user/winners", {
       form: { winner: "DEU", secretWinner: "ESP" },
-      headers: { Origin: "http://localhost:3000" },
+      headers: { Origin: ORIGIN },
     });
     expect(res.status()).toBe(400);
     const body = (await res.json()) as { error?: string };
@@ -58,7 +51,7 @@ test.describe("winner edit (locked path)", () => {
 
     const res = await page.request.post("/api/user/winners", {
       form: { winner: "ESP", secretWinner: "ESP" },
-      headers: { Origin: "http://localhost:3000" },
+      headers: { Origin: ORIGIN },
     });
     expect(res.status()).toBe(400);
   });
@@ -66,7 +59,7 @@ test.describe("winner edit (locked path)", () => {
   test("POST /api/user/winners requires a session", async ({ request }) => {
     const res = await request.post("/api/user/winners", {
       form: { winner: "DEU", secretWinner: "ESP" },
-      headers: { Origin: "http://localhost:3000" },
+      headers: { Origin: ORIGIN },
     });
     expect(res.status()).toBe(401);
     const body = (await res.json()) as { error?: string };


### PR DESCRIPTION
## Background
The app only had a handful of E2E specs and they had drifted from the current UI and seed data, so they no longer ran. We want a broad, deterministic Playwright suite covering the main user journeys with both happy-path and failure/validation cases, runnable before every deploy without any dependency on the shared/production database.

A small, coordinated change to the read API (its bind address becomes environment-configurable) is a prerequisite so the suite can run its own read-API instance on a dedicated port alongside a developer's running stack. That change is being landed separately in coordination with ongoing work in that repo; this PR should merge after it.

## What this changes
Adds an isolated end-to-end test stand that seeds a dedicated test database and boots its own frontend and read-API instances on separate ports, so the suite never touches the shared database. The suite now covers sign-in and sign-out (including the mobile path and remember-me), sign-up validation, tipping (entering, editing, persistence, locked/live matches, invalid input), password changes, avatar upload, language switching and persistence, profile privacy, and a mobile-viewport smoke pass across the main pages — each with positive and negative cases. A separate, documented end-to-end mode is available in the quality-gate script.