### PR TITLE
XR-007: fix missing Material Symbols icons in production (CSP)

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -17,7 +17,10 @@ const CSP = [
   "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
   "font-src 'self' https://fonts.gstatic.com",
   "img-src 'self' data:",
-  "connect-src 'self'",
+  // The service worker (Serwist defaultCache) re-fetches the Material Symbols
+  // icon font from Google Fonts with its own fetch(), which is governed by this
+  // CSP. These origins are already trusted by style-src/font-src.
+  "connect-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com",
   "frame-ancestors 'none'",
   "form-action 'self'",
   "base-uri 'self'",


### PR DESCRIPTION
## Background
In production the Material Symbols icons rendered as their ligature text (e.g. `save`, `person`) instead of the glyphs. The service worker re-fetches the icon font from Google Fonts with its own request, and that request is governed by the page Content-Security-Policy, whose `connect-src` only allowed same-origin — so the cross-origin font fetch was blocked. (There is no service worker in development, so this only affected production.)

## What this changes
Allows the two Google Fonts origins in `connect-src` (they are already trusted by `style-src`/`font-src`), so the service worker can fetch and cache the icon font. Icons now render in production.