### PR TITLE
FE-078: mobile UX polish (language, logout, ranking labels, tabs, texts)

### DIFF
--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -6,6 +6,7 @@ import { TopAppBar } from "@/components/dashboard/TopAppBar";
 import { BottomNav } from "@/components/dashboard/BottomNav";
 import { PasswordChangeForm } from "@/components/settings/PasswordChangeForm";
 import { AvatarUpload } from "@/components/settings/AvatarUpload";
+import { LocaleSwitcher } from "@/components/LocaleSwitcher";
 import { ReminderPreferences } from "@/components/settings/ReminderPreferences";
 import {
   getEnabledLeadMinutes,
@@ -48,10 +49,9 @@ export default async function SettingsPage(): Promise<React.ReactElement> {
         <form action="/api/auth/logout" method="POST">
           <button
             type="submit"
-            aria-label={t("logout")}
-            className="material-symbols-outlined text-primary"
+            className="text-label-caps uppercase font-bold text-primary border border-outline-variant rounded-lg px-3 py-1.5 active:scale-95 transition-colors"
           >
-            logout
+            {t("logout")}
           </button>
         </form>
       </header>
@@ -106,6 +106,18 @@ export default async function SettingsPage(): Promise<React.ReactElement> {
                   </p>
                 </div>
                 <LogoutButton label={t("logout")} />
+              </div>
+            </section>
+
+            <section className="bg-surface-container rounded-lg p-lg border border-outline-variant">
+              <h2 className="text-label-caps uppercase tracking-widest text-primary mb-lg">
+                {t("language")}
+              </h2>
+              <div className="flex items-center justify-between gap-md p-md bg-surface-container-highest border border-outline-variant rounded-lg">
+                <p className="text-body-sm text-on-surface-variant">
+                  {t("languageHint")}
+                </p>
+                <LocaleSwitcher />
               </div>
             </section>
           </div>

--- a/components/dashboard/TabBar.tsx
+++ b/components/dashboard/TabBar.tsx
@@ -25,7 +25,7 @@ export function TabBar({
         <h3 className="text-label-caps uppercase text-on-surface mb-md">
           {t("ranking")}
         </h3>
-        <div className="flex gap-sm overflow-x-auto no-scrollbar">
+        <div className="flex flex-wrap gap-sm">
           {tabs.map((tab) => {
             const isActive = tab.id === active;
             return (

--- a/components/dashboard/TopAppBar.tsx
+++ b/components/dashboard/TopAppBar.tsx
@@ -17,9 +17,12 @@ export function TopAppBar({ active }: TopAppBarProps): React.ReactElement {
   return (
     <header className="bg-background border-b border-outline-variant fixed top-0 left-0 w-full z-40 hidden md:block">
       <div className="flex justify-between items-center w-full px-margin-desktop h-16 max-w-(--container-max-desktop) mx-auto">
-        <div className="text-headline-md font-black text-on-background tracking-tighter">
+        <Link
+          href="/"
+          className="text-headline-md font-black text-on-background tracking-tighter hover:text-primary transition-colors"
+        >
           {t("title")}
-        </div>
+        </Link>
         <nav className="flex gap-lg">
           {LINKS.map((link) => {
             const isActive = link.id === active;

--- a/components/ranking/RankingTable.tsx
+++ b/components/ranking/RankingTable.tsx
@@ -174,7 +174,7 @@ export function RankingTable({
                     className="flex flex-col items-center bg-surface-container rounded p-xs"
                   >
                     <dt className="text-label-caps uppercase text-on-surface-variant">
-                      {t(col.shortKey)}
+                      {t(col.fullKey)}
                     </dt>
                     <dd
                       className={`font-mono text-data-mono ${

--- a/messages/de.json
+++ b/messages/de.json
@@ -104,7 +104,7 @@
     "userCount": "{count, plural, one {# Nutzer} other {# Nutzer}}",
     "pointAbbrev": "P",
     "offline": "Rangliste-API offline",
-    "offlineHint": "Die Tabellenstände erscheinen, sobald der Rust-Service läuft."
+    "offlineHint": "Die Tabellenstände erscheinen, sobald der Dienst wieder verfügbar ist."
   },
   "Scoring": {
     "title": "Punktesystem",
@@ -141,7 +141,7 @@
     "save": "Speichern",
     "predictionHistory": "Tipp-Verlauf",
     "serviceOffline": "Service offline",
-    "historyOfflineHint": "Der Tipp-Verlauf erscheint, sobald der Rust-Service läuft.",
+    "historyOfflineHint": "Der Tipp-Verlauf erscheint, sobald der Dienst wieder verfügbar ist.",
     "noPredictions": "Noch keine Tipps",
     "match": "Spiel",
     "prediction": "Tipp",
@@ -165,7 +165,7 @@
     "userPredictions": "Nutzer-Tipps",
     "sortedByPoints": "Sortiert nach erzielten Punkten",
     "predictionsOffline": "Tipp-Service offline",
-    "predictionsOfflineHint": "Die Nutzer-Tipps erscheinen, sobald der Rust-Service läuft.",
+    "predictionsOfflineHint": "Die Nutzer-Tipps erscheinen, sobald der Dienst wieder verfügbar ist.",
     "rank": "RANG",
     "user": "NUTZER",
     "predictionCol": "TIPP",
@@ -265,7 +265,7 @@
     "reminderSaved": "Erinnerungen gespeichert.",
     "pushHeading": "Push-Benachrichtigungen",
     "pushChannel": "Push im Browser aktivieren",
-    "pushHint": "Erhalte Erinnerungen als Browser-Benachrichtigung, auch wenn die App nicht geöffnet ist. Funktioniert nur in der installierten App (pnpm build && pnpm start), nicht im Entwicklungsmodus.",
+    "pushHint": "Erhalte Erinnerungen als Browser-Benachrichtigung, auch wenn die App nicht geöffnet ist. Verfügbar, sobald du die App zum Startbildschirm hinzufügst.",
     "pushWorking": "Wird eingerichtet …",
     "pushUnsupported": "Push wird von diesem Browser nicht unterstützt.",
     "pushPermissionDenied": "Benachrichtigungen wurden abgelehnt. Bitte erlaube sie in den Browser-Einstellungen.",

--- a/messages/de.json
+++ b/messages/de.json
@@ -218,6 +218,8 @@
   "Settings": {
     "title": "Profil-Einstellungen",
     "subtitle": "Verwalte deine Konto-Identität und Sicherheitseinstellungen.",
+    "language": "Sprache",
+    "languageHint": "Anzeigesprache",
     "identity": "Identität",
     "security": "Sicherheit & Zugangsdaten",
     "session": "Sitzungsverwaltung",

--- a/messages/en.json
+++ b/messages/en.json
@@ -218,6 +218,8 @@
   "Settings": {
     "title": "Profile Settings",
     "subtitle": "Manage your account identity and security preferences.",
+    "language": "Language",
+    "languageHint": "Display language",
     "identity": "Identity",
     "security": "Security & Credentials",
     "session": "Session Management",

--- a/messages/en.json
+++ b/messages/en.json
@@ -104,7 +104,7 @@
     "userCount": "{count, plural, one {# user} other {# users}}",
     "pointAbbrev": "P",
     "offline": "Ranking API offline",
-    "offlineHint": "The standings will appear once the Rust service is up."
+    "offlineHint": "The standings will appear once the service is back online."
   },
   "Scoring": {
     "title": "Scoring System",
@@ -141,7 +141,7 @@
     "save": "Save",
     "predictionHistory": "Prediction History",
     "serviceOffline": "Service offline",
-    "historyOfflineHint": "Prediction history will appear once the Rust service is up.",
+    "historyOfflineHint": "Prediction history will appear once the service is back online.",
     "noPredictions": "No predictions yet",
     "match": "Match",
     "prediction": "Prediction",
@@ -165,7 +165,7 @@
     "userPredictions": "User Predictions",
     "sortedByPoints": "Sorted by Points Scored",
     "predictionsOffline": "Predictions service offline",
-    "predictionsOfflineHint": "The user predictions will appear once the Rust service is up.",
+    "predictionsOfflineHint": "The user predictions will appear once the service is back online.",
     "rank": "RANK",
     "user": "USER",
     "predictionCol": "PREDICTION",
@@ -265,7 +265,7 @@
     "reminderSaved": "Reminders saved.",
     "pushHeading": "Push notifications",
     "pushChannel": "Enable push in this browser",
-    "pushHint": "Get reminders as a browser notification, even when the app is not open. Works only in the installed app (pnpm build && pnpm start), not in development mode.",
+    "pushHint": "Get reminders as a browser notification, even when the app isn't open. Available once you install the app to your home screen.",
     "pushWorking": "Setting up …",
     "pushUnsupported": "Push is not supported by this browser.",
     "pushPermissionDenied": "Notifications were denied. Please allow them in your browser settings.",


### PR DESCRIPTION
## Background
Several mobile and copy issues surfaced on the live site: the language switcher was desktop-only, the mobile settings logout was an icon-only control, the ranking columns used cryptic abbreviations on mobile, the department tabs were cut off, the app title was not clickable, and a reminder hint exposed developer-only instructions to end users.

## What this changes
Adds a language switcher and a clearly labelled logout button to the settings page so both work on mobile. The ranking shows full column labels on mobile, the department tabs wrap so all are visible, and the app title links back to the home page. End-user hint texts no longer mention developer build steps or internal service names.