### PR TITLE
FE-079: mobile footer + tip layout

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -29,7 +29,7 @@ export function Footer(): React.ReactElement {
             {t("featuresHeading")}
           </Link>
 
-          <div className="flex items-center gap-md">
+          <div className="flex items-center justify-center gap-md self-center md:self-auto">
             <a
               aria-label="GitHub"
               href={GITHUB_URL}

--- a/components/dashboard/TipForm.tsx
+++ b/components/dashboard/TipForm.tsx
@@ -103,7 +103,7 @@ export function TipForm({
   if (!isEditing && savedTip) {
     return (
       <div className="flex flex-col gap-xs">
-        <div className="flex items-center gap-md justify-end">
+        <div className="flex items-center gap-md justify-between md:justify-end">
           <div
             onClick={disabled ? undefined : enterEdit}
             className={`text-headline-md font-mono min-h-12 flex items-center tabular-nums ${
@@ -147,7 +147,7 @@ export function TipForm({
     >
       <form
         onSubmit={onSubmit}
-        className="flex items-center gap-md justify-end"
+        className="flex items-center gap-md justify-between md:justify-end"
       >
         <div className="flex gap-xs items-center">
           <input


### PR DESCRIPTION
## Background
On mobile the footer's GitHub link was left-aligned while the other footer items were centered, and the tip entry row was right-justified and looked cramped.

## What this changes
Centers the footer GitHub link on mobile (consistent with the other footer items) and balances the tip entry/score row across the card width on mobile, while keeping the desktop layout unchanged.