### PR TITLE
FE-080: install-the-app prompt in settings

### DIFF
--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -7,6 +7,7 @@ import { BottomNav } from "@/components/dashboard/BottomNav";
 import { PasswordChangeForm } from "@/components/settings/PasswordChangeForm";
 import { AvatarUpload } from "@/components/settings/AvatarUpload";
 import { LocaleSwitcher } from "@/components/LocaleSwitcher";
+import { InstallApp } from "@/components/InstallApp";
 import { ReminderPreferences } from "@/components/settings/ReminderPreferences";
 import {
   getEnabledLeadMinutes,
@@ -120,6 +121,8 @@ export default async function SettingsPage(): Promise<React.ReactElement> {
                 <LocaleSwitcher />
               </div>
             </section>
+
+            <InstallApp />
           </div>
 
           <div className="lg:col-span-7 space-y-lg">

--- a/components/InstallApp.tsx
+++ b/components/InstallApp.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+}
+
+type Mode = "loading" | "hidden" | "android" | "ios";
+
+function isStandalone(): boolean {
+  const nav = window.navigator as Navigator & { standalone?: boolean };
+  return (
+    window.matchMedia("(display-mode: standalone)").matches ||
+    nav.standalone === true
+  );
+}
+
+function isIos(): boolean {
+  const nav = window.navigator;
+  const iOSDevice = /iphone|ipad|ipod/i.test(nav.userAgent);
+  // iPadOS reports a desktop UA but has touch points.
+  const iPadOS = nav.platform === "MacIntel" && nav.maxTouchPoints > 1;
+  return iOSDevice || iPadOS;
+}
+
+/**
+ * "Install the app" card. Self-hides unless the app is genuinely installable:
+ * - Android/Chrome: shows a button that triggers the native install dialog
+ *   (captured from `beforeinstallprompt`).
+ * - iOS/Safari: shows the manual "Share → Add to Home Screen" instruction.
+ * - Desktop, or already installed (standalone): renders nothing.
+ * It lives in the account/settings area, so it only appears after login.
+ */
+export function InstallApp(): React.ReactElement | null {
+  const t = useTranslations("Install");
+  const [mode, setMode] = useState<Mode>("loading");
+  const [deferred, setDeferred] = useState<BeforeInstallPromptEvent | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (isStandalone()) {
+      setMode("hidden");
+      return;
+    }
+    if (isIos()) {
+      setMode("ios");
+      return;
+    }
+    // Android / Chromium: wait for the installability signal. Desktop stays
+    // hidden because we only set "android" once this fires on a mobile-eligible
+    // context and we never surface it elsewhere.
+    const onPrompt = (event: Event): void => {
+      event.preventDefault();
+      setDeferred(event as BeforeInstallPromptEvent);
+      setMode("android");
+    };
+    const onInstalled = (): void => setMode("hidden");
+    window.addEventListener("beforeinstallprompt", onPrompt);
+    window.addEventListener("appinstalled", onInstalled);
+    return () => {
+      window.removeEventListener("beforeinstallprompt", onPrompt);
+      window.removeEventListener("appinstalled", onInstalled);
+    };
+  }, []);
+
+  if (mode === "loading" || mode === "hidden") return null;
+
+  async function install(): Promise<void> {
+    if (!deferred) return;
+    await deferred.prompt();
+    await deferred.userChoice;
+    setDeferred(null);
+    setMode("hidden");
+  }
+
+  return (
+    <section className="bg-surface-container rounded-lg p-lg border border-outline-variant">
+      <h2 className="text-label-caps uppercase tracking-widest text-primary mb-md">
+        {t("title")}
+      </h2>
+      <p className="text-body-sm text-on-surface-variant mb-lg">
+        {t("description")}
+      </p>
+      {mode === "android" ? (
+        <button
+          type="button"
+          onClick={install}
+          className="w-full bg-primary text-on-primary font-bold uppercase tracking-tight py-3 rounded-lg hover:brightness-110 active:scale-[0.98] transition-all"
+        >
+          {t("installButton")}
+        </button>
+      ) : (
+        <div className="flex items-start gap-md p-md bg-surface-container-highest border border-outline-variant rounded-lg">
+          <span
+            aria-hidden="true"
+            className="material-symbols-outlined text-primary"
+          >
+            ios_share
+          </span>
+          <p className="text-body-sm text-on-surface">{t("iosHint")}</p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/messages/de.json
+++ b/messages/de.json
@@ -10,6 +10,12 @@
   "Footer": {
     "featuresHeading": "Funktionen"
   },
+  "Install": {
+    "title": "App installieren",
+    "description": "Schnellzugriff direkt vom Home-Bildschirm – kein App Store nötig.",
+    "installButton": "Installieren",
+    "iosHint": "Auf dem iPhone: unten auf „Teilen“ tippen und dann „Zum Home-Bildschirm hinzufügen“."
+  },
   "Features": {
     "title": "Funktionen",
     "intro": "Was die App kann — ein Überblick für Nutzer und Entwickler.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -10,6 +10,12 @@
   "Footer": {
     "featuresHeading": "Features"
   },
+  "Install": {
+    "title": "Install the app",
+    "description": "Quick access straight from your home screen — no app store needed.",
+    "installButton": "Install",
+    "iosHint": "On iPhone: tap Share at the bottom, then “Add to Home Screen”."
+  },
   "Features": {
     "title": "Features",
     "intro": "What the app can do — an overview for users and developers.",


### PR DESCRIPTION
## Background
Users couldn't easily discover that the site can be installed as an app. We want a clear, non-intrusive way to install it from the account area — not a pushy first-visit banner.

## What this changes
Adds an "Install the app" section to the settings page. On Android/Chrome it shows an Install button that triggers the native install dialog; on iPhone it shows the Share → Add to Home Screen instruction; on desktop or when the app is already installed it shows nothing. Because it lives in settings, it only appears after login.