### PR TITLE
FE-081: language menu + reliable switch on mobile

### DIFF
--- a/components/LocaleSwitcher.tsx
+++ b/components/LocaleSwitcher.tsx
@@ -2,41 +2,43 @@
 
 import { useTransition } from "react";
 import { useLocale } from "next-intl";
-import { useRouter } from "next/navigation";
 import { setLocale } from "@/i18n/locale-action";
 import { locales, type Locale } from "@/i18n/config";
 
+const LOCALE_LABELS: Record<Locale, string> = {
+  de: "Deutsch",
+  en: "English",
+};
+
 export function LocaleSwitcher(): React.ReactElement {
-  const active = useLocale();
-  const router = useRouter();
+  const active = useLocale() as Locale;
   const [pending, startTransition] = useTransition();
 
-  function change(locale: Locale): void {
+  function onChange(event: React.ChangeEvent<HTMLSelectElement>): void {
+    const locale = event.target.value as Locale;
     if (locale === active) return;
     startTransition(async () => {
       await setLocale(locale);
-      router.refresh();
+      // Full reload so the new language is applied even when the service worker
+      // serves a cached RSC payload (a soft router.refresh() showed stale text
+      // on mobile / the installed PWA).
+      window.location.reload();
     });
   }
 
   return (
-    <div className="flex items-center gap-xs" aria-label="Language">
-      {locales.map((l) => (
-        <button
-          key={l}
-          type="button"
-          onClick={() => change(l)}
-          disabled={pending}
-          aria-pressed={l === active}
-          className={`text-label-caps uppercase px-xs transition-colors ${
-            l === active
-              ? "text-primary"
-              : "text-on-surface-variant hover:text-on-surface"
-          }`}
-        >
-          {l}
-        </button>
+    <select
+      aria-label="Language"
+      value={active}
+      onChange={onChange}
+      disabled={pending}
+      className="bg-surface-container-low border border-outline-variant text-on-surface text-body-sm rounded-lg px-md py-2 focus:border-primary focus:outline-none transition-colors disabled:opacity-60"
+    >
+      {locales.map((locale) => (
+        <option key={locale} value={locale}>
+          {LOCALE_LABELS[locale]}
+        </option>
       ))}
-    </div>
+    </select>
   );
 }

--- a/tests/e2e/i18n.spec.ts
+++ b/tests/e2e/i18n.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from "@playwright/test";
 // The suite forces locale=en globally (see playwright.config.ts). These tests
 // clear that cookie to exercise the real default + the switcher persistence.
 test.describe("i18n language switcher", () => {
-  test("defaults to German and the auth-page switcher toggles to English", async ({
+  test("defaults to German and the language menu switches to English", async ({
     page,
     context,
   }) => {
@@ -15,7 +15,7 @@ test.describe("i18n language switcher", () => {
       page.getByRole("button", { name: "Anmelden" }),
     ).toBeVisible();
 
-    await page.getByRole("button", { name: "en", exact: true }).click();
+    await page.getByRole("combobox", { name: "Language" }).selectOption("en");
 
     // Now English → "Sign In".
     await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible();
@@ -28,7 +28,7 @@ test.describe("i18n language switcher", () => {
     await context.clearCookies();
 
     await page.goto("/login");
-    await page.getByRole("button", { name: "en", exact: true }).click();
+    await page.getByRole("combobox", { name: "Language" }).selectOption("en");
     await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible();
 
     await page.reload();


### PR DESCRIPTION
## Background
The language switcher was a pair of tiny de/en toggles, and on mobile / the installed PWA the change often didn't visibly apply because a soft refresh could be served a stale (cached) page by the service worker.

## What this changes
Replaces the toggles with a proper dropdown menu showing the full language names, and applies the choice with a full reload so the new language reliably takes effect everywhere, including on mobile and the installed app.