### PR TITLE
FE-082: keep the DE/EN toggle + drop redundant mobile settings header

### DIFF
--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -42,20 +42,6 @@ export default async function SettingsPage(): Promise<React.ReactElement> {
   return (
     <>
       <TopAppBar active="settings" />
-      {/* Mobile header carries logout because BottomNav has none. */}
-      <header className="flex md:hidden items-center justify-between px-margin-mobile h-16 border-b border-outline-variant bg-background">
-        <span className="text-headline-md font-black text-on-background tracking-tighter">
-          {t("title")}
-        </span>
-        <form action="/api/auth/logout" method="POST">
-          <button
-            type="submit"
-            className="text-label-caps uppercase font-bold text-primary border border-outline-variant rounded-lg px-3 py-1.5 active:scale-95 transition-colors"
-          >
-            {t("logout")}
-          </button>
-        </form>
-      </header>
 
       <main className="pt-4 md:pt-24 pb-24 md:pb-8 px-margin-mobile md:px-margin-desktop max-w-(--container-max-desktop) mx-auto">
         <div className="mb-lg">

--- a/components/LocaleSwitcher.tsx
+++ b/components/LocaleSwitcher.tsx
@@ -5,40 +5,39 @@ import { useLocale } from "next-intl";
 import { setLocale } from "@/i18n/locale-action";
 import { locales, type Locale } from "@/i18n/config";
 
-const LOCALE_LABELS: Record<Locale, string> = {
-  de: "Deutsch",
-  en: "English",
-};
-
 export function LocaleSwitcher(): React.ReactElement {
-  const active = useLocale() as Locale;
+  const active = useLocale();
   const [pending, startTransition] = useTransition();
 
-  function onChange(event: React.ChangeEvent<HTMLSelectElement>): void {
-    const locale = event.target.value as Locale;
+  function change(locale: Locale): void {
     if (locale === active) return;
     startTransition(async () => {
       await setLocale(locale);
-      // Full reload so the new language is applied even when the service worker
+      // Full reload so the new language applies even when the service worker
       // serves a cached RSC payload (a soft router.refresh() showed stale text
-      // on mobile / the installed PWA).
+      // in the installed PWA / on mobile).
       window.location.reload();
     });
   }
 
   return (
-    <select
-      aria-label="Language"
-      value={active}
-      onChange={onChange}
-      disabled={pending}
-      className="bg-surface-container-low border border-outline-variant text-on-surface text-body-sm rounded-lg px-md py-2 focus:border-primary focus:outline-none transition-colors disabled:opacity-60"
-    >
-      {locales.map((locale) => (
-        <option key={locale} value={locale}>
-          {LOCALE_LABELS[locale]}
-        </option>
+    <div className="flex items-center gap-xs" aria-label="Language">
+      {locales.map((l) => (
+        <button
+          key={l}
+          type="button"
+          onClick={() => change(l)}
+          disabled={pending}
+          aria-pressed={l === active}
+          className={`text-label-caps uppercase px-xs transition-colors disabled:opacity-60 ${
+            l === active
+              ? "text-primary"
+              : "text-on-surface-variant hover:text-on-surface"
+          }`}
+        >
+          {l}
+        </button>
       ))}
-    </select>
+    </div>
   );
 }

--- a/tests/e2e/i18n.spec.ts
+++ b/tests/e2e/i18n.spec.ts
@@ -15,7 +15,7 @@ test.describe("i18n language switcher", () => {
       page.getByRole("button", { name: "Anmelden" }),
     ).toBeVisible();
 
-    await page.getByRole("combobox", { name: "Language" }).selectOption("en");
+    await page.getByRole("button", { name: "en", exact: true }).click();
 
     // Now English → "Sign In".
     await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible();
@@ -28,7 +28,7 @@ test.describe("i18n language switcher", () => {
     await context.clearCookies();
 
     await page.goto("/login");
-    await page.getByRole("combobox", { name: "Language" }).selectOption("en");
+    await page.getByRole("button", { name: "en", exact: true }).click();
     await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible();
 
     await page.reload();


### PR DESCRIPTION
## Background
The dropdown language menu was a step back from the simple DE/EN toggle, and the mobile settings page had a redundant header (page title + logout) duplicating the heading and the logout already in the session card.

## What this changes
Restores the compact DE/EN toggle (keeping the full-reload fix so the language reliably switches on mobile and the installed app) and removes the duplicate mobile settings header; logout stays available in the session card.