### PR TITLE
FE-083: WM '26 rebrand

### DIFF
--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
+import { Logo } from "@/components/Logo";
 import { getCurrentSession } from "@/lib/session";
 import { ForgotPasswordForm } from "./forgot-password-form";
 
@@ -22,9 +23,7 @@ export default async function ForgotPasswordPage(): Promise<React.ReactElement> 
     >
       <div className="w-full max-w-[440px] z-10">
         <div className="mb-lg text-center">
-          <h1 className="text-headline-lg font-black text-on-background uppercase tracking-tighter">
-            {t("appName")}
-          </h1>
+          <Logo />
           <p className="text-body-sm text-on-surface-variant mt-xs opacity-60">
             {t("forgotPasswordTitle")}
           </p>

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { getCurrentSession } from "@/lib/session";
+import { Logo } from "@/components/Logo";
 import { LoginForm } from "./login-form";
 
 interface LoginPageProps {
@@ -29,13 +30,8 @@ export default async function LoginPage({
       }}
     >
       <div className="w-full max-w-[440px] z-10">
-        <div className="mb-lg text-center">
-          <h1 className="text-headline-lg font-black text-on-background uppercase tracking-tighter">
-            {t("appName")}
-          </h1>
-          <p className="text-body-sm text-on-surface-variant mt-xs opacity-60">
-            {t("tagline")}
-          </p>
+        <div className="mb-lg">
+          <Logo />
         </div>
 
         <div className="bg-surface-container border border-outline-variant rounded-lg p-xl shadow-2xl">

--- a/app/(auth)/reset-password/page.tsx
+++ b/app/(auth)/reset-password/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
+import { Logo } from "@/components/Logo";
 import { getCurrentSession } from "@/lib/session";
 import { ResetPasswordForm } from "./reset-password-form";
 
@@ -30,9 +31,7 @@ export default async function ResetPasswordPage({
     >
       <div className="w-full max-w-[440px] z-10">
         <div className="mb-lg text-center">
-          <h1 className="text-headline-lg font-black text-on-background uppercase tracking-tighter">
-            {t("appName")}
-          </h1>
+          <Logo />
           <p className="text-body-sm text-on-surface-variant mt-xs opacity-60">
             {t("resetPasswordTitle")}
           </p>

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { getCurrentSession } from "@/lib/session";
+import { Logo } from "@/components/Logo";
 import { SignupForm } from "./signup-form";
 
 export default async function SignupPage(): Promise<React.ReactElement> {
@@ -22,9 +23,7 @@ export default async function SignupPage(): Promise<React.ReactElement> {
     >
       <div className="w-full max-w-[600px]">
         <div className="flex flex-col items-center mb-xl">
-          <h1 className="text-headline-lg font-black text-on-background uppercase tracking-tighter mb-xs">
-            {t("appName")}
-          </h1>
+          <Logo />
         </div>
 
         <div className="bg-surface-container border border-outline-variant rounded-lg p-lg shadow-2xl relative overflow-hidden">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,13 +17,13 @@ const jetbrainsMono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
-  applicationName: "Tournament Predictor",
-  title: "Football Betting",
+  applicationName: "WM ’26",
+  title: "WM ’26 — a valantic guessing game",
   description: "Office tournament pool",
   appleWebApp: {
     capable: true,
     statusBarStyle: "black-translucent",
-    title: "Predictor",
+    title: "WM ’26",
   },
   formatDetection: {
     telephone: false,

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -2,9 +2,9 @@ import type { MetadataRoute } from "next";
 
 export default function manifest(): MetadataRoute.Manifest {
   return {
-    name: "Tournament Predictor",
-    short_name: "Predictor",
-    description: "Office tournament pool",
+    name: "WM ’26 — a valantic guessing game",
+    short_name: "WM ’26",
+    description: "a valantic guessing game",
     start_url: "/",
     display: "standalone",
     background_color: "#121317",

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -1,0 +1,16 @@
+// Brand logo, carried over from the EM '24 frontend: an italic bold title and
+// the "a valantic guessing game" tagline (valantic extra-bold). No custom font
+// is involved — the original "gilroy" class was never defined.
+export function Logo(): React.ReactElement {
+  return (
+    <div className="text-center">
+      <div className="italic text-4xl font-bold text-on-background leading-none">
+        WM ’26
+      </div>
+      <p className="text-sm font-light text-on-surface-variant mt-xs">
+        a <span className="font-extrabold text-white">valantic</span> guessing
+        game
+      </p>
+    </div>
+  );
+}

--- a/components/dashboard/TopAppBar.tsx
+++ b/components/dashboard/TopAppBar.tsx
@@ -19,7 +19,7 @@ export function TopAppBar({ active }: TopAppBarProps): React.ReactElement {
       <div className="flex justify-between items-center w-full px-margin-desktop h-16 max-w-(--container-max-desktop) mx-auto">
         <Link
           href="/"
-          className="text-headline-md font-black text-on-background tracking-tighter hover:text-primary transition-colors"
+          className="text-headline-md italic font-black text-on-background tracking-tighter hover:text-primary transition-colors"
         >
           {t("title")}
         </Link>

--- a/messages/de.json
+++ b/messages/de.json
@@ -1,6 +1,6 @@
 {
   "Nav": {
-    "title": "Turnier-Tipp",
+    "title": "WM ’26",
     "dashboard": "Dashboard",
     "ranking": "Rangliste",
     "profile": "Profil",
@@ -12,21 +12,21 @@
   },
   "Install": {
     "title": "App installieren",
-    "description": "Schnellzugriff direkt vom Home-Bildschirm – kein App Store nötig.",
+    "description": "Schnellzugriff direkt vom Home-Bildschirm â kein App Store nÃ¶tig.",
     "installButton": "Installieren",
-    "iosHint": "Auf dem iPhone: unten auf „Teilen“ tippen und dann „Zum Home-Bildschirm hinzufügen“."
+    "iosHint": "Auf dem iPhone: unten auf âTeilenâ tippen und dann âZum Home-Bildschirm hinzufÃ¼genâ."
   },
   "Features": {
     "title": "Funktionen",
-    "intro": "Was die App kann — ein Überblick für Nutzer und Entwickler.",
+    "intro": "Was die App kann â ein Ãberblick fÃ¼r Nutzer und Entwickler.",
     "items": {
       "liveScoring": {
         "title": "Live-Scoring & Auto-Refresh",
-        "desc": "Spielstände und Ranglisten-Punkte aktualisieren sich während laufender Spiele automatisch — ohne manuelles Neuladen."
+        "desc": "SpielstÃ¤nde und Ranglisten-Punkte aktualisieren sich wÃ¤hrend laufender Spiele automatisch â ohne manuelles Neuladen."
       },
       "predicting": {
         "title": "Tippen & Wertung",
-        "desc": "Ein Tipp pro Spiel. Wertung: Volltreffer 5, Tordifferenz 3, Tendenz 2 Punkte — plus Bonus für den Weltmeister-Tipp."
+        "desc": "Ein Tipp pro Spiel. Wertung: Volltreffer 5, Tordifferenz 3, Tendenz 2 Punkte â plus Bonus fÃ¼r den Weltmeister-Tipp."
       },
       "rankings": {
         "title": "Ranglisten",
@@ -34,19 +34,19 @@
       },
       "history": {
         "title": "Profil & Tipp-Historie",
-        "desc": "Eigenes Profil mit Statistiken und vollständiger Tipp-Historie — sortier-, filter- und seitenweise blätterbar."
+        "desc": "Eigenes Profil mit Statistiken und vollstÃ¤ndiger Tipp-Historie â sortier-, filter- und seitenweise blÃ¤tterbar."
       },
       "reminders": {
         "title": "Erinnerungen",
-        "desc": "Erinnerungen für noch nicht getippte Spiele — per Email und/oder Push in der installierten App, mit wählbaren Vorlaufzeiten."
+        "desc": "Erinnerungen fÃ¼r noch nicht getippte Spiele â per Email und/oder Push in der installierten App, mit wÃ¤hlbaren Vorlaufzeiten."
       },
       "pwaOffline": {
         "title": "Installierbare PWA",
-        "desc": "Als App auf Android und iOS installierbar, läuft standalone, mit Offline-Seite."
+        "desc": "Als App auf Android und iOS installierbar, lÃ¤uft standalone, mit Offline-Seite."
       },
       "passwordReset": {
         "title": "Passwort-Reset",
-        "desc": "Passwort vergessen? Sicheres Zurücksetzen über einen zeitlich begrenzten Link per Email."
+        "desc": "Passwort vergessen? Sicheres ZurÃ¼cksetzen Ã¼ber einen zeitlich begrenzten Link per Email."
       },
       "avatars": {
         "title": "Avatare",
@@ -72,13 +72,13 @@
     "points": "PUNKTE:",
     "upcomingFixtures": "ANSTEHENDE SPIELE",
     "noUpcomingFixtures": "Keine anstehenden Spiele.",
-    "loadNext": "Nächste {count} laden",
+    "loadNext": "NÃ¤chste {count} laden",
     "loadAll": "Alle laden",
     "ranking": "RANGLISTE",
     "viewFullRanking": "GESAMTE RANGLISTE",
     "noRankingData": "Noch keine Ranglistendaten.",
     "noUsersInDepartment": "Keine Nutzer in diesem Standort.",
-    "rankingOffline": "Rangliste-API offline. Bitte später erneut versuchen."
+    "rankingOffline": "Rangliste-API offline. Bitte spÃ¤ter erneut versuchen."
   },
   "TipForm": {
     "saved": "GESPEICHERT",
@@ -87,13 +87,13 @@
     "save": "SPEICHERN",
     "failedToSave": "Tipp konnte nicht gespeichert werden.",
     "networkError": "Netzwerkfehler. Bitte erneut versuchen.",
-    "offlineBlocked": "Tipps können nur online abgegeben werden. Stelle die Verbindung wieder her und versuche es erneut.",
+    "offlineBlocked": "Tipps kÃ¶nnen nur online abgegeben werden. Stelle die Verbindung wieder her und versuche es erneut.",
     "homeScoreTip": "Tipp Heimtor",
-    "awayScoreTip": "Tipp Auswärtstor"
+    "awayScoreTip": "Tipp AuswÃ¤rtstor"
   },
   "Ranking": {
     "leaderboard": "Rangliste",
-    "subtitle": "Tabellenstände des Büro-Turniers.",
+    "subtitle": "TabellenstÃ¤nde des BÃ¼ro-Turniers.",
     "pos": "POS",
     "username": "NUTZERNAME",
     "exact": "EXAKT",
@@ -110,7 +110,7 @@
     "userCount": "{count, plural, one {# Nutzer} other {# Nutzer}}",
     "pointAbbrev": "P",
     "offline": "Rangliste-API offline",
-    "offlineHint": "Die Tabellenstände erscheinen, sobald der Dienst wieder verfügbar ist."
+    "offlineHint": "Die TabellenstÃ¤nde erscheinen, sobald der Dienst wieder verfÃ¼gbar ist."
   },
   "Scoring": {
     "title": "Punktesystem",
@@ -137,17 +137,17 @@
     "tournamentWinner": "TURNIERSIEGER",
     "secretWinner": "GEHEIMSIEGER",
     "editLabel": "{label} bearbeiten",
-    "pickDeadlineHint": "Änderbar bis zum Anpfiff des ersten Spiels.",
+    "pickDeadlineHint": "Ãnderbar bis zum Anpfiff des ersten Spiels.",
     "winnerSelectLabel": "Turniersieger",
     "secretWinnerSelectLabel": "Geheimsieger",
-    "winnersMustDiffer": "Sieger und Geheimsieger müssen unterschiedlich sein.",
+    "winnersMustDiffer": "Sieger und Geheimsieger mÃ¼ssen unterschiedlich sein.",
     "failedToUpdateWinners": "Sieger konnten nicht aktualisiert werden.",
     "networkError": "Netzwerkfehler. Bitte erneut versuchen.",
     "cancel": "Abbrechen",
     "save": "Speichern",
     "predictionHistory": "Tipp-Verlauf",
     "serviceOffline": "Service offline",
-    "historyOfflineHint": "Der Tipp-Verlauf erscheint, sobald der Dienst wieder verfügbar ist.",
+    "historyOfflineHint": "Der Tipp-Verlauf erscheint, sobald der Dienst wieder verfÃ¼gbar ist.",
     "noPredictions": "Noch keine Tipps",
     "match": "Spiel",
     "prediction": "Tipp",
@@ -155,7 +155,7 @@
     "points": "Punkte",
     "sortByPoints": "Punkte",
     "sortByDate": "Datum",
-    "previous": "Zurück",
+    "previous": "ZurÃ¼ck",
     "next": "Weiter",
     "pageOf": "Seite {current} / {total}",
     "showingCount": "{shown} von {total}",
@@ -171,18 +171,18 @@
     "userPredictions": "Nutzer-Tipps",
     "sortedByPoints": "Sortiert nach erzielten Punkten",
     "predictionsOffline": "Tipp-Service offline",
-    "predictionsOfflineHint": "Die Nutzer-Tipps erscheinen, sobald der Dienst wieder verfügbar ist.",
+    "predictionsOfflineHint": "Die Nutzer-Tipps erscheinen, sobald der Dienst wieder verfÃ¼gbar ist.",
     "rank": "RANG",
     "user": "NUTZER",
     "predictionCol": "TIPP",
     "pointsCol": "PUNKTE",
     "noPredictionsYet": "Noch keine Tipps",
-    "noPredictionsSubmitted": "Für dieses Spiel wurden keine Tipps abgegeben"
+    "noPredictionsSubmitted": "FÃ¼r dieses Spiel wurden keine Tipps abgegeben"
   },
   "Auth": {
     "appName": "TURNIER-TIPP",
-    "tagline": "Büro-Turnier-Pool",
-    "copyright": "© 2026 Turnier-Tipp",
+    "tagline": "BÃ¼ro-Turnier-Pool",
+    "copyright": "Â© 2026 valantic",
     "accountCreated": "Konto erstellt. Bitte unten anmelden.",
     "createAccount": "Konto erstellen",
     "emailAddress": "E-Mail-Adresse",
@@ -198,68 +198,68 @@
     "valanticEmailHint": "Nur valantic.com-Email-Adressen sind erlaubt.",
     "repeatPassword": "Passwort wiederholen",
     "department": "Standort",
-    "selectLocation": "Standort wählen ...",
+    "selectLocation": "Standort wÃ¤hlen ...",
     "tournamentWinner": "Turniersieger",
     "secretWinner": "Geheimsieger",
-    "selectTeam": "Team wählen",
+    "selectTeam": "Team wÃ¤hlen",
     "register": "Registrieren",
-    "passwordsDoNotMatch": "Passwörter stimmen nicht überein.",
-    "invalidPassword": "Ungültiges Passwort",
-    "winnersMustDiffer": "Sieger und Geheimsieger müssen unterschiedlich sein.",
+    "passwordsDoNotMatch": "PasswÃ¶rter stimmen nicht Ã¼berein.",
+    "invalidPassword": "UngÃ¼ltiges Passwort",
+    "winnersMustDiffer": "Sieger und Geheimsieger mÃ¼ssen unterschiedlich sein.",
     "couldNotCreateAccount": "Konto konnte nicht erstellt werden.",
     "forgotPassword": "Passwort vergessen?",
-    "forgotPasswordTitle": "Passwort zurücksetzen",
-    "forgotPasswordHint": "Gib deine E-Mail-Adresse ein und wir senden dir einen Link zum Zurücksetzen deines Passworts.",
-    "forgotPasswordSent": "Falls diese E-Mail-Adresse registriert ist, haben wir einen Link zum Zurücksetzen gesendet.",
+    "forgotPasswordTitle": "Passwort zurÃ¼cksetzen",
+    "forgotPasswordHint": "Gib deine E-Mail-Adresse ein und wir senden dir einen Link zum ZurÃ¼cksetzen deines Passworts.",
+    "forgotPasswordSent": "Falls diese E-Mail-Adresse registriert ist, haben wir einen Link zum ZurÃ¼cksetzen gesendet.",
     "sendResetLink": "Link senden",
-    "backToLogin": "Zurück zur Anmeldung",
-    "resetPasswordTitle": "Neues Passwort wählen",
-    "resetTokenMissing": "Dieser Link ist ungültig oder abgelaufen.",
+    "backToLogin": "ZurÃ¼ck zur Anmeldung",
+    "resetPasswordTitle": "Neues Passwort wÃ¤hlen",
+    "resetTokenMissing": "Dieser Link ist ungÃ¼ltig oder abgelaufen.",
     "newPassword": "Neues Passwort",
-    "confirmNewPassword": "Neues Passwort bestätigen",
+    "confirmNewPassword": "Neues Passwort bestÃ¤tigen",
     "setNewPassword": "Neues Passwort setzen",
     "resetPasswordSuccess": "Dein Passwort wurde aktualisiert. Du kannst dich jetzt anmelden.",
-    "resetPasswordFailed": "Passwort konnte nicht zurückgesetzt werden."
+    "resetPasswordFailed": "Passwort konnte nicht zurÃ¼ckgesetzt werden."
   },
   "Settings": {
     "title": "Profil-Einstellungen",
-    "subtitle": "Verwalte deine Konto-Identität und Sicherheitseinstellungen.",
+    "subtitle": "Verwalte deine Konto-IdentitÃ¤t und Sicherheitseinstellungen.",
     "language": "Sprache",
     "languageHint": "Anzeigesprache",
-    "identity": "Identität",
+    "identity": "IdentitÃ¤t",
     "security": "Sicherheit & Zugangsdaten",
     "session": "Sitzungsverwaltung",
     "username": "Benutzername",
     "email": "E-Mail-Adresse",
-    "changePhoto": "Foto ändern",
+    "changePhoto": "Foto Ã¤ndern",
     "avatarHint": "PNG, JPG oder WebP, max. 5 MB.",
     "avatarTypeError": "Nur PNG, JPG oder WebP erlaubt.",
-    "avatarSizeError": "Datei ist zu groß (max. 5 MB).",
+    "avatarSizeError": "Datei ist zu groÃ (max. 5 MB).",
     "avatarUploadFailed": "Foto konnte nicht hochgeladen werden.",
     "currentPassword": "Aktuelles Passwort",
     "newPassword": "Neues Passwort",
     "newPasswordPlaceholder": "Mindestens 8 Zeichen",
-    "confirmPassword": "Neues Passwort bestätigen",
-    "confirmPasswordPlaceholder": "Neues Passwort bestätigen",
+    "confirmPassword": "Neues Passwort bestÃ¤tigen",
+    "confirmPasswordPlaceholder": "Neues Passwort bestÃ¤tigen",
     "updatePassword": "Passwort aktualisieren",
     "updateSuccess": "Passwort erfolgreich aktualisiert.",
     "updateFailed": "Passwort konnte nicht aktualisiert werden.",
     "newPasswordTooShort": "Das neue Passwort muss mindestens 8 Zeichen lang sein.",
-    "passwordsDoNotMatch": "Passwörter stimmen nicht überein.",
+    "passwordsDoNotMatch": "PasswÃ¶rter stimmen nicht Ã¼berein.",
     "networkError": "Netzwerkfehler. Bitte erneut versuchen.",
     "logout": "Abmelden",
-    "logoutHeading": "Von diesem Gerät abmelden",
+    "logoutHeading": "Von diesem GerÃ¤t abmelden",
     "logoutHint": "Deine aktuelle Sitzung wird sofort beendet.",
     "reminders": "Erinnerungen",
-    "reminderHint": "Wir erinnern dich an Spiele, die du noch nicht getippt hast. Wähle, wie lange vor Anpfiff.",
+    "reminderHint": "Wir erinnern dich an Spiele, die du noch nicht getippt hast. WÃ¤hle, wie lange vor Anpfiff.",
     "emailHeading": "E-Mail",
     "emailChannel": "E-Mail-Erinnerungen",
-    "emailHint": "Erhalte Erinnerungen per E-Mail. Standardmäßig an – schalte sie aus, um nur Push zu nutzen.",
+    "emailHint": "Erhalte Erinnerungen per E-Mail. StandardmÃ¤Ãig an â schalte sie aus, um nur Push zu nutzen.",
     "emailError": "E-Mail-Erinnerungen konnten nicht aktualisiert werden. Bitte erneut versuchen.",
     "reminderLeadHeading": "Vorlaufzeiten",
     "reminderNoChannel": "Aktiviere E-Mail oder Push, um Erinnerungen zu erhalten.",
     "pushInstallRequired": "Installiere die App, um Push-Benachrichtigungen zu aktivieren.",
-    "pushOtherDeviceActive": "Push ist für dieses Konto auf einem anderen Gerät aktiv.",
+    "pushOtherDeviceActive": "Push ist fÃ¼r dieses Konto auf einem anderen GerÃ¤t aktiv.",
     "reminderLead": {
       "1440": "1 Tag vorher",
       "720": "12 Stunden vorher",
@@ -271,9 +271,9 @@
     "reminderSaved": "Erinnerungen gespeichert.",
     "pushHeading": "Push-Benachrichtigungen",
     "pushChannel": "Push im Browser aktivieren",
-    "pushHint": "Erhalte Erinnerungen als Browser-Benachrichtigung, auch wenn die App nicht geöffnet ist. Verfügbar, sobald du die App zum Startbildschirm hinzufügst.",
-    "pushWorking": "Wird eingerichtet …",
-    "pushUnsupported": "Push wird von diesem Browser nicht unterstützt.",
+    "pushHint": "Erhalte Erinnerungen als Browser-Benachrichtigung, auch wenn die App nicht geÃ¶ffnet ist. VerfÃ¼gbar, sobald du die App zum Startbildschirm hinzufÃ¼gst.",
+    "pushWorking": "Wird eingerichtet â¦",
+    "pushUnsupported": "Push wird von diesem Browser nicht unterstÃ¼tzt.",
     "pushPermissionDenied": "Benachrichtigungen wurden abgelehnt. Bitte erlaube sie in den Browser-Einstellungen.",
     "pushError": "Push konnte nicht aktiviert werden. Bitte erneut versuchen.",
     "pushEnableButton": "Benachrichtigungen aktivieren",
@@ -281,40 +281,40 @@
     "pushEnabledStatus": "Benachrichtigungen aktiviert"
   },
   "Errors": {
-    "invalidEmail": "Ungültige E-Mail-Adresse",
-    "invalidPassword": "Ungültiges Passwort",
-    "passwordsDoNotMatch": "Passwörter stimmen nicht überein.",
-    "winnersMustDiffer": "Sieger und Geheimsieger müssen unterschiedlich sein.",
+    "invalidEmail": "UngÃ¼ltige E-Mail-Adresse",
+    "invalidPassword": "UngÃ¼ltiges Passwort",
+    "passwordsDoNotMatch": "PasswÃ¶rter stimmen nicht Ã¼berein.",
+    "winnersMustDiffer": "Sieger und Geheimsieger mÃ¼ssen unterschiedlich sein.",
     "valanticEmailOnly": "Nur valantic.com-E-Mail-Adressen sind erlaubt.",
     "username": "Bitte gib einen Nutzernamen ein.",
-    "department": "Bitte wähle einen Standort.",
-    "winner": "Bitte wähle einen Turniersieger.",
-    "secretWinner": "Bitte wähle einen Geheimsieger.",
+    "department": "Bitte wÃ¤hle einen Standort.",
+    "winner": "Bitte wÃ¤hle einen Turniersieger.",
+    "secretWinner": "Bitte wÃ¤hle einen Geheimsieger.",
     "currentPasswordRequired": "Bitte gib dein aktuelles Passwort ein.",
     "newPasswordTooShort": "Das neue Passwort muss mindestens 8 Zeichen lang sein.",
-    "confirmPasswordRequired": "Bitte bestätige dein neues Passwort.",
-    "tooManyRequests": "Zu viele Anfragen, bitte später erneut versuchen.",
-    "invalidResetToken": "Dieser Link ist ungültig oder abgelaufen.",
+    "confirmPasswordRequired": "Bitte bestÃ¤tige dein neues Passwort.",
+    "tooManyRequests": "Zu viele Anfragen, bitte spÃ¤ter erneut versuchen.",
+    "invalidResetToken": "Dieser Link ist ungÃ¼ltig oder abgelaufen.",
     "loginError": "E-Mail oder Passwort ist falsch.",
-    "invalidInput": "Ungültige Eingabe.",
-    "missingRequiredFields": "Bitte fülle alle Pflichtfelder aus.",
+    "invalidInput": "UngÃ¼ltige Eingabe.",
+    "missingRequiredFields": "Bitte fÃ¼lle alle Pflichtfelder aus.",
     "emailAlreadyRegistered": "Diese E-Mail-Adresse ist bereits registriert.",
     "usernameTaken": "Dieser Nutzername ist bereits vergeben.",
     "notLoggedIn": "Nicht angemeldet.",
-    "invalidRequestBody": "Ungültige Anfrage.",
+    "invalidRequestBody": "UngÃ¼ltige Anfrage.",
     "currentPasswordIncorrect": "Das aktuelle Passwort ist falsch.",
     "failedToUpdatePassword": "Passwort konnte nicht aktualisiert werden.",
-    "picksLocked": "Das Turnier hat bereits begonnen — die Auswahl ist gesperrt.",
+    "picksLocked": "Das Turnier hat bereits begonnen â die Auswahl ist gesperrt.",
     "failedToUpdateWinners": "Sieger konnten nicht aktualisiert werden.",
     "failedToUpdateReminders": "Erinnerungen konnten nicht aktualisiert werden.",
-    "noFileProvided": "Keine Datei ausgewählt.",
-    "imageTooLarge": "Bild ist zu groß.",
-    "unsupportedImageType": "Nicht unterstützter Bildtyp.",
-    "invalidImage": "Ungültiges Bild.",
+    "noFileProvided": "Keine Datei ausgewÃ¤hlt.",
+    "imageTooLarge": "Bild ist zu groÃ.",
+    "unsupportedImageType": "Nicht unterstÃ¼tzter Bildtyp.",
+    "invalidImage": "UngÃ¼ltiges Bild.",
     "failedToSaveAvatar": "Foto konnte nicht gespeichert werden.",
     "matchNotFound": "Spiel nicht gefunden.",
     "matchStartedOrFinished": "Spiel hat bereits begonnen oder ist beendet.",
-    "tipOutOfRange": "Tipp außerhalb des gültigen Bereichs (0–20).",
+    "tipOutOfRange": "Tipp auÃerhalb des gÃ¼ltigen Bereichs (0â20).",
     "failedToSave": "Tipp konnte nicht gespeichert werden."
   },
   "Countries": {
@@ -330,6 +330,6 @@
   },
   "Offline": {
     "title": "Du bist offline",
-    "description": "Keine Internetverbindung. Stelle die Verbindung wieder her, um aktuelle Spiele und Tabellenstände zu sehen."
+    "description": "Keine Internetverbindung. Stelle die Verbindung wieder her, um aktuelle Spiele und TabellenstÃ¤nde zu sehen."
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,6 +1,6 @@
 {
   "Nav": {
-    "title": "Tournament Predictor",
+    "title": "WM ’26",
     "dashboard": "Dashboard",
     "ranking": "Ranking",
     "profile": "Profile",
@@ -12,21 +12,21 @@
   },
   "Install": {
     "title": "Install the app",
-    "description": "Quick access straight from your home screen — no app store needed.",
+    "description": "Quick access straight from your home screen â no app store needed.",
     "installButton": "Install",
-    "iosHint": "On iPhone: tap Share at the bottom, then “Add to Home Screen”."
+    "iosHint": "On iPhone: tap Share at the bottom, then âAdd to Home Screenâ."
   },
   "Features": {
     "title": "Features",
-    "intro": "What the app can do — an overview for users and developers.",
+    "intro": "What the app can do â an overview for users and developers.",
     "items": {
       "liveScoring": {
         "title": "Live scoring & auto-refresh",
-        "desc": "Scores and ranking points update automatically while matches are in play — no manual reload."
+        "desc": "Scores and ranking points update automatically while matches are in play â no manual reload."
       },
       "predicting": {
         "title": "Predictions & scoring",
-        "desc": "One prediction per match. Scoring: exact 5, goal difference 3, tendency 2 points — plus a bonus for the champion pick."
+        "desc": "One prediction per match. Scoring: exact 5, goal difference 3, tendency 2 points â plus a bonus for the champion pick."
       },
       "rankings": {
         "title": "Rankings",
@@ -34,11 +34,11 @@
       },
       "history": {
         "title": "Profile & prediction history",
-        "desc": "Your profile with statistics and a full prediction history — sortable, filterable and paginated."
+        "desc": "Your profile with statistics and a full prediction history â sortable, filterable and paginated."
       },
       "reminders": {
         "title": "Reminders",
-        "desc": "Reminders for matches you haven't predicted yet — by email and/or push in the installed app, with selectable lead times."
+        "desc": "Reminders for matches you haven't predicted yet â by email and/or push in the installed app, with selectable lead times."
       },
       "pwaOffline": {
         "title": "Installable PWA",
@@ -182,7 +182,7 @@
   "Auth": {
     "appName": "TOURNAMENT PREDICTOR",
     "tagline": "Office Tournament Pool",
-    "copyright": "© 2026 Tournament Predictor",
+    "copyright": "Â© 2026 valantic",
     "accountCreated": "Account created. Sign in below.",
     "createAccount": "Create an account",
     "emailAddress": "Email Address",
@@ -254,7 +254,7 @@
     "reminderHint": "We remind you about matches you have not predicted yet. Choose how long before kickoff.",
     "emailHeading": "Email",
     "emailChannel": "Email reminders",
-    "emailHint": "Get reminders by email. On by default — turn it off to use push only.",
+    "emailHint": "Get reminders by email. On by default â turn it off to use push only.",
     "emailError": "Could not update email reminders. Please try again.",
     "reminderLeadHeading": "Lead times",
     "reminderNoChannel": "Enable email or push to receive reminders.",
@@ -272,7 +272,7 @@
     "pushHeading": "Push notifications",
     "pushChannel": "Enable push in this browser",
     "pushHint": "Get reminders as a browser notification, even when the app isn't open. Available once you install the app to your home screen.",
-    "pushWorking": "Setting up …",
+    "pushWorking": "Setting up â¦",
     "pushUnsupported": "Push is not supported by this browser.",
     "pushPermissionDenied": "Notifications were denied. Please allow them in your browser settings.",
     "pushError": "Could not enable push. Please try again.",
@@ -304,7 +304,7 @@
     "invalidRequestBody": "Invalid request.",
     "currentPasswordIncorrect": "Current password is incorrect.",
     "failedToUpdatePassword": "Failed to update password.",
-    "picksLocked": "Tournament has already started — picks are locked.",
+    "picksLocked": "Tournament has already started â picks are locked.",
     "failedToUpdateWinners": "Failed to update winners.",
     "failedToUpdateReminders": "Failed to update reminders.",
     "noFileProvided": "No file provided.",
@@ -314,7 +314,7 @@
     "failedToSaveAvatar": "Failed to save avatar.",
     "matchNotFound": "Match not found.",
     "matchStartedOrFinished": "Match already started or finished.",
-    "tipOutOfRange": "Tip out of range (0–20).",
+    "tipOutOfRange": "Tip out of range (0â20).",
     "failedToSave": "Failed to save tip."
   },
   "Countries": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "football-betting-frontend",
-  "version": "0.1.0",
+  "version": "4.0.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Background
The app should carry the familiar branding (an italic title + 'a valantic guessing game' tagline) updated for the 2026 World Cup.

## What this changes
Introduces the WM '26 logo on the auth pages, updates the in-app top bar and footer brand, the installed-app (PWA) name, and the copyright line accordingly, and bumps the version to 4.0.0.