### PR TITLE
FE-086: settings bottom-nav active

### DIFF
--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -133,7 +133,7 @@ export default async function SettingsPage(): Promise<React.ReactElement> {
         </div>
       </main>
 
-      <BottomNav active="profile" />
+      <BottomNav active="settings" />
     </>
   );
 }


### PR DESCRIPTION
## Background
On mobile, opening Settings highlighted the Profile tab in the bottom navigation instead of Settings.

## What this changes
The settings page now marks the Settings tab as active in the bottom navigation.