### PR TITLE
FE-087: show app-install prompt on mobile only

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import { Hanken_Grotesk, JetBrains_Mono } from "next/font/google";
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale } from "next-intl/server";
+import { InstallProvider } from "@/components/InstallContext";
 import "./globals.css";
 
 const hankenGrotesk = Hanken_Grotesk({
@@ -52,7 +53,9 @@ export default async function RootLayout({
         />
       </head>
       <body>
-        <NextIntlClientProvider>{children}</NextIntlClientProvider>
+        <NextIntlClientProvider>
+          <InstallProvider>{children}</InstallProvider>
+        </NextIntlClientProvider>
       </body>
     </html>
   );

--- a/components/InstallApp.tsx
+++ b/components/InstallApp.tsx
@@ -2,80 +2,39 @@
 
 import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
+import { useInstall } from "@/components/InstallContext";
 
-interface BeforeInstallPromptEvent extends Event {
-  prompt: () => Promise<void>;
-  userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
-}
+type Device = "loading" | "desktop" | "android" | "ios";
 
-type Mode = "loading" | "hidden" | "android" | "ios";
-
-function isStandalone(): boolean {
-  const nav = window.navigator as Navigator & { standalone?: boolean };
-  return (
-    window.matchMedia("(display-mode: standalone)").matches ||
-    nav.standalone === true
-  );
-}
-
-function isIos(): boolean {
+function detectDevice(): Device {
   const nav = window.navigator;
-  const iOSDevice = /iphone|ipad|ipod/i.test(nav.userAgent);
+  const ua = nav.userAgent;
   // iPadOS reports a desktop UA but has touch points.
   const iPadOS = nav.platform === "MacIntel" && nav.maxTouchPoints > 1;
-  return iOSDevice || iPadOS;
+  if (/iphone|ipad|ipod/i.test(ua) || iPadOS) return "ios";
+  if (/android/i.test(ua)) return "android";
+  return "desktop";
 }
 
 /**
- * "Install the app" card. Self-hides unless the app is genuinely installable:
- * - Android/Chrome: shows a button that triggers the native install dialog
- *   (captured from `beforeinstallprompt`).
- * - iOS/Safari: shows the manual "Share → Add to Home Screen" instruction.
- * - Desktop, or already installed (standalone): renders nothing.
- * It lives in the account/settings area, so it only appears after login.
+ * "Install the app" card, shown only on mobile (the `beforeinstallprompt`
+ * signal — captured app-wide by InstallProvider — also fires on desktop Chrome,
+ * so we gate on the device, not on the signal):
+ * - Android: native install button when a prompt was captured, otherwise a
+ *   manual "browser menu → Install app" hint.
+ * - iOS/Safari: the manual "Share → Add to Home Screen" instruction.
+ * - Desktop, or already installed: renders nothing.
  */
 export function InstallApp(): React.ReactElement | null {
   const t = useTranslations("Install");
-  const [mode, setMode] = useState<Mode>("loading");
-  const [deferred, setDeferred] = useState<BeforeInstallPromptEvent | null>(
-    null,
-  );
+  const { canInstall, installed, install } = useInstall();
+  const [device, setDevice] = useState<Device>("loading");
 
   useEffect(() => {
-    if (isStandalone()) {
-      setMode("hidden");
-      return;
-    }
-    if (isIos()) {
-      setMode("ios");
-      return;
-    }
-    // Android / Chromium: wait for the installability signal. Desktop stays
-    // hidden because we only set "android" once this fires on a mobile-eligible
-    // context and we never surface it elsewhere.
-    const onPrompt = (event: Event): void => {
-      event.preventDefault();
-      setDeferred(event as BeforeInstallPromptEvent);
-      setMode("android");
-    };
-    const onInstalled = (): void => setMode("hidden");
-    window.addEventListener("beforeinstallprompt", onPrompt);
-    window.addEventListener("appinstalled", onInstalled);
-    return () => {
-      window.removeEventListener("beforeinstallprompt", onPrompt);
-      window.removeEventListener("appinstalled", onInstalled);
-    };
+    setDevice(detectDevice());
   }, []);
 
-  if (mode === "loading" || mode === "hidden") return null;
-
-  async function install(): Promise<void> {
-    if (!deferred) return;
-    await deferred.prompt();
-    await deferred.userChoice;
-    setDeferred(null);
-    setMode("hidden");
-  }
+  if (installed || device === "loading" || device === "desktop") return null;
 
   return (
     <section className="bg-surface-container rounded-lg p-lg border border-outline-variant">
@@ -85,7 +44,7 @@ export function InstallApp(): React.ReactElement | null {
       <p className="text-body-sm text-on-surface-variant mb-lg">
         {t("description")}
       </p>
-      {mode === "android" ? (
+      {device === "android" && canInstall ? (
         <button
           type="button"
           onClick={install}
@@ -99,9 +58,11 @@ export function InstallApp(): React.ReactElement | null {
             aria-hidden="true"
             className="material-symbols-outlined text-primary"
           >
-            ios_share
+            {device === "ios" ? "ios_share" : "more_vert"}
           </span>
-          <p className="text-body-sm text-on-surface">{t("iosHint")}</p>
+          <p className="text-body-sm text-on-surface">
+            {device === "ios" ? t("iosHint") : t("androidHint")}
+          </p>
         </div>
       )}
     </section>

--- a/components/InstallContext.tsx
+++ b/components/InstallContext.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+}
+
+interface InstallState {
+  // A native install prompt was captured (Android/Chromium, app not installed).
+  canInstall: boolean;
+  // App is running standalone, or was installed this session.
+  installed: boolean;
+  install: () => Promise<void>;
+}
+
+const InstallContext = createContext<InstallState>({
+  canInstall: false,
+  installed: false,
+  install: async () => {},
+});
+
+export function useInstall(): InstallState {
+  return useContext(InstallContext);
+}
+
+// Mounted high in the tree (root layout) so the `beforeinstallprompt` event —
+// which fires once, early, on the first page load — is captured even before the
+// user navigates to the settings page where the install button lives.
+export function InstallProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.ReactElement {
+  const [deferred, setDeferred] = useState<BeforeInstallPromptEvent | null>(
+    null,
+  );
+  const [installed, setInstalled] = useState(false);
+
+  useEffect(() => {
+    const nav = window.navigator as Navigator & { standalone?: boolean };
+    if (
+      window.matchMedia("(display-mode: standalone)").matches ||
+      nav.standalone === true
+    ) {
+      setInstalled(true);
+    }
+    const onPrompt = (event: Event): void => {
+      event.preventDefault();
+      setDeferred(event as BeforeInstallPromptEvent);
+    };
+    const onInstalled = (): void => {
+      setInstalled(true);
+      setDeferred(null);
+    };
+    window.addEventListener("beforeinstallprompt", onPrompt);
+    window.addEventListener("appinstalled", onInstalled);
+    return () => {
+      window.removeEventListener("beforeinstallprompt", onPrompt);
+      window.removeEventListener("appinstalled", onInstalled);
+    };
+  }, []);
+
+  const install = useCallback(async (): Promise<void> => {
+    if (!deferred) return;
+    await deferred.prompt();
+    await deferred.userChoice;
+    setDeferred(null);
+  }, [deferred]);
+
+  return (
+    <InstallContext.Provider
+      value={{ canInstall: deferred !== null, installed, install }}
+    >
+      {children}
+    </InstallContext.Provider>
+  );
+}

--- a/messages/de.json
+++ b/messages/de.json
@@ -14,7 +14,8 @@
     "title": "App installieren",
     "description": "Schnellzugriff direkt vom Home-Bildschirm – kein App Store nötig.",
     "installButton": "Installieren",
-    "iosHint": "Auf dem iPhone: unten auf „Teilen“ tippen und dann „Zum Home-Bildschirm hinzufügen“."
+    "iosHint": "Auf dem iPhone: unten auf „Teilen“ tippen und dann „Zum Home-Bildschirm hinzufügen“.",
+    "androidHint": "Im Browser-Menü (⋮) oben rechts auf „App installieren“ tippen."
   },
   "Features": {
     "title": "Funktionen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -14,7 +14,8 @@
     "title": "Install the app",
     "description": "Quick access straight from your home screen — no app store needed.",
     "installButton": "Install",
-    "iosHint": "On iPhone: tap Share at the bottom, then “Add to Home Screen”."
+    "iosHint": "On iPhone: tap Share at the bottom, then “Add to Home Screen”.",
+    "androidHint": "Open the browser menu (⋮) top-right and choose “Install app”."
   },
   "Features": {
     "title": "Features",


### PR DESCRIPTION
## Background
The "Install the app" affordance in settings relied on the browser's
`beforeinstallprompt` signal alone. That signal also fires on desktop Chrome, so
the card appeared on Desktop — where it was not wanted — while on Android it
often failed to appear at all, because the signal fires once early on the first
page load, before the settings page (and its listener) had mounted.

## What this changes
The install affordance is now mobile-only and reliable:
- It is shown on Android and iOS, and stays hidden on Desktop and when the app
  is already installed.
- The installability signal is now captured app-wide as soon as the app loads,
  so it is still available once the user reaches settings — the Android install
  button works regardless of how the user navigated there.
- When no native install dialog is available on Android, a short manual hint is
  shown instead, so there is always a clear path to install.