### PR TITLE
FE-089: reliable install capture + already-installed state

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -51,6 +51,16 @@ export default async function RootLayout({
           rel="stylesheet"
           href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap"
         />
+        <script
+          // Capture the install signal before React hydrates: `beforeinstallprompt`
+          // fires once, early, and would otherwise be missed by client components.
+          dangerouslySetInnerHTML={{
+            __html:
+              "(function(){window.__wmInstall={e:null};" +
+              "addEventListener('beforeinstallprompt',function(ev){ev.preventDefault();window.__wmInstall.e=ev;dispatchEvent(new Event('wm-installable'))});" +
+              "addEventListener('appinstalled',function(){window.__wmInstall.e=null;dispatchEvent(new Event('wm-installed'))})})();",
+          }}
+        />
       </head>
       <body>
         <NextIntlClientProvider>

--- a/components/InstallContext.tsx
+++ b/components/InstallContext.tsx
@@ -13,10 +13,21 @@ interface BeforeInstallPromptEvent extends Event {
   userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
 }
 
+// Set up by the inline head script in the root layout, which captures
+// `beforeinstallprompt` before React hydrates (the event fires once, early).
+type InstallWindow = Window & {
+  __wmInstall?: { e: BeforeInstallPromptEvent | null };
+};
+
+type RelatedAppsNavigator = Navigator & {
+  standalone?: boolean;
+  getInstalledRelatedApps?: () => Promise<unknown[]>;
+};
+
 interface InstallState {
   // A native install prompt was captured (Android/Chromium, app not installed).
   canInstall: boolean;
-  // App is running standalone, or was installed this session.
+  // App is running standalone, or is already installed on this device.
   installed: boolean;
   install: () => Promise<void>;
 }
@@ -31,9 +42,9 @@ export function useInstall(): InstallState {
   return useContext(InstallContext);
 }
 
-// Mounted high in the tree (root layout) so the `beforeinstallprompt` event —
-// which fires once, early, on the first page load — is captured even before the
-// user navigates to the settings page where the install button lives.
+// Mounted high in the tree (root layout). Adopts the install signal captured by
+// the inline head script and tracks whether the app is already installed, so the
+// settings install card only offers an install when one is genuinely possible.
 export function InstallProvider({
   children,
 }: {
@@ -45,13 +56,21 @@ export function InstallProvider({
   const [installed, setInstalled] = useState(false);
 
   useEffect(() => {
-    const nav = window.navigator as Navigator & { standalone?: boolean };
+    const w = window as InstallWindow;
+    const nav = window.navigator as RelatedAppsNavigator;
+
     if (
       window.matchMedia("(display-mode: standalone)").matches ||
       nav.standalone === true
     ) {
       setInstalled(true);
     }
+    // Adopt a prompt the head script captured before this component mounted.
+    if (w.__wmInstall?.e) setDeferred(w.__wmInstall.e);
+
+    const onInstallable = (): void => {
+      if (w.__wmInstall?.e) setDeferred(w.__wmInstall.e);
+    };
     const onPrompt = (event: Event): void => {
       event.preventDefault();
       setDeferred(event as BeforeInstallPromptEvent);
@@ -60,19 +79,37 @@ export function InstallProvider({
       setInstalled(true);
       setDeferred(null);
     };
+    window.addEventListener("wm-installable", onInstallable);
+    window.addEventListener("wm-installed", onInstalled);
     window.addEventListener("beforeinstallprompt", onPrompt);
     window.addEventListener("appinstalled", onInstalled);
+
+    // The PWA is already installed on this device — don't offer to install it.
+    if (typeof nav.getInstalledRelatedApps === "function") {
+      nav
+        .getInstalledRelatedApps()
+        .then((apps) => {
+          if (apps.length > 0) setInstalled(true);
+        })
+        .catch(() => {});
+    }
+
     return () => {
+      window.removeEventListener("wm-installable", onInstallable);
+      window.removeEventListener("wm-installed", onInstalled);
       window.removeEventListener("beforeinstallprompt", onPrompt);
       window.removeEventListener("appinstalled", onInstalled);
     };
   }, []);
 
   const install = useCallback(async (): Promise<void> => {
-    if (!deferred) return;
-    await deferred.prompt();
-    await deferred.userChoice;
+    const w = window as InstallWindow;
+    const event = deferred ?? w.__wmInstall?.e ?? null;
+    if (!event) return;
+    await event.prompt();
+    await event.userChoice;
     setDeferred(null);
+    if (w.__wmInstall) w.__wmInstall.e = null;
   }, [deferred]);
 
   return (


### PR DESCRIPTION
## Background
On a device where the app was already installed, the settings install card kept
showing a manual "install via the browser menu" hint, which is confusing — there
is nothing left to install. Separately, the browser's install signal fires once,
very early in the page lifecycle, so it could be missed before the app had fully
loaded, leaving a not-yet-installed user without the native install button.

## What this changes
- The install signal is now captured as soon as the page starts loading, so the
  native install button reliably appears for users who can still install.
- When the app is already installed on the device, the install card no longer
  appears, so installed users are not shown an install hint they do not need.