### PR TITLE
FE-090: add Siegen as a selectable location

### DIFF
--- a/app/(app)/ranking/page.tsx
+++ b/app/(app)/ranking/page.tsx
@@ -19,6 +19,7 @@ const TAB_BY_PARAM: Record<string, string> = {
   langenfeld: "Langenfeld",
   mannheim: "Mannheim",
   mainz: "Mainz",
+  siegen: "Siegen",
 };
 
 async function loadRating(): Promise<RatingResponse | null> {

--- a/lib/data/departments.ts
+++ b/lib/data/departments.ts
@@ -1,4 +1,9 @@
-export const DEPARTMENTS = ["Langenfeld", "Mannheim", "Mainz"] as const;
+export const DEPARTMENTS = [
+  "Langenfeld",
+  "Mannheim",
+  "Mainz",
+  "Siegen",
+] as const;
 
 export type Department = (typeof DEPARTMENTS)[number];
 


### PR DESCRIPTION
## Background
The sign-up form let new users pick an office location from Langenfeld,
Mannheim and Mainz. The Siegen office was missing, so people there could not be
assigned to their location and no Siegen standing appeared in the leaderboard.

## What this changes
Siegen is now offered as a location during registration and appears as its own
tab in the leaderboard alongside the other locations. Existing accounts keep
their current location; the new option applies to new registrations and anyone
choosing their location.