### PR TITLE
FE-092: localize team names in winner selectors

### DIFF
--- a/app/(auth)/signup/signup-form.tsx
+++ b/app/(auth)/signup/signup-form.tsx
@@ -1,14 +1,16 @@
 "use client";
 
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { useState, type FormEvent } from "react";
 import { DEPARTMENTS, displayDepartment } from "@/lib/data/departments";
-import { TEAMS } from "@/lib/data/teams";
+import { localizedTeams } from "@/lib/data/teams";
 import { extractErrorKey } from "@/lib/error-message";
 
 export function SignupForm(): React.ReactElement {
   const t = useTranslations("Auth");
   const tErrors = useTranslations("Errors");
+  const locale = useLocale();
+  const teams = localizedTeams(locale);
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
 
@@ -227,9 +229,9 @@ export function SignupForm(): React.ReactElement {
             <option disabled value="">
               {t("selectTeam")}
             </option>
-            {TEAMS.map((t) => (
-              <option key={t.code} value={t.code}>
-                {t.name}
+            {teams.map((team) => (
+              <option key={team.code} value={team.code}>
+                {team.name}
               </option>
             ))}
           </select>
@@ -252,9 +254,9 @@ export function SignupForm(): React.ReactElement {
             <option disabled value="">
               {t("selectTeam")}
             </option>
-            {TEAMS.map((t) => (
-              <option key={t.code} value={t.code}>
-                {t.name}
+            {teams.map((team) => (
+              <option key={team.code} value={team.code}>
+                {team.name}
               </option>
             ))}
           </select>

--- a/components/profile/WinnerEditForm.tsx
+++ b/components/profile/WinnerEditForm.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { useState, type FormEvent } from "react";
-import { TEAMS } from "@/lib/data/teams";
+import { localizedTeams } from "@/lib/data/teams";
 import { extractErrorKey } from "@/lib/error-message";
 
 interface WinnerEditFormProps {
@@ -21,6 +21,8 @@ export function WinnerEditForm({
 }: WinnerEditFormProps): React.ReactElement {
   const t = useTranslations("Profile");
   const tErrors = useTranslations("Errors");
+  const locale = useLocale();
+  const teams = localizedTeams(locale);
   const router = useRouter();
   const [winner, setWinner] = useState(initialWinner);
   const [secretWinner, setSecretWinner] = useState(initialSecret);
@@ -85,9 +87,9 @@ export function WinnerEditForm({
           aria-label={t("winnerSelectLabel")}
           className="min-h-12 px-md bg-surface-container-low border border-outline-variant rounded text-body-lg focus:border-primary focus:ring-0 disabled:opacity-60"
         >
-          {TEAMS.map((t) => (
-            <option key={t.code} value={t.code}>
-              {t.code} — {t.name}
+          {teams.map((team) => (
+            <option key={team.code} value={team.code}>
+              {team.code} — {team.name}
             </option>
           ))}
         </select>
@@ -104,9 +106,9 @@ export function WinnerEditForm({
           aria-label={t("secretWinnerSelectLabel")}
           className="min-h-12 px-md bg-surface-container-low border border-outline-variant rounded text-body-lg focus:border-primary focus:ring-0 disabled:opacity-60"
         >
-          {TEAMS.map((t) => (
-            <option key={t.code} value={t.code}>
-              {t.code} — {t.name}
+          {teams.map((team) => (
+            <option key={team.code} value={team.code}>
+              {team.code} — {team.name}
             </option>
           ))}
         </select>

--- a/lib/data/teams.ts
+++ b/lib/data/teams.ts
@@ -1,54 +1,55 @@
 // WM '26 participants. `code` is the football-data.org TLA (matches the imported
-// match data and the betting-api TOURNAMENT_WINNER env), `name` is German.
+// match data and the betting-api TOURNAMENT_WINNER env); `de`/`en` are the
+// localized display names.
 export const TEAMS = [
-  { code: "EGY", name: "Ägypten" },
-  { code: "ALG", name: "Algerien" },
-  { code: "ARG", name: "Argentinien" },
-  { code: "AUS", name: "Australien" },
-  { code: "BEL", name: "Belgien" },
-  { code: "BIH", name: "Bosnien-Herzegowina" },
-  { code: "BRA", name: "Brasilien" },
-  { code: "CUW", name: "Curaçao" },
-  { code: "COD", name: "DR Kongo" },
-  { code: "GER", name: "Deutschland" },
-  { code: "ECU", name: "Ecuador" },
-  { code: "CIV", name: "Elfenbeinküste" },
-  { code: "ENG", name: "England" },
-  { code: "FRA", name: "Frankreich" },
-  { code: "GHA", name: "Ghana" },
-  { code: "HAI", name: "Haiti" },
-  { code: "IRQ", name: "Irak" },
-  { code: "IRN", name: "Iran" },
-  { code: "JPN", name: "Japan" },
-  { code: "JOR", name: "Jordanien" },
-  { code: "CAN", name: "Kanada" },
-  { code: "CPV", name: "Kap Verde" },
-  { code: "QAT", name: "Katar" },
-  { code: "COL", name: "Kolumbien" },
-  { code: "CRO", name: "Kroatien" },
-  { code: "MAR", name: "Marokko" },
-  { code: "MEX", name: "Mexiko" },
-  { code: "NZL", name: "Neuseeland" },
-  { code: "NED", name: "Niederlande" },
-  { code: "NOR", name: "Norwegen" },
-  { code: "AUT", name: "Österreich" },
-  { code: "PAN", name: "Panama" },
-  { code: "PAR", name: "Paraguay" },
-  { code: "POR", name: "Portugal" },
-  { code: "KSA", name: "Saudi-Arabien" },
-  { code: "SCO", name: "Schottland" },
-  { code: "SWE", name: "Schweden" },
-  { code: "SUI", name: "Schweiz" },
-  { code: "SEN", name: "Senegal" },
-  { code: "ESP", name: "Spanien" },
-  { code: "RSA", name: "Südafrika" },
-  { code: "KOR", name: "Südkorea" },
-  { code: "CZE", name: "Tschechien" },
-  { code: "TUN", name: "Tunesien" },
-  { code: "TUR", name: "Türkei" },
-  { code: "URY", name: "Uruguay" },
-  { code: "USA", name: "USA" },
-  { code: "UZB", name: "Usbekistan" },
+  { code: "EGY", de: "Ägypten", en: "Egypt" },
+  { code: "ALG", de: "Algerien", en: "Algeria" },
+  { code: "ARG", de: "Argentinien", en: "Argentina" },
+  { code: "AUS", de: "Australien", en: "Australia" },
+  { code: "BEL", de: "Belgien", en: "Belgium" },
+  { code: "BIH", de: "Bosnien-Herzegowina", en: "Bosnia and Herzegovina" },
+  { code: "BRA", de: "Brasilien", en: "Brazil" },
+  { code: "CUW", de: "Curaçao", en: "Curaçao" },
+  { code: "COD", de: "DR Kongo", en: "DR Congo" },
+  { code: "GER", de: "Deutschland", en: "Germany" },
+  { code: "ECU", de: "Ecuador", en: "Ecuador" },
+  { code: "CIV", de: "Elfenbeinküste", en: "Ivory Coast" },
+  { code: "ENG", de: "England", en: "England" },
+  { code: "FRA", de: "Frankreich", en: "France" },
+  { code: "GHA", de: "Ghana", en: "Ghana" },
+  { code: "HAI", de: "Haiti", en: "Haiti" },
+  { code: "IRQ", de: "Irak", en: "Iraq" },
+  { code: "IRN", de: "Iran", en: "Iran" },
+  { code: "JPN", de: "Japan", en: "Japan" },
+  { code: "JOR", de: "Jordanien", en: "Jordan" },
+  { code: "CAN", de: "Kanada", en: "Canada" },
+  { code: "CPV", de: "Kap Verde", en: "Cape Verde" },
+  { code: "QAT", de: "Katar", en: "Qatar" },
+  { code: "COL", de: "Kolumbien", en: "Colombia" },
+  { code: "CRO", de: "Kroatien", en: "Croatia" },
+  { code: "MAR", de: "Marokko", en: "Morocco" },
+  { code: "MEX", de: "Mexiko", en: "Mexico" },
+  { code: "NZL", de: "Neuseeland", en: "New Zealand" },
+  { code: "NED", de: "Niederlande", en: "Netherlands" },
+  { code: "NOR", de: "Norwegen", en: "Norway" },
+  { code: "AUT", de: "Österreich", en: "Austria" },
+  { code: "PAN", de: "Panama", en: "Panama" },
+  { code: "PAR", de: "Paraguay", en: "Paraguay" },
+  { code: "POR", de: "Portugal", en: "Portugal" },
+  { code: "KSA", de: "Saudi-Arabien", en: "Saudi Arabia" },
+  { code: "SCO", de: "Schottland", en: "Scotland" },
+  { code: "SWE", de: "Schweden", en: "Sweden" },
+  { code: "SUI", de: "Schweiz", en: "Switzerland" },
+  { code: "SEN", de: "Senegal", en: "Senegal" },
+  { code: "ESP", de: "Spanien", en: "Spain" },
+  { code: "RSA", de: "Südafrika", en: "South Africa" },
+  { code: "KOR", de: "Südkorea", en: "South Korea" },
+  { code: "CZE", de: "Tschechien", en: "Czechia" },
+  { code: "TUN", de: "Tunesien", en: "Tunisia" },
+  { code: "TUR", de: "Türkei", en: "Türkiye" },
+  { code: "URY", de: "Uruguay", en: "Uruguay" },
+  { code: "USA", de: "USA", en: "USA" },
+  { code: "UZB", de: "Usbekistan", en: "Uzbekistan" },
 ] as const;
 
 export type TeamCode = (typeof TEAMS)[number]["code"];
@@ -57,4 +58,28 @@ export const TEAM_CODES: readonly TeamCode[] = TEAMS.map((t) => t.code);
 
 export function isTeamCode(value: string): value is TeamCode {
   return (TEAM_CODES as readonly string[]).includes(value);
+}
+
+type TeamNameLocale = "de" | "en";
+
+function resolveLocale(locale: string): TeamNameLocale {
+  return locale.startsWith("en") ? "en" : "de";
+}
+
+// Localized team display name for a code (falls back to the code itself).
+export function teamName(code: string, locale: string): string {
+  const team = TEAMS.find((t) => t.code === code);
+  if (!team) return code;
+  return team[resolveLocale(locale)];
+}
+
+// Teams as `{ code, name }`, localized and sorted alphabetically in that locale
+// (so the dropdown order is correct for both German and English).
+export function localizedTeams(
+  locale: string,
+): { code: TeamCode; name: string }[] {
+  const key = resolveLocale(locale);
+  return TEAMS.map((t) => ({ code: t.code, name: t[key] })).sort((a, b) =>
+    a.name.localeCompare(b.name, key),
+  );
 }


### PR DESCRIPTION
## Background
On the sign-up form (and the profile winner editor), the Tournament Winner and
Secret Winner dropdowns always listed the teams with German names, even when the
interface language was set to English.

## What this changes
The team names in both winner selectors now follow the chosen language — German
names in German, English names in English — and the list is sorted
alphabetically for the active language.