### PR TITLE
FE-093: test coverage for the notification path and recent logic

### DIFF
--- a/tests/unit/app-origin.test.ts
+++ b/tests/unit/app-origin.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { NextRequest } from "next/server";
+import { resolveAppOrigin } from "@/lib/app-origin";
+
+function request(origin: string): NextRequest {
+  return { nextUrl: { origin } } as unknown as NextRequest;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("resolveAppOrigin", () => {
+  it("uses APP_BASE_URL and strips trailing slashes", () => {
+    vi.stubEnv("APP_BASE_URL", "https://wm.example.com//");
+    expect(resolveAppOrigin(request("http://localhost:3000"))).toBe(
+      "https://wm.example.com",
+    );
+  });
+
+  it("returns null in production when APP_BASE_URL is unset (fail closed)", () => {
+    vi.stubEnv("APP_BASE_URL", "");
+    vi.stubEnv("NODE_ENV", "production");
+    expect(resolveAppOrigin(request("http://evil.test"))).toBeNull();
+  });
+
+  it("falls back to the request origin outside production", () => {
+    vi.stubEnv("APP_BASE_URL", "");
+    vi.stubEnv("NODE_ENV", "development");
+    expect(resolveAppOrigin(request("http://localhost:3000"))).toBe(
+      "http://localhost:3000",
+    );
+  });
+});

--- a/tests/unit/cron-notifications.test.ts
+++ b/tests/unit/cron-notifications.test.ts
@@ -1,0 +1,266 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+// The cron route orchestrates many data-layer + delivery functions. Mock those
+// so the test drives the real eligibility logic (@/lib/reminders stays real)
+// without a database, SMTP, or web-push network.
+vi.mock("@/lib/match", () => ({ getUpcomingMatches: vi.fn() }));
+vi.mock("@/lib/rate-limit", () => ({ checkRateLimit: vi.fn() }));
+vi.mock("@/lib/app-origin", () => ({ resolveAppOrigin: vi.fn() }));
+vi.mock("@/lib/reminder-store", () => ({
+  getAllReminderSettings: vi.fn(),
+  getEmailDisabledUserIds: vi.fn(),
+  getSentKeysForMatches: vi.fn(),
+  markReminderSent: vi.fn(),
+}));
+vi.mock("@/lib/push-store", () => ({
+  getPushSubscriptionsByUserIds: vi.fn(),
+  deletePushSubscriptionByEndpoint: vi.fn(),
+}));
+vi.mock("@/lib/tip", () => ({ getTipByUserAndMatchIds: vi.fn() }));
+vi.mock("@/lib/user", () => ({ getUserEmailsByIds: vi.fn() }));
+vi.mock("@/lib/mail", () => ({ sendTipReminderEmail: vi.fn() }));
+vi.mock("@/lib/push", () => ({
+  buildPushPayload: vi.fn(() => "payload"),
+  sendPush: vi.fn(),
+}));
+
+import { getUpcomingMatches } from "@/lib/match";
+import { checkRateLimit } from "@/lib/rate-limit";
+import { resolveAppOrigin } from "@/lib/app-origin";
+import {
+  getAllReminderSettings,
+  getEmailDisabledUserIds,
+  getSentKeysForMatches,
+  markReminderSent,
+} from "@/lib/reminder-store";
+import {
+  deletePushSubscriptionByEndpoint,
+  getPushSubscriptionsByUserIds,
+} from "@/lib/push-store";
+import { getTipByUserAndMatchIds } from "@/lib/tip";
+import { getUserEmailsByIds } from "@/lib/user";
+import { sendTipReminderEmail } from "@/lib/mail";
+import { sendPush } from "@/lib/push";
+import { GET, POST } from "@/app/api/cron/notifications/route";
+
+const SECRET = "cron-secret";
+let prevSecret: string | undefined;
+
+function makeRequest(secret?: string): NextRequest {
+  const headers = new Headers();
+  if (secret) headers.set("x-cron-secret", secret);
+  return {
+    method: "POST",
+    headers,
+    nextUrl: { origin: "http://localhost" },
+  } as unknown as NextRequest;
+}
+
+type AwaitedReturn<T extends (...args: never[]) => unknown> = Awaited<
+  ReturnType<T>
+>;
+
+function match(id: number, offsetMinutes: number) {
+  return {
+    id,
+    homeTeam: { name: `H${id}`, tla: "H" },
+    awayTeam: { name: `A${id}`, tla: "A" },
+    status: "TIMED",
+    utcDate: new Date(Date.now() + offsetMinutes * 60_000),
+    homeScore: null,
+    awayScore: null,
+  };
+}
+
+// 13h ahead: only the 1440-minute (24h) lead window is open.
+const ONLY_1440 = 780;
+// ~3.5h ahead: the 6h/12h/24h windows are all open at once (360/720/1440).
+const THREE_LEADS = 210;
+
+const ALL_LEADS = [1440, 720, 360, 180, 60].map((leadMinutes) => ({
+  userId: 1,
+  leadMinutes,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  prevSecret = process.env.CRON_SECRET;
+  process.env.CRON_SECRET = SECRET;
+
+  vi.mocked(checkRateLimit).mockReturnValue({
+    ok: true,
+  } as AwaitedReturn<typeof checkRateLimit>);
+  vi.mocked(resolveAppOrigin).mockReturnValue("https://test");
+  vi.mocked(getUpcomingMatches).mockResolvedValue([
+    match(1, ONLY_1440),
+  ] as AwaitedReturn<typeof getUpcomingMatches>);
+  vi.mocked(getAllReminderSettings).mockResolvedValue([
+    { userId: 1, leadMinutes: 1440 },
+  ] as AwaitedReturn<typeof getAllReminderSettings>);
+  vi.mocked(getEmailDisabledUserIds).mockResolvedValue(new Set<number>());
+  vi.mocked(getUserEmailsByIds).mockResolvedValue(new Map([[1, "u1@test"]]));
+  vi.mocked(getSentKeysForMatches).mockResolvedValue(new Set<string>());
+  vi.mocked(getPushSubscriptionsByUserIds).mockResolvedValue(
+    new Map([
+      [1, [{ endpoint: "https://push/1", p256dh: "p", auth: "a" }]],
+    ]) as AwaitedReturn<typeof getPushSubscriptionsByUserIds>,
+  );
+  vi.mocked(getTipByUserAndMatchIds).mockResolvedValue(
+    [] as AwaitedReturn<typeof getTipByUserAndMatchIds>,
+  );
+  vi.mocked(markReminderSent).mockResolvedValue(true);
+  vi.mocked(sendTipReminderEmail).mockResolvedValue(undefined);
+  vi.mocked(sendPush).mockResolvedValue({
+    ok: true,
+  } as AwaitedReturn<typeof sendPush>);
+});
+
+afterEach(() => {
+  if (prevSecret === undefined) delete process.env.CRON_SECRET;
+  else process.env.CRON_SECRET = prevSecret;
+});
+
+describe("cron notifications — auth", () => {
+  it("rejects a request with no secret (401)", async () => {
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(401);
+    expect(getUpcomingMatches).not.toHaveBeenCalled();
+  });
+
+  it("rejects a wrong secret (401)", async () => {
+    const res = await POST(makeRequest("nope"));
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects GET with 405", () => {
+    expect(GET().status).toBe(405);
+  });
+});
+
+describe("cron notifications — delivery", () => {
+  it("sends email + push for an untipped match (sent: 2)", async () => {
+    const res = await POST(makeRequest(SECRET));
+    expect(await res.json()).toEqual({ sent: 2 });
+    expect(sendTipReminderEmail).toHaveBeenCalledTimes(1);
+    expect(sendTipReminderEmail).toHaveBeenCalledWith(
+      "u1@test",
+      expect.objectContaining({
+        matchLabel: "H1 – A1",
+        predictUrl: "https://test/",
+      }),
+    );
+    expect(sendPush).toHaveBeenCalledTimes(1);
+    expect(markReminderSent).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not notify a match the user already tipped (sent: 0)", async () => {
+    vi.mocked(getTipByUserAndMatchIds).mockResolvedValue([
+      { matchId: 1 },
+    ] as AwaitedReturn<typeof getTipByUserAndMatchIds>);
+    const res = await POST(makeRequest(SECRET));
+    expect(await res.json()).toEqual({ sent: 0 });
+    expect(sendTipReminderEmail).not.toHaveBeenCalled();
+    expect(sendPush).not.toHaveBeenCalled();
+  });
+
+  it("does not re-send an already-sent slot (dedup, sent: 0)", async () => {
+    vi.mocked(getSentKeysForMatches).mockResolvedValue(
+      new Set(["1:1:1440:email", "1:1:1440:push"]),
+    );
+    const res = await POST(makeRequest(SECRET));
+    expect(await res.json()).toEqual({ sent: 0 });
+    expect(sendTipReminderEmail).not.toHaveBeenCalled();
+    expect(sendPush).not.toHaveBeenCalled();
+  });
+});
+
+describe("cron notifications — channel selection", () => {
+  it("skips email when the user opted out (push only)", async () => {
+    vi.mocked(getEmailDisabledUserIds).mockResolvedValue(new Set([1]));
+    const res = await POST(makeRequest(SECRET));
+    expect(await res.json()).toEqual({ sent: 1 });
+    expect(sendTipReminderEmail).not.toHaveBeenCalled();
+    expect(sendPush).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips push when the user has no subscription (email only)", async () => {
+    vi.mocked(getPushSubscriptionsByUserIds).mockResolvedValue(
+      new Map() as AwaitedReturn<typeof getPushSubscriptionsByUserIds>,
+    );
+    const res = await POST(makeRequest(SECRET));
+    expect(await res.json()).toEqual({ sent: 1 });
+    expect(sendTipReminderEmail).toHaveBeenCalledTimes(1);
+    expect(sendPush).not.toHaveBeenCalled();
+  });
+});
+
+describe("cron notifications — resilience", () => {
+  it("leaves the email slot unreserved when sending fails (mark-on-success)", async () => {
+    vi.mocked(sendTipReminderEmail).mockRejectedValue(new Error("smtp down"));
+    const res = await POST(makeRequest(SECRET));
+    // Only the push delivery is counted and reserved; email stays retryable.
+    expect(await res.json()).toEqual({ sent: 1 });
+    expect(sendTipReminderEmail).toHaveBeenCalledTimes(1);
+    expect(markReminderSent).toHaveBeenCalledTimes(1);
+    expect(markReminderSent).toHaveBeenCalledWith(
+      1,
+      1,
+      1440,
+      "push",
+      expect.any(Date),
+    );
+  });
+
+  it("prunes a gone push subscription without reserving its slot", async () => {
+    vi.mocked(sendPush).mockResolvedValue({
+      ok: false,
+      gone: true,
+      statusCode: 410,
+    } as AwaitedReturn<typeof sendPush>);
+    const res = await POST(makeRequest(SECRET));
+    expect(deletePushSubscriptionByEndpoint).toHaveBeenCalledWith(
+      "https://push/1",
+    );
+    // Email still delivered; the dead push endpoint is not counted.
+    expect((await res.json()).sent).toBe(1);
+  });
+});
+
+describe("cron notifications — real-world scenarios", () => {
+  it("notifies only the untipped of two matches at the same kickoff", async () => {
+    vi.mocked(getUpcomingMatches).mockResolvedValue([
+      match(1, ONLY_1440),
+      match(2, ONLY_1440),
+    ] as AwaitedReturn<typeof getUpcomingMatches>);
+    vi.mocked(getTipByUserAndMatchIds).mockResolvedValue([
+      { matchId: 1 },
+    ] as AwaitedReturn<typeof getTipByUserAndMatchIds>);
+
+    const res = await POST(makeRequest(SECRET));
+    expect(await res.json()).toEqual({ sent: 2 });
+    expect(sendTipReminderEmail).toHaveBeenCalledTimes(1);
+    expect(sendTipReminderEmail).toHaveBeenCalledWith(
+      "u1@test",
+      expect.objectContaining({ matchLabel: "H2 – A2" }),
+    );
+    expect(sendPush).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires every open lead window at once near kickoff (3 leads → 3 emails + 3 pushes)", async () => {
+    // A match ~3.5h out with all five lead times enabled: the 6h/12h/24h
+    // windows are open together, so three reminders go out per channel in one
+    // run. (In real time these arrive spread out: 24h, then 12h, then 6h.)
+    vi.mocked(getUpcomingMatches).mockResolvedValue([
+      match(1, THREE_LEADS),
+    ] as AwaitedReturn<typeof getUpcomingMatches>);
+    vi.mocked(getAllReminderSettings).mockResolvedValue(
+      ALL_LEADS as AwaitedReturn<typeof getAllReminderSettings>,
+    );
+
+    const res = await POST(makeRequest(SECRET));
+    expect(await res.json()).toEqual({ sent: 6 });
+    expect(sendTipReminderEmail).toHaveBeenCalledTimes(3);
+    expect(sendPush).toHaveBeenCalledTimes(3);
+  });
+});

--- a/tests/unit/error-message.test.ts
+++ b/tests/unit/error-message.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { extractErrorKey } from "@/lib/error-message";
+
+describe("extractErrorKey", () => {
+  it("returns the error string from a well-formed body", () => {
+    expect(extractErrorKey({ error: "tooManyRequests" })).toBe(
+      "tooManyRequests",
+    );
+  });
+
+  it("returns null when error is missing or not a string", () => {
+    expect(extractErrorKey({})).toBeNull();
+    expect(extractErrorKey({ error: 42 })).toBeNull();
+    expect(extractErrorKey({ message: "boom" })).toBeNull();
+  });
+
+  it("returns null for non-object input", () => {
+    expect(extractErrorKey(null)).toBeNull();
+    expect(extractErrorKey(undefined)).toBeNull();
+    expect(extractErrorKey("error")).toBeNull();
+    expect(extractErrorKey(["error"])).toBeNull();
+  });
+});

--- a/tests/unit/teams.test.ts
+++ b/tests/unit/teams.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  TEAMS,
+  TEAM_CODES,
+  isTeamCode,
+  localizedTeams,
+  teamName,
+} from "@/lib/data/teams";
+
+describe("teamName", () => {
+  it("returns the German name for a de locale", () => {
+    expect(teamName("GER", "de")).toBe("Deutschland");
+    expect(teamName("BRA", "de")).toBe("Brasilien");
+  });
+
+  it("returns the English name for an en locale", () => {
+    expect(teamName("GER", "en")).toBe("Germany");
+    expect(teamName("BRA", "en")).toBe("Brazil");
+  });
+
+  it("treats any non-en locale as German", () => {
+    expect(teamName("GER", "de-DE")).toBe("Deutschland");
+    expect(teamName("GER", "fr")).toBe("Deutschland");
+  });
+
+  it("falls back to the code for an unknown team", () => {
+    expect(teamName("ZZZ", "en")).toBe("ZZZ");
+  });
+});
+
+describe("localizedTeams", () => {
+  it("returns every team for both locales", () => {
+    expect(localizedTeams("de")).toHaveLength(TEAMS.length);
+    expect(localizedTeams("en")).toHaveLength(TEAMS.length);
+  });
+
+  it("localizes the names by locale", () => {
+    const de = localizedTeams("de").find((t) => t.code === "GER");
+    const en = localizedTeams("en").find((t) => t.code === "GER");
+    expect(de?.name).toBe("Deutschland");
+    expect(en?.name).toBe("Germany");
+  });
+
+  it("sorts alphabetically within the active locale", () => {
+    const en = localizedTeams("en").map((t) => t.name);
+    const sorted = [...en].sort((a, b) => a.localeCompare(b, "en"));
+    expect(en).toEqual(sorted);
+  });
+});
+
+describe("isTeamCode / TEAM_CODES", () => {
+  it("accepts a known code and rejects an unknown one", () => {
+    expect(isTeamCode("GER")).toBe(true);
+    expect(isTeamCode("XXX")).toBe(false);
+  });
+
+  it("has exactly one unique code per team", () => {
+    expect(TEAM_CODES).toHaveLength(TEAMS.length);
+    expect(new Set(TEAM_CODES).size).toBe(TEAMS.length);
+  });
+});

--- a/tests/unit/tip-reminder-email.test.ts
+++ b/tests/unit/tip-reminder-email.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Transporter } from "nodemailer";
+import {
+  _internal,
+  sendTipReminderEmail,
+  type TransportFactory,
+} from "@/lib/mail";
+
+const SMTP_KEYS = [
+  "SMTP_HOST",
+  "SMTP_PORT",
+  "SMTP_SECURE",
+  "SMTP_USER",
+  "SMTP_PASS",
+  "SMTP_FROM",
+] as const;
+
+const originalEnv: Record<string, string | undefined> = {};
+
+function captureFactory(): { factory: TransportFactory; sent: unknown[] } {
+  const sent: unknown[] = [];
+  const factory: TransportFactory = () =>
+    ({
+      sendMail: async (message: unknown) => {
+        sent.push(message);
+        return {};
+      },
+    }) as unknown as Transporter;
+  return { factory, sent };
+}
+
+beforeEach(() => {
+  for (const key of SMTP_KEYS) originalEnv[key] = process.env[key];
+  process.env.SMTP_HOST = "smtp.example.com";
+  process.env.SMTP_PORT = "587";
+  process.env.SMTP_SECURE = "false";
+  process.env.SMTP_USER = "user@example.com";
+  process.env.SMTP_PASS = "s3cret";
+  process.env.SMTP_FROM = "WM 2026 <no-reply@example.com>";
+});
+
+afterEach(() => {
+  for (const key of SMTP_KEYS) {
+    if (originalEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = originalEnv[key];
+  }
+  _internal.reset();
+});
+
+describe("sendTipReminderEmail (branded)", () => {
+  it("includes the wordmark, match label, kickoff and dashboard CTA", async () => {
+    const { factory, sent } = captureFactory();
+    _internal.setTransportFactory(factory);
+
+    await sendTipReminderEmail("player@example.com", {
+      matchLabel: "Mexico – South Africa",
+      kickoff: "Donnerstag, 11. Juni, 19:00 Uhr",
+      predictUrl: "https://wm.example.com/",
+    });
+
+    expect(sent).toHaveLength(1);
+    const msg = sent[0] as {
+      to: string;
+      subject: string;
+      html: string;
+      text: string;
+    };
+    expect(msg.to).toBe("player@example.com");
+    expect(msg.subject).toContain("Mexico – South Africa");
+    expect(msg.html).toContain("valantic");
+    expect(msg.html).toContain("Mexico – South Africa");
+    expect(msg.html).toContain("Donnerstag, 11. Juni, 19:00 Uhr");
+    expect(msg.html).toContain('href="https://wm.example.com/"');
+    // Plain-text fallback still carries the link.
+    expect(msg.text).toContain("https://wm.example.com/");
+  });
+
+  it("escapes HTML in dynamic values (no markup injection)", async () => {
+    const { factory, sent } = captureFactory();
+    _internal.setTransportFactory(factory);
+
+    await sendTipReminderEmail("player@example.com", {
+      matchLabel: '<script>alert(1)</script> & "x"',
+      kickoff: "k",
+      predictUrl: "https://wm.example.com/",
+    });
+
+    const html = (sent[0] as { html: string }).html;
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&lt;script&gt;");
+    expect(html).toContain("&amp;");
+  });
+});

--- a/tests/unit/validation-schemas.test.ts
+++ b/tests/unit/validation-schemas.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  pushSubscriptionSchema,
+  pushUnsubscribeSchema,
+} from "@/lib/validation/push-subscription";
+import { reminderEmailSchema } from "@/lib/validation/reminder-email";
+
+const validSub = {
+  endpoint: "https://fcm.googleapis.com/fcm/send/abc",
+  keys: { p256dh: "p256dh-key", auth: "auth-key" },
+};
+
+describe("pushSubscriptionSchema", () => {
+  it("accepts a valid subscription", () => {
+    expect(pushSubscriptionSchema.safeParse(validSub).success).toBe(true);
+  });
+
+  it("rejects a non-URL endpoint", () => {
+    expect(
+      pushSubscriptionSchema.safeParse({ ...validSub, endpoint: "not-a-url" })
+        .success,
+    ).toBe(false);
+  });
+
+  it("rejects missing or empty keys", () => {
+    expect(
+      pushSubscriptionSchema.safeParse({ endpoint: validSub.endpoint }).success,
+    ).toBe(false);
+    expect(
+      pushSubscriptionSchema.safeParse({
+        ...validSub,
+        keys: { p256dh: "", auth: "auth-key" },
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("pushUnsubscribeSchema", () => {
+  it("requires a URL endpoint", () => {
+    expect(
+      pushUnsubscribeSchema.safeParse({ endpoint: "https://x.test/e" }).success,
+    ).toBe(true);
+    expect(pushUnsubscribeSchema.safeParse({ endpoint: "x" }).success).toBe(
+      false,
+    );
+  });
+});
+
+describe("reminderEmailSchema", () => {
+  it("requires a boolean enabled flag", () => {
+    expect(reminderEmailSchema.safeParse({ enabled: true }).success).toBe(true);
+    expect(reminderEmailSchema.safeParse({ enabled: "yes" }).success).toBe(
+      false,
+    );
+    expect(reminderEmailSchema.safeParse({}).success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Background
The tip-reminder pipeline had been validated only by hand against the production
database — not repeatable, not in CI, and not covering the failure and channel
paths. The orchestration that decides who gets notified, on which channel, and
when had no automated test, and a few recently added pieces (localized team
names, the branded reminder email, small helpers) were untested too.

## What this changes
Adds automated coverage so the notification behaviour is locked in and verifiable
without touching production: the reminder job's end-to-end decision logic
(authorization, the "only untipped matches" filter, de-duplication, email/push
channel selection, retry-on-failure, pruning of dead push endpoints, two matches
at the same kickoff, and several reminders firing together near kickoff), the
localized team names, the branded reminder email, and a handful of pure helpers.