### PR TITLE
FE-094: DB integration tests on seeded demo data

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -43,11 +43,14 @@ jobs:
       - name: Unit tests + coverage
         run: pnpm exec vitest run --coverage
 
+      - name: DB integration tests + coverage (seeded demo data)
+        run: pnpm exec vitest run --config vitest.integration.config.ts --coverage
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: football-betting/frontend
           flags: frontend
-          files: ./coverage/lcov.info
+          files: ./coverage/lcov.info,./coverage-integration/lcov.info
           fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # Testing
 /coverage
+/coverage-integration
 /playwright-report
 /test-results
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test:unit": "vitest run tests/unit",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
-    "test:e2e:headed": "playwright test --headed"
+    "test:e2e:headed": "playwright test --headed",
+    "test:integration": "vitest run --config vitest.integration.config.ts"
   },
   "dependencies": {
     "@lucia-auth/adapter-drizzle": "^1.1.0",

--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -1,0 +1,17 @@
+// Narrow an array's first element to a defined value or fail loudly — keeps the
+// integration tests honest under `noUncheckedIndexedAccess`.
+export function first<T>(arr: readonly T[], message: string): T {
+  const value = arr[0];
+  if (value === undefined) throw new Error(message);
+  return value;
+}
+
+// Known seeded demo accounts (see scripts/demo_data.ts).
+export const SEED_EMAIL = {
+  ada: "ada.lovelace@local.dev",
+  marie: "marie.curie@local.dev",
+  nikola: "nikola.tesla@local.dev",
+  rosa: "rosa.parks@local.dev",
+  testUser: "test.user@local.dev",
+  isaac: "isaac.newton@local.dev",
+} as const;

--- a/tests/integration/match.integration.test.ts
+++ b/tests/integration/match.integration.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { getLiveState, getMatchById, getUpcomingMatches } from "@/lib/match";
+import { isUpcomingStatus } from "@/lib/reminders";
+import { first } from "./helpers";
+
+describe("match store (seeded demo data)", () => {
+  it("returns upcoming matches: all future, SCHEDULED/TIMED, ascending", async () => {
+    const matches = await getUpcomingMatches();
+    expect(matches.length).toBeGreaterThan(0);
+
+    const cutoff = Date.now() - 60_000;
+    for (const m of matches) {
+      expect(isUpcomingStatus(m.status)).toBe(true);
+      expect(m.utcDate.getTime()).toBeGreaterThanOrEqual(cutoff);
+    }
+
+    const times = matches.map((m) => m.utcDate.getTime());
+    expect(times).toEqual([...times].sort((a, b) => a - b));
+  });
+
+  it("round-trips getMatchById for a known match", async () => {
+    const target = first(
+      await getUpcomingMatches(),
+      "seed has no upcoming match",
+    );
+    const byId = await getMatchById(target.id);
+    expect(byId?.id).toBe(target.id);
+    expect(byId?.homeTeam.name).toBe(target.homeTeam.name);
+  });
+
+  it("reports the next kickoff via getLiveState", async () => {
+    const state = await getLiveState();
+    expect(state.nextKickoff).not.toBeNull();
+  });
+});

--- a/tests/integration/push-store.integration.test.ts
+++ b/tests/integration/push-store.integration.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { getUserByEmail } from "@/lib/user";
+import {
+  deletePushSubscriptionByEndpoint,
+  getPushSubscriptionCountsByUserIds,
+  getPushSubscriptionsByUserIds,
+  savePushSubscription,
+  userHasPushSubscription,
+} from "@/lib/push-store";
+import { SEED_EMAIL } from "./helpers";
+
+describe("push store (round-trip on seeded DB)", () => {
+  it("saves, reads and deletes a subscription", async () => {
+    const u = await getUserByEmail(SEED_EMAIL.rosa);
+    expect(await userHasPushSubscription(u!.id)).toBe(false);
+
+    const sub = {
+      endpoint: "https://push.example/ep-rosa",
+      p256dh: "p256",
+      auth: "auth",
+    };
+    await savePushSubscription(u!.id, sub, new Date());
+
+    expect(await userHasPushSubscription(u!.id)).toBe(true);
+    const map = await getPushSubscriptionsByUserIds([u!.id]);
+    expect(map.get(u!.id)?.[0]?.endpoint).toBe(sub.endpoint);
+    expect((await getPushSubscriptionCountsByUserIds([u!.id])).get(u!.id)).toBe(
+      1,
+    );
+
+    await deletePushSubscriptionByEndpoint(sub.endpoint);
+    expect(await userHasPushSubscription(u!.id)).toBe(false);
+  });
+
+  it("upserts the same endpoint in place (refreshes keys, no duplicate)", async () => {
+    const u = await getUserByEmail(SEED_EMAIL.isaac);
+    const sub = {
+      endpoint: "https://push.example/ep-isaac",
+      p256dh: "p1",
+      auth: "a1",
+    };
+    await savePushSubscription(u!.id, sub, new Date());
+    await savePushSubscription(
+      u!.id,
+      { ...sub, p256dh: "p2", auth: "a2" },
+      new Date(),
+    );
+
+    const list = (await getPushSubscriptionsByUserIds([u!.id])).get(u!.id);
+    expect(list).toHaveLength(1);
+    expect(list?.[0]?.p256dh).toBe("p2");
+  });
+});

--- a/tests/integration/reminder-store.integration.test.ts
+++ b/tests/integration/reminder-store.integration.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { getUserByEmail } from "@/lib/user";
+import { getUpcomingMatches } from "@/lib/match";
+import {
+  getEmailDisabledUserIds,
+  getEnabledLeadMinutes,
+  getSentKeysForMatches,
+  isEmailEnabled,
+  markReminderSent,
+  replaceLeadMinutes,
+  setEmailEnabled,
+} from "@/lib/reminder-store";
+import { first, SEED_EMAIL } from "./helpers";
+
+describe("reminder store (round-trip on seeded DB)", () => {
+  it("replaces and reads enabled lead minutes (deduped, full overwrite)", async () => {
+    const u = await getUserByEmail(SEED_EMAIL.marie);
+    await replaceLeadMinutes(u!.id, [60, 1440, 60]);
+    expect(new Set(await getEnabledLeadMinutes(u!.id))).toEqual(
+      new Set([60, 1440]),
+    );
+
+    await replaceLeadMinutes(u!.id, [360]);
+    expect(await getEnabledLeadMinutes(u!.id)).toEqual([360]);
+  });
+
+  it("dedups markReminderSent per (user, match, lead, channel)", async () => {
+    const u = await getUserByEmail(SEED_EMAIL.marie);
+    const matchId = first(
+      await getUpcomingMatches(),
+      "seed has no upcoming match",
+    ).id;
+    const now = new Date();
+
+    expect(await markReminderSent(u!.id, matchId, 1440, "email", now)).toBe(
+      true,
+    );
+    // Same slot again → no new row.
+    expect(await markReminderSent(u!.id, matchId, 1440, "email", now)).toBe(
+      false,
+    );
+    // Different channel is an independent slot.
+    expect(await markReminderSent(u!.id, matchId, 1440, "push", now)).toBe(true);
+
+    const keys = await getSentKeysForMatches([matchId]);
+    expect(keys.has(`${u!.id}:${matchId}:1440:email`)).toBe(true);
+    expect(keys.has(`${u!.id}:${matchId}:1440:push`)).toBe(true);
+  });
+
+  it("toggles email enabled (on by default, opt-out, opt-in)", async () => {
+    const u = await getUserByEmail(SEED_EMAIL.nikola);
+    expect(await isEmailEnabled(u!.id)).toBe(true);
+
+    await setEmailEnabled(u!.id, false);
+    expect(await isEmailEnabled(u!.id)).toBe(false);
+    expect((await getEmailDisabledUserIds([u!.id])).has(u!.id)).toBe(true);
+
+    await setEmailEnabled(u!.id, true);
+    expect(await isEmailEnabled(u!.id)).toBe(true);
+    expect((await getEmailDisabledUserIds([u!.id])).has(u!.id)).toBe(false);
+  });
+});

--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -1,0 +1,44 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+
+// Rebuild a dedicated integration DB from scratch before the suite: drop the
+// file, migrate the schema, seed the demo data. Mirrors the E2E global setup
+// but targets its own DB (itest.db) so the two suites never collide. Re-running
+// this is exactly the "restore to a known state" step — the demo seed wipes and
+// re-inserts inside a transaction.
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const FRONTEND_ROOT = path.resolve(HERE, "../..");
+const REL_DB = "../shared/db/itest.db";
+const ABS_DB = path.resolve(FRONTEND_ROOT, REL_DB);
+
+function removeDbFiles(): void {
+  for (const suffix of ["", "-shm", "-wal"]) {
+    const file = ABS_DB + suffix;
+    if (fs.existsSync(file)) fs.rmSync(file, { force: true });
+  }
+}
+
+function run(cmd: string, args: string[]): void {
+  const result = spawnSync(cmd, args, {
+    stdio: "inherit",
+    env: { ...process.env, DATABASE_URL: REL_DB },
+    shell: false,
+    cwd: FRONTEND_ROOT,
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `integration globalSetup: ${cmd} ${args.join(" ")} failed with exit code ${result.status}`,
+    );
+  }
+}
+
+export default function globalSetup(): void {
+  // Ensure ../shared/db exists (it is not part of the frontend checkout in CI).
+  fs.mkdirSync(path.dirname(ABS_DB), { recursive: true });
+  removeDbFiles();
+  run("pnpm", ["db:migrate"]);
+  // db:seed honours DATABASE_URL (set above) → seeds itest.db, not the real DB.
+  run("pnpm", ["db:seed"]);
+}

--- a/tests/integration/tip.integration.test.ts
+++ b/tests/integration/tip.integration.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { getUserByEmail } from "@/lib/user";
+import { getUpcomingMatches } from "@/lib/match";
+import {
+  getTipByUserAndMatch,
+  getTipByUserAndMatchIds,
+  saveTip,
+} from "@/lib/tip";
+import { first, SEED_EMAIL } from "./helpers";
+
+describe("tip store (round-trip on seeded DB)", () => {
+  it("saves, reads and upserts a tip", async () => {
+    const user = await getUserByEmail(SEED_EMAIL.ada);
+    const matchId = first(
+      await getUpcomingMatches(),
+      "seed has no upcoming match",
+    ).id;
+
+    const saved = await saveTip(user!.id, matchId, 3, 1);
+    expect(saved.scoreHome).toBe(3);
+    expect(saved.scoreAway).toBe(1);
+
+    const found = await getTipByUserAndMatch(user!.id, matchId);
+    expect(found?.scoreHome).toBe(3);
+
+    const list = await getTipByUserAndMatchIds(user!.id, [matchId, -999]);
+    expect(list).toHaveLength(1);
+
+    // Saving again upserts in place — still exactly one row.
+    await saveTip(user!.id, matchId, 0, 0);
+    const after = await getTipByUserAndMatchIds(user!.id, [matchId]);
+    expect(after).toHaveLength(1);
+    expect(after[0]?.scoreHome).toBe(0);
+  });
+
+  it("returns an empty list for matches the user has not tipped", async () => {
+    const user = await getUserByEmail(SEED_EMAIL.isaac);
+    expect(await getTipByUserAndMatchIds(user!.id, [-1, -2])).toEqual([]);
+  });
+});

--- a/tests/integration/user.integration.test.ts
+++ b/tests/integration/user.integration.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { getUserByEmail, getUserById, getUserEmailsByIds } from "@/lib/user";
+import { SEED_EMAIL } from "./helpers";
+
+describe("user store (seeded demo data)", () => {
+  it("reads a seeded user by email", async () => {
+    const u = await getUserByEmail(SEED_EMAIL.ada);
+    expect(u).toBeDefined();
+    expect(u?.username).toBe("AdaLovelace");
+    expect(u?.department).toBe("Mainz");
+  });
+
+  it("reads the same user back by id", async () => {
+    const byEmail = await getUserByEmail(SEED_EMAIL.ada);
+    expect(byEmail).toBeDefined();
+    const byId = await getUserById(byEmail!.id);
+    expect(byId?.email).toBe(SEED_EMAIL.ada);
+  });
+
+  it("maps ids to emails", async () => {
+    const u = await getUserByEmail(SEED_EMAIL.testUser);
+    const map = await getUserEmailsByIds([u!.id]);
+    expect(map.get(u!.id)).toBe(SEED_EMAIL.testUser);
+  });
+
+  it("returns undefined for an unknown email", async () => {
+    expect(await getUserByEmail("nobody@local.dev")).toBeUndefined();
+  });
+});

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+// DB-backed integration tests. A dedicated SQLite file (itest.db) is migrated
+// and seeded with the demo data by the global setup before any test runs, and
+// rebuilt from scratch on every run — so a previous run's writes never leak in
+// (the demo seed IS the restore point). Kept separate from the fast, DB-free
+// unit suite (vitest.config.ts).
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "."),
+      "server-only": path.resolve(__dirname, "tests/stubs/server-only.ts"),
+    },
+  },
+  test: {
+    environment: "node",
+    include: ["tests/integration/**/*.test.ts"],
+    globals: false,
+    globalSetup: ["tests/integration/setup.ts"],
+    env: {
+      DATABASE_URL: "../shared/db/itest.db",
+    },
+    // One shared SQLite file: run test files sequentially to avoid write
+    // contention / cross-file interleaving.
+    fileParallelism: false,
+    reporters: ["default"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      // Separate dir so it can be merged with the unit report (./coverage)
+      // rather than overwriting it.
+      reportsDirectory: "./coverage-integration",
+      include: ["lib/**", "app/api/**"],
+    },
+  },
+});


### PR DESCRIPTION
## Background
The data-access layer (users, tips, matches, reminder and push stores) was only
covered indirectly, and the demo data was never exercised by an automated test.
Manual checking against a real database is not repeatable and can leave the data
in an unknown state.

## What this changes
Adds a separate, database-backed test suite that rebuilds a dedicated database
from the demo data before every run — so each run starts from the same known
state and any prior writes are discarded — and verifies the real data-access
behaviour against it. It runs in CI as its own step, without the API or browser
stack, and its coverage is combined with the existing unit coverage so the
data-access modules now count toward the reported total.