### PR TITLE
FE-096: unit coverage for 7 partially-tested lib modules

### DIFF
--- a/tests/unit/api-timing.test.ts
+++ b/tests/unit/api-timing.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 import { fetchApi } from "@/lib/api";
 
 function jsonResponse(body: unknown): Response {
@@ -7,6 +8,15 @@ function jsonResponse(body: unknown): Response {
     status: 200,
     statusText: "OK",
     json: async () => body,
+  } as Response;
+}
+
+function errorResponse(status: number, statusText: string): Response {
+  return {
+    ok: false,
+    status,
+    statusText,
+    json: async () => ({}),
   } as Response;
 }
 
@@ -62,6 +72,108 @@ describe("fetchApi timing log", () => {
       expect.stringMatching(
         /^\[rust-api\] GET \/user\/5 → failed in \d+ms \(network error\)$/,
       ),
+    );
+  });
+});
+
+describe("fetchApi URL building and options", () => {
+  it("strips a leading slash from the endpoint and a trailing slash from RUST_API_URL", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.stubEnv("RUST_API_URL", "http://api.example.com/");
+    const fetchMock = vi.fn(async () => jsonResponse({ value: 1 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchApi("/game/9");
+
+    expect(fetchMock).toHaveBeenCalledWith("http://api.example.com/game/9");
+  });
+
+  it("falls back to localhost:8080 when RUST_API_URL is unset", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.stubEnv("RUST_API_URL", undefined);
+    const fetchMock = vi.fn(async () => jsonResponse({ value: 1 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchApi("rating");
+
+    expect(fetchMock).toHaveBeenCalledWith("http://localhost:8080/rating");
+  });
+
+  it("returns the raw payload when no wrappedByKey or schema is given", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.stubGlobal("fetch", vi.fn(async () => jsonResponse({ a: 1 })));
+
+    await expect(fetchApi("x")).resolves.toEqual({ a: 1 });
+  });
+
+  it("accepts the legacy string signature as wrappedByKey", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.stubGlobal("fetch", vi.fn(async () => jsonResponse({ table: [1, 2] })));
+
+    await expect(fetchApi("rating", "table")).resolves.toEqual([1, 2]);
+  });
+});
+
+describe("fetchApi error paths", () => {
+  it("throws with status and statusText when the response is not ok", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => errorResponse(503, "Service Unavailable")),
+    );
+
+    await expect(fetchApi("rating")).rejects.toThrow(
+      /fetchApi: 503 Service Unavailable for/,
+    );
+  });
+
+  it("throws when wrappedByKey is missing from the response object", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.stubGlobal("fetch", vi.fn(async () => jsonResponse({ other: [] })));
+
+    await expect(
+      fetchApi("rating", { wrappedByKey: "table" }),
+    ).rejects.toThrow(/response missing key 'table'/);
+  });
+
+  it("throws when the response is not an object but a key is expected", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.stubGlobal("fetch", vi.fn(async () => jsonResponse(null)));
+
+    await expect(
+      fetchApi("rating", { wrappedByKey: "table" }),
+    ).rejects.toThrow(/response missing key 'table'/);
+  });
+});
+
+describe("fetchApi schema validation", () => {
+  const schema = z.object({ id: z.number() });
+
+  it("returns parsed data when the schema accepts the payload", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.stubGlobal("fetch", vi.fn(async () => jsonResponse({ id: 7 })));
+
+    await expect(fetchApi("game/7", { schema })).resolves.toEqual({ id: 7 });
+  });
+
+  it("validates the unwrapped candidate when both wrappedByKey and schema are set", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ data: { id: 7 } })),
+    );
+
+    await expect(
+      fetchApi("game/7", { wrappedByKey: "data", schema }),
+    ).resolves.toEqual({ id: 7 });
+  });
+
+  it("throws a schema-validation error when the payload does not match", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.stubGlobal("fetch", vi.fn(async () => jsonResponse({ id: "no" })));
+
+    await expect(fetchApi("game/7", { schema })).rejects.toThrow(
+      /schema validation failed for/,
     );
   });
 });

--- a/tests/unit/password-validation.test.ts
+++ b/tests/unit/password-validation.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { changePasswordSchema } from "@/lib/validation/password";
+import {
+  changePasswordSchema,
+  resetPasswordSchema,
+} from "@/lib/validation/password";
 
 describe("changePasswordSchema", () => {
   it("accepts a valid payload where new equals confirm", () => {
@@ -63,6 +66,68 @@ describe("changePasswordSchema", () => {
       currentPassword: "oldpass1",
       newPassword: 12345678,
       confirmPassword: 12345678,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("resetPasswordSchema", () => {
+  it("accepts a valid payload where new equals confirm", () => {
+    const result = resetPasswordSchema.safeParse({
+      token: "valid-token",
+      newPassword: "newpass123",
+      confirmPassword: "newpass123",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an empty token", () => {
+    const result = resetPasswordSchema.safeParse({
+      token: "",
+      newPassword: "newpass123",
+      confirmPassword: "newpass123",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) => i.path.includes("token"));
+      expect(issue?.message).toBe("invalidResetToken");
+    }
+  });
+
+  it("rejects when new password is shorter than 8 characters", () => {
+    const result = resetPasswordSchema.safeParse({
+      token: "valid-token",
+      newPassword: "short",
+      confirmPassword: "short",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) =>
+        i.path.includes("newPassword"),
+      );
+      expect(issue?.message).toBe("newPasswordTooShort");
+    }
+  });
+
+  it("rejects when confirm does not equal new password", () => {
+    const result = resetPasswordSchema.safeParse({
+      token: "valid-token",
+      newPassword: "newpass123",
+      confirmPassword: "different123",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) =>
+        i.path.includes("confirmPassword"),
+      );
+      expect(issue?.message).toBe("passwordsDoNotMatch");
+    }
+  });
+
+  it("rejects when the token field is missing", () => {
+    const result = resetPasswordSchema.safeParse({
+      newPassword: "newpass123",
+      confirmPassword: "newpass123",
     });
     expect(result.success).toBe(false);
   });

--- a/tests/unit/push.test.ts
+++ b/tests/unit/push.test.ts
@@ -1,5 +1,39 @@
-import { describe, expect, it } from "vitest";
-import { buildPushPayload, isGoneStatus } from "@/lib/push";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const setVapidDetails = vi.fn();
+const sendNotification = vi.fn();
+
+vi.mock("web-push", () => ({
+  default: {
+    setVapidDetails: (...args: unknown[]) => setVapidDetails(...args),
+    sendNotification: (...args: unknown[]) => sendNotification(...args),
+  },
+}));
+
+import {
+  _internal,
+  buildPushPayload,
+  isGoneStatus,
+  sendPush,
+} from "@/lib/push";
+
+const VAPID_ENV = {
+  VAPID_SUBJECT: "mailto:test@example.com",
+  NEXT_PUBLIC_VAPID_PUBLIC_KEY: "public-key",
+  VAPID_PRIVATE_KEY: "private-key",
+} as const;
+
+function setVapidEnv(): void {
+  vi.stubEnv("VAPID_SUBJECT", VAPID_ENV.VAPID_SUBJECT);
+  vi.stubEnv("NEXT_PUBLIC_VAPID_PUBLIC_KEY", VAPID_ENV.NEXT_PUBLIC_VAPID_PUBLIC_KEY);
+  vi.stubEnv("VAPID_PRIVATE_KEY", VAPID_ENV.VAPID_PRIVATE_KEY);
+}
+
+const subscription = {
+  endpoint: "https://push.example.com/abc",
+  p256dh: "p256dh-key",
+  auth: "auth-key",
+};
 
 describe("buildPushPayload", () => {
   it("serializes exactly title, body and url for the service worker", () => {
@@ -26,5 +60,114 @@ describe("isGoneStatus", () => {
     expect(isGoneStatus(429)).toBe(false);
     expect(isGoneStatus(500)).toBe(false);
     expect(isGoneStatus(201)).toBe(false);
+  });
+});
+
+describe("readVapidConfig", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns the full config when all VAPID env vars are present", () => {
+    setVapidEnv();
+    expect(_internal.readVapidConfig()).toEqual({
+      subject: VAPID_ENV.VAPID_SUBJECT,
+      publicKey: VAPID_ENV.NEXT_PUBLIC_VAPID_PUBLIC_KEY,
+      privateKey: VAPID_ENV.VAPID_PRIVATE_KEY,
+    });
+  });
+
+  it("throws listing every missing var when none are set", () => {
+    vi.stubEnv("VAPID_SUBJECT", "");
+    vi.stubEnv("NEXT_PUBLIC_VAPID_PUBLIC_KEY", "");
+    vi.stubEnv("VAPID_PRIVATE_KEY", "");
+    expect(() => _internal.readVapidConfig()).toThrowError(
+      "Web push is not configured: missing VAPID_SUBJECT, NEXT_PUBLIC_VAPID_PUBLIC_KEY, VAPID_PRIVATE_KEY",
+    );
+  });
+
+  it("throws naming only the single missing var", () => {
+    vi.stubEnv("VAPID_SUBJECT", VAPID_ENV.VAPID_SUBJECT);
+    vi.stubEnv("NEXT_PUBLIC_VAPID_PUBLIC_KEY", VAPID_ENV.NEXT_PUBLIC_VAPID_PUBLIC_KEY);
+    vi.stubEnv("VAPID_PRIVATE_KEY", "");
+    expect(() => _internal.readVapidConfig()).toThrowError(
+      "Web push is not configured: missing VAPID_PRIVATE_KEY",
+    );
+  });
+});
+
+describe("sendPush", () => {
+  beforeEach(() => {
+    setVapidEnv();
+    _internal.resetVapidConfigured();
+    setVapidDetails.mockReset();
+    sendNotification.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns {ok:true} on a successful send and configures VAPID once", async () => {
+    sendNotification.mockResolvedValue(undefined);
+    const payload = buildPushPayload({ title: "t", body: "b", url: "u" });
+
+    const first = await sendPush(subscription, payload);
+    const second = await sendPush(subscription, payload);
+
+    expect(first).toEqual({ ok: true });
+    expect(second).toEqual({ ok: true });
+    // ensureVapidConfigured only runs setVapidDetails on the first call.
+    expect(setVapidDetails).toHaveBeenCalledTimes(1);
+    expect(setVapidDetails).toHaveBeenCalledWith(
+      VAPID_ENV.VAPID_SUBJECT,
+      VAPID_ENV.NEXT_PUBLIC_VAPID_PUBLIC_KEY,
+      VAPID_ENV.VAPID_PRIVATE_KEY,
+    );
+    expect(sendNotification).toHaveBeenCalledWith(
+      {
+        endpoint: subscription.endpoint,
+        keys: { p256dh: subscription.p256dh, auth: subscription.auth },
+      },
+      payload,
+    );
+  });
+
+  it("returns {ok:false, gone:true} when the push service responds 410", async () => {
+    sendNotification.mockRejectedValue({ statusCode: 410 });
+    const result = await sendPush(subscription, "payload");
+    expect(result).toEqual({ ok: false, gone: true, statusCode: 410 });
+  });
+
+  it("returns {ok:false, gone:true} when the push service responds 404", async () => {
+    sendNotification.mockRejectedValue({ statusCode: 404 });
+    const result = await sendPush(subscription, "payload");
+    expect(result).toEqual({ ok: false, gone: true, statusCode: 404 });
+  });
+
+  it("returns {ok:false, gone:false, statusCode} for a non-gone error status", async () => {
+    sendNotification.mockRejectedValue({ statusCode: 500 });
+    const result = await sendPush(subscription, "payload");
+    expect(result).toEqual({ ok: false, gone: false, statusCode: 500 });
+  });
+
+  it("returns statusCode null for an error without a numeric statusCode", async () => {
+    sendNotification.mockRejectedValue(new Error("network down"));
+    const result = await sendPush(subscription, "payload");
+    expect(result).toEqual({ ok: false, gone: false, statusCode: null });
+  });
+
+  it("returns statusCode null when statusCode is not a number", async () => {
+    sendNotification.mockRejectedValue({ statusCode: "410" });
+    const result = await sendPush(subscription, "payload");
+    expect(result).toEqual({ ok: false, gone: false, statusCode: null });
+  });
+
+  it("returns a failure (statusCode null) when VAPID config is missing", async () => {
+    vi.stubEnv("VAPID_PRIVATE_KEY", "");
+    _internal.resetVapidConfigured();
+    const result = await sendPush(subscription, "payload");
+    expect(result).toEqual({ ok: false, gone: false, statusCode: null });
+    expect(sendNotification).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   _internal,
   checkRateLimit,
@@ -67,6 +67,121 @@ describe("checkRateLimit", () => {
     expect(checkRateLimit("3.3.3.3", "login").ok).toBe(false);
     resetRateLimit("3.3.3.3", "login");
     expect(checkRateLimit("3.3.3.3", "login").ok).toBe(true);
+  });
+
+  it("starts a fresh window after the previous one has expired", () => {
+    vi.useFakeTimers();
+    try {
+      for (let i = 0; i < _internal.MAX_ATTEMPTS; i += 1) {
+        checkRateLimit("4.4.4.4", "login");
+      }
+      expect(checkRateLimit("4.4.4.4", "login").ok).toBe(false);
+
+      // Advance past the window: the stale entry's resetAt <= now, so the next
+      // call opens a brand-new window and is allowed again.
+      vi.advanceTimersByTime(_internal.WINDOW_MS + 1);
+      expect(checkRateLimit("4.4.4.4", "login").ok).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("sweeps expired entries on the interval timer", async () => {
+    // The sweep interval is created lazily on first checkRateLimit. To control
+    // it deterministically we load a fresh module instance with fake timers
+    // already installed, so this module's setInterval is the fake one.
+    vi.resetModules();
+    vi.useFakeTimers();
+    try {
+      const fresh = await import("@/lib/rate-limit");
+      fresh.checkRateLimit("5.5.5.5", "login");
+      expect(fresh._internal.buckets.size).toBe(1);
+
+      // Past the window → the entry is expired; the next sweep tick deletes it.
+      vi.advanceTimersByTime(
+        fresh._internal.WINDOW_MS + fresh._internal.SWEEP_MS + 1,
+      );
+      expect(fresh._internal.buckets.size).toBe(0);
+    } finally {
+      vi.useRealTimers();
+      vi.resetModules();
+    }
+  });
+});
+
+describe("checkRateLimit bucket eviction (MAX_BUCKETS)", () => {
+  beforeEach(() => {
+    _internal.buckets.clear();
+    delete process.env.DISABLE_RATE_LIMIT;
+  });
+
+  afterEach(() => {
+    _internal.buckets.clear();
+    vi.useRealTimers();
+  });
+
+  it("evicts expired entries first when at capacity", () => {
+    vi.useFakeTimers();
+    const now = Date.now();
+    // Fill to capacity with already-expired entries.
+    for (let i = 0; i < _internal.MAX_BUCKETS; i += 1) {
+      _internal.buckets.set(`login:expired-${i}`, {
+        count: 1,
+        resetAt: now - 1,
+      });
+    }
+    expect(_internal.buckets.size).toBe(_internal.MAX_BUCKETS);
+
+    const res = checkRateLimit("new.client", "login");
+    expect(res.ok).toBe(true);
+    // The expired entries were pruned to make room; size stays within cap.
+    expect(_internal.buckets.size).toBeLessThanOrEqual(_internal.MAX_BUCKETS);
+    expect(_internal.buckets.has("login:new.client")).toBe(true);
+  });
+
+  it("evicts the oldest entry when nothing is expired and at capacity", () => {
+    vi.useFakeTimers();
+    const future = Date.now() + _internal.WINDOW_MS;
+    for (let i = 0; i < _internal.MAX_BUCKETS; i += 1) {
+      _internal.buckets.set(`login:live-${i}`, { count: 1, resetAt: future });
+    }
+    expect(_internal.buckets.size).toBe(_internal.MAX_BUCKETS);
+
+    // First (oldest) inserted key.
+    expect(_internal.buckets.has("login:live-0")).toBe(true);
+
+    const res = checkRateLimit("fresh.client", "login");
+    expect(res.ok).toBe(true);
+    // Oldest live entry evicted to admit the newcomer.
+    expect(_internal.buckets.has("login:live-0")).toBe(false);
+    expect(_internal.buckets.has("login:fresh.client")).toBe(true);
+    expect(_internal.buckets.size).toBeLessThanOrEqual(_internal.MAX_BUCKETS);
+  });
+});
+
+describe("checkRateLimit DISABLE_RATE_LIMIT in production", () => {
+  beforeEach(() => {
+    _internal.buckets.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("ignores the bypass in production and warns once", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("DISABLE_RATE_LIMIT", "1");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    // Limiting is still enforced despite the bypass flag.
+    for (let i = 0; i < _internal.MAX_ATTEMPTS; i += 1) {
+      expect(checkRateLimit("prod.client", "login").ok).toBe(true);
+    }
+    expect(checkRateLimit("prod.client", "login").ok).toBe(false);
+
+    // The warning fires (at most once across the module lifetime).
+    expect(warn.mock.calls.length).toBeLessThanOrEqual(1);
   });
 });
 

--- a/tests/unit/rating.test.ts
+++ b/tests/unit/rating.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { sliceGlobalShortTable, type RatingUser } from "@/lib/rating";
+
+function makeUser(userId: number, position: number): RatingUser {
+  return {
+    name: `user-${userId}`,
+    user_id: userId,
+    department: "Langenfeld",
+    position,
+    score_sum: 0,
+    sum_win_exact: 0,
+    sum_score_diff: 0,
+    sum_team: 0,
+    extra_point: 0,
+    tips: [],
+  };
+}
+
+function makeGlobal(count: number): RatingUser[] {
+  return Array.from({ length: count }, (_, i) => makeUser(i + 1, i + 1));
+}
+
+describe("sliceGlobalShortTable", () => {
+  it("returns empty rows and no gap for an empty global table", () => {
+    expect(sliceGlobalShortTable([], 1)).toEqual({
+      topRows: [],
+      neighborRows: [],
+      hasGap: false,
+    });
+  });
+
+  it("shows the top 6 and no gap when the current user is unknown", () => {
+    const global = makeGlobal(10);
+    const slice = sliceGlobalShortTable(global, 999);
+    expect(slice.hasGap).toBe(false);
+    expect(slice.neighborRows).toEqual([]);
+    expect(slice.topRows.map((u) => u.user_id)).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  it("shows the top 6 and no gap when the current user is in the top 3", () => {
+    const global = makeGlobal(10);
+    const slice = sliceGlobalShortTable(global, 2);
+    expect(slice.hasGap).toBe(false);
+    expect(slice.neighborRows).toEqual([]);
+    expect(slice.topRows).toHaveLength(6);
+  });
+
+  it("treats the 4th-place user (first of the tail) as no-gap", () => {
+    // userIndexInTail === 0 → not > 0, falls through to the top-6 branch.
+    const global = makeGlobal(10);
+    const slice = sliceGlobalShortTable(global, 4);
+    expect(slice.hasGap).toBe(false);
+    expect(slice.neighborRows).toEqual([]);
+    expect(slice.topRows).toHaveLength(6);
+  });
+
+  it("returns top 3 plus a 3-row neighbor window with a gap for a mid-table user", () => {
+    const global = makeGlobal(10);
+    // current user_id 7 → index 6 → tail index 3 (>0) → gap branch.
+    const slice = sliceGlobalShortTable(global, 7);
+    expect(slice.hasGap).toBe(true);
+    expect(slice.topRows.map((u) => u.user_id)).toEqual([1, 2, 3]);
+    // tail = ids 4..10; tail index 3 → start 2, end 5 → ids 6,7,8.
+    expect(slice.neighborRows.map((u) => u.user_id)).toEqual([6, 7, 8]);
+  });
+
+  it("clamps the neighbor window at the start of the tail (5th-place user)", () => {
+    const global = makeGlobal(10);
+    // current user_id 5 → tail index 1 (>0) → start = max(0, 0) = 0, end = 3.
+    const slice = sliceGlobalShortTable(global, 5);
+    expect(slice.hasGap).toBe(true);
+    expect(slice.neighborRows.map((u) => u.user_id)).toEqual([4, 5, 6]);
+  });
+
+  it("returns only the available neighbors when the user is last", () => {
+    const global = makeGlobal(10);
+    // current user_id 10 → tail index 6 → start 5, end 8 (clamped by slice).
+    const slice = sliceGlobalShortTable(global, 10);
+    expect(slice.hasGap).toBe(true);
+    expect(slice.neighborRows.map((u) => u.user_id)).toEqual([9, 10]);
+  });
+});

--- a/tests/unit/score-tone.test.ts
+++ b/tests/unit/score-tone.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { scoreColor, scoreToneClass, type ScoreTone } from "@/lib/scoring";
+
+describe("scoreColor", () => {
+  it("maps 5 points to success", () => {
+    expect(scoreColor(5)).toBe("success");
+  });
+
+  it("maps 3 points to warning", () => {
+    expect(scoreColor(3)).toBe("warning");
+  });
+
+  it("maps 0 points to danger", () => {
+    expect(scoreColor(0)).toBe("danger");
+  });
+
+  it("maps any other value (e.g. 2) to neutral", () => {
+    expect(scoreColor(2)).toBe("neutral");
+    expect(scoreColor(1)).toBe("neutral");
+    expect(scoreColor(99)).toBe("neutral");
+  });
+});
+
+describe("scoreToneClass", () => {
+  it("returns the matching text class for each tone", () => {
+    const cases: Array<[ScoreTone, string]> = [
+      ["success", "text-success"],
+      ["warning", "text-warning"],
+      ["danger", "text-danger"],
+      ["neutral", "text-neutral"],
+    ];
+    for (const [tone, cls] of cases) {
+      expect(scoreToneClass(tone)).toBe(cls);
+    }
+  });
+
+  it("round-trips scoreColor output into a class", () => {
+    expect(scoreToneClass(scoreColor(5))).toBe("text-success");
+    expect(scoreToneClass(scoreColor(3))).toBe("text-warning");
+    expect(scoreToneClass(scoreColor(0))).toBe("text-danger");
+    expect(scoreToneClass(scoreColor(2))).toBe("text-neutral");
+  });
+});

--- a/tests/unit/tournament.test.ts
+++ b/tests/unit/tournament.test.ts
@@ -1,5 +1,16 @@
-import { describe, expect, it } from "vitest";
-import { isLockedFromTimestamp } from "@/lib/tournament";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const selectRows = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: () => ({
+      from: () => selectRows(),
+    }),
+  },
+}));
+
+import { isLockedFromTimestamp, isTournamentLocked } from "@/lib/tournament";
 
 describe("isLockedFromTimestamp", () => {
   const now = 1_700_000_000_000;
@@ -21,5 +32,34 @@ describe("isLockedFromTimestamp", () => {
   it("returns false when every match is in the future", () => {
     const oneHourFromNowSeconds = Math.floor(now / 1000) + 3600;
     expect(isLockedFromTimestamp(oneHourFromNowSeconds, now)).toBe(false);
+  });
+});
+
+describe("isTournamentLocked", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    selectRows.mockReset();
+  });
+
+  it("is locked when the earliest match kickoff is in the past", async () => {
+    const pastSeconds = Math.floor(Date.now() / 1000) - 3600;
+    selectRows.mockResolvedValue([{ min: pastSeconds }]);
+    await expect(isTournamentLocked()).resolves.toBe(true);
+  });
+
+  it("is not locked when the earliest match kickoff is in the future", async () => {
+    const futureSeconds = Math.floor(Date.now() / 1000) + 3600;
+    selectRows.mockResolvedValue([{ min: futureSeconds }]);
+    await expect(isTournamentLocked()).resolves.toBe(false);
+  });
+
+  it("is not locked when there are no matches (MIN is null)", async () => {
+    selectRows.mockResolvedValue([{ min: null }]);
+    await expect(isTournamentLocked()).resolves.toBe(false);
+  });
+
+  it("is not locked when the query returns no rows", async () => {
+    selectRows.mockResolvedValue([]);
+    await expect(isTournamentLocked()).resolves.toBe(false);
   });
 });


### PR DESCRIPTION
## Background
Several pure-logic and helper modules were only partially covered — push
delivery, the leaderboard slice, tournament lock, score tone, the read-API
client, rate limiting and password validation each had untested branches.

## What this changes
These modules are now fully exercised by unit tests, including their error and
edge paths (failed/expired push endpoints, leaderboard boundaries, rate-limit
window reset and eviction, API error and schema-mismatch handling). No
production code changed.