### PR TITLE
FE-098: hide other players' winner picks until first kickoff

### DIFF
--- a/app/(app)/user/[id]/page.tsx
+++ b/app/(app)/user/[id]/page.tsx
@@ -71,6 +71,9 @@ export default async function UserProfilePage({
   const isOwnProfile = Number(sessionUser.id) === userId;
   const locked = await isTournamentLocked();
   const editable = isOwnProfile && !locked;
+  // Another player's picks stay hidden until the tournament locks (first
+  // kickoff). Redact the values server-side so they never reach the client.
+  const revealPicks = isOwnProfile || locked;
 
   return (
     <>
@@ -97,10 +100,11 @@ export default async function UserProfilePage({
             </div>
             <div className="md:col-span-4">
               <WinnerCards
-                winner={localUser.winner}
-                secretWinner={localUser.secretWinner}
+                winner={revealPicks ? localUser.winner : ""}
+                secretWinner={revealPicks ? localUser.secretWinner : ""}
                 userId={userId}
                 editable={editable}
+                revealed={revealPicks}
               />
             </div>
           </div>

--- a/components/profile/WinnerCards.tsx
+++ b/components/profile/WinnerCards.tsx
@@ -10,6 +10,9 @@ interface WinnerCardsProps {
   secretWinner: string;
   userId: number;
   editable?: boolean;
+  // Whether the actual picks may be shown. False for another player's picks
+  // before the tournament locks (so picks can't be copied before kickoff).
+  revealed?: boolean;
 }
 
 function WinnerCard({
@@ -17,12 +20,14 @@ function WinnerCard({
   tla,
   icon,
   editable,
+  revealed,
   onEdit,
 }: {
   label: string;
   tla: string;
   icon: string;
   editable: boolean;
+  revealed: boolean;
   onEdit: () => void;
 }): React.ReactElement {
   const t = useTranslations("Profile");
@@ -33,14 +38,23 @@ function WinnerCard({
           {label}
         </span>
         <div className="flex items-center gap-md mt-sm">
-          <Flag
-            tla={tla}
-            name={tla}
-            className="w-10 h-auto rounded-sm"
-          />
-          <span className="text-headline-md font-bold uppercase tracking-widest">
-            {tla}
-          </span>
+          {revealed ? (
+            <>
+              <Flag tla={tla} name={tla} className="w-10 h-auto rounded-sm" />
+              <span className="text-headline-md font-bold uppercase tracking-widest">
+                {tla}
+              </span>
+            </>
+          ) : (
+            <>
+              <span className="material-symbols-outlined text-on-surface-variant text-[28px]">
+                lock
+              </span>
+              <span className="text-headline-md font-bold uppercase tracking-widest text-on-surface-variant">
+                {t("picksHidden")}
+              </span>
+            </>
+          )}
         </div>
       </div>
       {editable ? (
@@ -67,6 +81,7 @@ export function WinnerCards({
   secretWinner,
   userId,
   editable = false,
+  revealed = true,
 }: WinnerCardsProps): React.ReactElement {
   const t = useTranslations("Profile");
   const [isEditing, setIsEditing] = useState(false);
@@ -92,6 +107,7 @@ export function WinnerCards({
         tla={winner}
         icon="emoji_events"
         editable={editable}
+        revealed={revealed}
         onEdit={() => setIsEditing(true)}
       />
       <WinnerCard
@@ -99,11 +115,17 @@ export function WinnerCards({
         tla={secretWinner}
         icon="visibility_off"
         editable={editable}
+        revealed={revealed}
         onEdit={() => setIsEditing(true)}
       />
       {editable ? (
         <p className="text-label-caps text-on-surface-variant opacity-70">
           {t("pickDeadlineHint")}
+        </p>
+      ) : null}
+      {!revealed ? (
+        <p className="text-label-caps text-on-surface-variant opacity-70">
+          {t("picksHiddenHint")}
         </p>
       ) : null}
     </div>

--- a/messages/de.json
+++ b/messages/de.json
@@ -161,7 +161,9 @@
     "pageOf": "Seite {current} / {total}",
     "showingCount": "{shown} von {total}",
     "allResults": "Alle anzeigen",
-    "filteredBy": "Gefiltert nach: {category}"
+    "filteredBy": "Gefiltert nach: {category}",
+    "picksHidden": "Verborgen",
+    "picksHiddenHint": "Sichtbar, sobald das erste Spiel begonnen hat."
   },
   "Match": {
     "live": "LIVE",

--- a/messages/en.json
+++ b/messages/en.json
@@ -161,7 +161,9 @@
     "pageOf": "Page {current} / {total}",
     "showingCount": "{shown} of {total}",
     "allResults": "Show all",
-    "filteredBy": "Filtered by: {category}"
+    "filteredBy": "Filtered by: {category}",
+    "picksHidden": "Hidden",
+    "picksHiddenHint": "Visible once the first match has started."
   },
   "Match": {
     "live": "LIVE",


### PR DESCRIPTION
## Background
On another player's profile you could see their tournament winner and secret
winner even before the first match — while everyone can still change their
picks. That lets picks be copied before the deadline.

## What this changes
Another player's winner and secret-winner picks are now hidden until the
tournament locks (the first match kicks off); the cards show a locked
placeholder with a short hint until then. Your own picks are always visible, and
once the tournament locks everyone's picks become visible. The hidden values are
withheld on the server, so they are not present in the page at all before lock.