### PR TITLE
FE-100: change location in settings

### DIFF
--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -7,6 +7,7 @@ import { BottomNav } from "@/components/dashboard/BottomNav";
 import { PasswordChangeForm } from "@/components/settings/PasswordChangeForm";
 import { AvatarUpload } from "@/components/settings/AvatarUpload";
 import { LocaleSwitcher } from "@/components/LocaleSwitcher";
+import { DepartmentSwitcher } from "@/components/settings/DepartmentSwitcher";
 import { InstallApp } from "@/components/InstallApp";
 import { ReminderPreferences } from "@/components/settings/ReminderPreferences";
 import {
@@ -105,6 +106,18 @@ export default async function SettingsPage(): Promise<React.ReactElement> {
                   {t("languageHint")}
                 </p>
                 <LocaleSwitcher />
+              </div>
+            </section>
+
+            <section className="bg-surface-container rounded-lg p-lg border border-outline-variant">
+              <h2 className="text-label-caps uppercase tracking-widest text-primary mb-lg">
+                {t("location")}
+              </h2>
+              <div className="flex items-center justify-between gap-md p-md bg-surface-container-highest border border-outline-variant rounded-lg">
+                <p className="text-body-sm text-on-surface-variant">
+                  {t("locationHint")}
+                </p>
+                <DepartmentSwitcher current={localUser?.department ?? ""} />
               </div>
             </section>
 

--- a/app/api/user/department/route.ts
+++ b/app/api/user/department/route.ts
@@ -1,0 +1,79 @@
+import { getCurrentSession } from "@/lib/session";
+import { updateUserDepartment } from "@/lib/user";
+import { departmentSchema } from "@/lib/validation/department";
+import { checkRateLimit, getClientIp } from "@/lib/rate-limit";
+
+function jsonError(message: string, status: number): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+async function readBody(
+  request: Request,
+): Promise<{ department: unknown } | null> {
+  const contentType = request.headers.get("content-type") ?? "";
+  try {
+    if (contentType.includes("application/json")) {
+      const body = (await request.json()) as Record<string, unknown>;
+      return { department: body.department };
+    }
+    const formData = await request.formData();
+    return { department: formData.get("department") };
+  } catch {
+    return null;
+  }
+}
+
+// Location is a grouping for the per-office leaderboard; it does not affect
+// scoring, so it can be changed at any time (no tournament-lock gate).
+export async function POST(request: Request): Promise<Response> {
+  const { user: sessionUser } = await getCurrentSession();
+  if (!sessionUser) {
+    return jsonError("notLoggedIn", 401);
+  }
+
+  const userId = Number(sessionUser.id);
+  if (!Number.isFinite(userId) || userId <= 0) {
+    return jsonError("notLoggedIn", 401);
+  }
+
+  const ip = getClientIp(request.headers);
+  const limit = checkRateLimit(ip, "department");
+  if (!limit.ok) {
+    return new Response(JSON.stringify({ error: "tooManyRequests" }), {
+      status: 429,
+      headers: {
+        "Content-Type": "application/json",
+        ...(limit.retryAfter ? { "Retry-After": String(limit.retryAfter) } : {}),
+      },
+    });
+  }
+
+  const raw = await readBody(request);
+  if (!raw) {
+    return jsonError("invalidRequestBody", 400);
+  }
+
+  const parsed = departmentSchema.safeParse(raw);
+  if (!parsed.success) {
+    const first = parsed.error.issues[0];
+    return jsonError(first?.message ?? "invalidInput", 400);
+  }
+
+  try {
+    await updateUserDepartment(userId, parsed.data.department);
+  } catch (error) {
+    console.error("[department] update failed", error);
+    return jsonError("failedToUpdate", 500);
+  }
+
+  return new Response(
+    JSON.stringify({ success: true, department: parsed.data.department }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+}

--- a/components/settings/DepartmentSwitcher.tsx
+++ b/components/settings/DepartmentSwitcher.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { DEPARTMENTS, displayDepartment } from "@/lib/data/departments";
+
+export function DepartmentSwitcher({
+  current,
+}: {
+  current: string;
+}): React.ReactElement {
+  const t = useTranslations("Settings");
+  const router = useRouter();
+  const [value, setValue] = useState(current);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function change(next: string): void {
+    if (next === value) return;
+    const previous = value;
+    setValue(next);
+    setError(null);
+    startTransition(async () => {
+      try {
+        const res = await fetch("/api/user/department", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+          },
+          body: JSON.stringify({ department: next }),
+        });
+        if (!res.ok) throw new Error("failed");
+        router.refresh();
+      } catch {
+        setValue(previous);
+        setError(t("locationError"));
+      }
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-xs items-end">
+      <select
+        value={value}
+        onChange={(e) => change(e.target.value)}
+        disabled={pending}
+        aria-label={t("location")}
+        className="bg-surface-container-lowest border border-outline-variant rounded text-body-lg p-md text-on-surface focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary transition-all disabled:opacity-60"
+      >
+        {DEPARTMENTS.map((d) => (
+          <option key={d} value={d}>
+            {displayDepartment(d)}
+          </option>
+        ))}
+      </select>
+      {error ? <p className="text-body-sm text-danger">{error}</p> : null}
+    </div>
+  );
+}

--- a/lib/user.ts
+++ b/lib/user.ts
@@ -92,3 +92,10 @@ export async function updateUserAvatar(
 ): Promise<void> {
   await db.update(user).set({ avatar }).where(eq(user.id, userId));
 }
+
+export async function updateUserDepartment(
+  userId: number,
+  department: string,
+): Promise<void> {
+  await db.update(user).set({ department }).where(eq(user.id, userId));
+}

--- a/lib/validation/department.ts
+++ b/lib/validation/department.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+import { DEPARTMENTS } from "@/lib/data/departments";
+
+export const departmentSchema = z.object({
+  department: z.enum(DEPARTMENTS, { message: "invalidDepartment" }),
+});
+
+export type DepartmentInput = z.infer<typeof departmentSchema>;

--- a/messages/de.json
+++ b/messages/de.json
@@ -281,7 +281,10 @@
     "pushError": "Push konnte nicht aktiviert werden. Bitte erneut versuchen.",
     "pushEnableButton": "Benachrichtigungen aktivieren",
     "pushDisableButton": "Deaktivieren",
-    "pushEnabledStatus": "Benachrichtigungen aktiviert"
+    "pushEnabledStatus": "Benachrichtigungen aktiviert",
+    "location": "Standort",
+    "locationHint": "Dein Büro-Standort für die Standort-Rangliste.",
+    "locationError": "Standort konnte nicht geändert werden."
   },
   "Errors": {
     "invalidEmail": "Ungültige E-Mail-Adresse",

--- a/messages/en.json
+++ b/messages/en.json
@@ -281,7 +281,10 @@
     "pushError": "Could not enable push. Please try again.",
     "pushEnableButton": "Enable notifications",
     "pushDisableButton": "Disable",
-    "pushEnabledStatus": "Notifications enabled"
+    "pushEnabledStatus": "Notifications enabled",
+    "location": "Location",
+    "locationHint": "Your office location for the location leaderboard.",
+    "locationError": "Could not change location."
   },
   "Errors": {
     "invalidEmail": "Invalid email",

--- a/tests/unit/department-route.test.ts
+++ b/tests/unit/department-route.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/session", () => ({ getCurrentSession: vi.fn() }));
+vi.mock("@/lib/user", () => ({ updateUserDepartment: vi.fn() }));
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: vi.fn(),
+  getClientIp: vi.fn(() => "ip"),
+}));
+
+import { getCurrentSession } from "@/lib/session";
+import { updateUserDepartment } from "@/lib/user";
+import { checkRateLimit } from "@/lib/rate-limit";
+import { POST } from "@/app/api/user/department/route";
+
+type Session = Awaited<ReturnType<typeof getCurrentSession>>;
+type Limit = ReturnType<typeof checkRateLimit>;
+
+function req(body: unknown): Request {
+  return new Request("http://localhost/api/user/department", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getCurrentSession).mockResolvedValue({
+    user: { id: "1" },
+  } as Session);
+  vi.mocked(checkRateLimit).mockReturnValue({ ok: true } as Limit);
+  vi.mocked(updateUserDepartment).mockResolvedValue(undefined);
+});
+
+describe("POST /api/user/department", () => {
+  it("rejects an unauthenticated request (401)", async () => {
+    vi.mocked(getCurrentSession).mockResolvedValue({ user: null } as Session);
+    const res = await POST(req({ department: "Siegen" }));
+    expect(res.status).toBe(401);
+    expect(updateUserDepartment).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid department (400)", async () => {
+    const res = await POST(req({ department: "Atlantis" }));
+    expect(res.status).toBe(400);
+    expect(updateUserDepartment).not.toHaveBeenCalled();
+  });
+
+  it("updates a valid department for the session user", async () => {
+    const res = await POST(req({ department: "Siegen" }));
+    expect(res.status).toBe(200);
+    expect(updateUserDepartment).toHaveBeenCalledWith(1, "Siegen");
+    expect(await res.json()).toEqual({ success: true, department: "Siegen" });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    vi.mocked(checkRateLimit).mockReturnValue({ ok: false } as Limit);
+    const res = await POST(req({ department: "Siegen" }));
+    expect(res.status).toBe(429);
+    expect(updateUserDepartment).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Background
A member's office location was only chosen during registration, with no way to
change it afterwards — so anyone who picked the wrong location, or moved offices,
was stuck in the wrong location leaderboard.

## What this changes
Settings now has a Location section where you can switch your office location at
any time; the change takes effect immediately and moves you to that location's
leaderboard. Location is only a grouping and does not affect scoring, so it is
not tied to the tournament-lock deadline.