### PR TITLE
FE-094: bilingual FAQ page

### DIFF
--- a/app/(app)/faq/page.tsx
+++ b/app/(app)/faq/page.tsx
@@ -1,0 +1,49 @@
+import { getTranslations } from "next-intl/server";
+import { TopAppBar } from "@/components/dashboard/TopAppBar";
+import { BottomNav } from "@/components/dashboard/BottomNav";
+import { FAQ_SECTIONS } from "@/lib/faq";
+
+export default async function FaqPage(): Promise<React.ReactElement> {
+  const t = await getTranslations("FAQ");
+
+  return (
+    <>
+      <TopAppBar active="dashboard" />
+      <main className="pt-4 md:pt-24 pb-24 md:pb-8 px-margin-mobile md:px-margin-desktop max-w-(--container-max-desktop) mx-auto">
+        <div className="mb-lg">
+          <h1 className="text-headline-lg font-bold mb-xs">{t("title")}</h1>
+          <p className="text-body-sm text-on-surface-variant">{t("intro")}</p>
+        </div>
+
+        <div className="space-y-xl">
+          {FAQ_SECTIONS.map((section) => (
+            <section key={section.key}>
+              <h2 className="text-body-lg font-bold text-on-background mb-md">
+                {t(`sections.${section.key}.heading`)}
+              </h2>
+              <div className="space-y-sm">
+                {section.items.map((item) => (
+                  <details
+                    key={item}
+                    className="group bg-surface-container rounded-lg border border-outline-variant"
+                  >
+                    <summary className="flex items-center justify-between gap-md cursor-pointer list-none p-lg text-body-lg font-bold text-on-background [&::-webkit-details-marker]:hidden">
+                      {t(`sections.${section.key}.items.${item}.q`)}
+                      <span className="material-symbols-outlined text-on-surface-variant transition-transform group-open:rotate-180">
+                        expand_more
+                      </span>
+                    </summary>
+                    <p className="px-lg pb-lg text-body-sm text-on-surface-variant">
+                      {t(`sections.${section.key}.items.${item}.a`)}
+                    </p>
+                  </details>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      </main>
+      <BottomNav active="dashboard" />
+    </>
+  );
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -24,12 +24,20 @@ export function Footer(): React.ReactElement {
             </div>
           </div>
 
-          <Link
-            href="/features"
-            className="self-center md:self-auto text-label-caps uppercase text-on-surface-variant hover:text-primary transition-colors"
-          >
-            {t("featuresHeading")}
-          </Link>
+          <nav className="flex items-center justify-center gap-lg self-center md:self-auto">
+            <Link
+              href="/features"
+              className="text-label-caps uppercase text-on-surface-variant hover:text-primary transition-colors"
+            >
+              {t("featuresHeading")}
+            </Link>
+            <Link
+              href="/faq"
+              className="text-label-caps uppercase text-on-surface-variant hover:text-primary transition-colors"
+            >
+              {t("faqHeading")}
+            </Link>
+          </nav>
 
           <div className="flex items-center justify-center gap-md self-center md:self-auto">
             <a

--- a/lib/faq.ts
+++ b/lib/faq.ts
@@ -1,0 +1,27 @@
+export const FAQ_SECTIONS = [
+  {
+    key: "rules",
+    items: [
+      "howToTip",
+      "deadline",
+      "regularTimeOnly",
+      "scoring",
+      "winnerBonus",
+      "secretWinner",
+    ],
+  },
+  {
+    key: "ranking",
+    items: ["howRanking", "globalVsDepartment", "liveUpdate"],
+  },
+  {
+    key: "account",
+    items: [
+      "whoCanRegister",
+      "passwordReset",
+      "reminders",
+      "installApp",
+      "languages",
+    ],
+  },
+] as const;

--- a/messages/de.json
+++ b/messages/de.json
@@ -8,7 +8,8 @@
     "settings": "Einstellungen"
   },
   "Footer": {
-    "featuresHeading": "Funktionen"
+    "featuresHeading": "Funktionen",
+    "faqHeading": "FAQ"
   },
   "Install": {
     "title": "App installieren",
@@ -56,6 +57,83 @@
       "languages": {
         "title": "Mehrsprachig",
         "desc": "Komplett auf Deutsch und Englisch, jederzeit umschaltbar."
+      }
+    }
+  },
+  "FAQ": {
+    "title": "Häufig gestellte Fragen",
+    "intro": "Alles Wichtige zum Tipspiel auf einen Blick.",
+    "sections": {
+      "rules": {
+        "heading": "Tippen & Regeln",
+        "items": {
+          "howToTip": {
+            "q": "Wie gebe ich einen Tipp ab?",
+            "a": "Öffne das Dashboard, wähle ein anstehendes Spiel und trage deine Vorhersage für die Tore von Heim- und Gastmannschaft ein. Pro Spiel gibst du genau einen Tipp ab."
+          },
+          "deadline": {
+            "q": "Bis wann kann ich tippen?",
+            "a": "Bis zum Anpfiff. Vorher kannst du deinen Tipp beliebig oft ändern – sobald das Spiel beginnt, ist er gesperrt."
+          },
+          "regularTimeOnly": {
+            "q": "Welche Spielzeit zählt für den Tipp?",
+            "a": "Gewertet wird die reguläre Spielzeit (90 Minuten inklusive Nachspielzeit). In der K.-o.-Phase zählen Verlängerung und Elfmeterschießen nicht mit."
+          },
+          "scoring": {
+            "q": "Wie werden Punkte vergeben?",
+            "a": "5 Punkte für das exakte Ergebnis, 3 Punkte für die richtige Tordifferenz (kein Unentschieden), 2 Punkte für die richtige Tendenz oder ein korrekt getipptes Unentschieden, sonst 0 Punkte."
+          },
+          "winnerBonus": {
+            "q": "Was bringt der Turniersieger-Tipp?",
+            "a": "Wird das von dir offen getippte Team tatsächlich Weltmeister, erhältst du 12 Bonuspunkte."
+          },
+          "secretWinner": {
+            "q": "Was ist der „Secret Winner“?",
+            "a": "Ein zweiter, geheimer Sieger-Tipp, der sich von deinem offenen Tipp unterscheiden muss. Wird dieses Team Weltmeister, bekommst du 6 Bonuspunkte."
+          }
+        }
+      },
+      "ranking": {
+        "heading": "Rangliste & Abteilungen",
+        "items": {
+          "howRanking": {
+            "q": "Wie funktioniert die Rangliste?",
+            "a": "Alle Punkte aus gewerteten Spielen plus deine Boni werden summiert. Die Rangliste sortiert nach der Gesamtpunktzahl."
+          },
+          "globalVsDepartment": {
+            "q": "Was ist der Unterschied zwischen globaler und Abteilungs-Wertung?",
+            "a": "Es gibt eine globale Rangliste über alle Teilnehmenden und je eine Rangliste pro Abteilung (Langenfeld, Mannheim, Mainz). Über die Tabs wechselst du zwischen den Ansichten."
+          },
+          "liveUpdate": {
+            "q": "Wann werden meine Punkte aktualisiert?",
+            "a": "Während laufender Spiele live – Spielstände und Punkte aktualisieren sich automatisch, ohne dass du die Seite neu laden musst."
+          }
+        }
+      },
+      "account": {
+        "heading": "Konto & Technik",
+        "items": {
+          "whoCanRegister": {
+            "q": "Wer kann sich registrieren?",
+            "a": "Alle mit einer gültigen valantic-E-Mail-Adresse."
+          },
+          "passwordReset": {
+            "q": "Ich habe mein Passwort vergessen – was tun?",
+            "a": "Klicke auf der Login-Seite auf „Passwort vergessen?“ und gib deine E-Mail-Adresse ein. Du erhältst einen Link, mit dem du ein neues Passwort setzen kannst."
+          },
+          "reminders": {
+            "q": "Werde ich an Spiele erinnert?",
+            "a": "Nur wenn du es aktivierst. Schalte in den Einstellungen mindestens einen Kanal ein – Push (im Browser bzw. in der installierten App) und/oder E-Mail. Danach wählst du, wie lange vor Anpfiff du erinnert werden möchtest. Ohne aktiven Kanal werden keine Erinnerungen verschickt."
+          },
+          "installApp": {
+            "q": "Kann ich die App installieren?",
+            "a": "Ja. Die App ist eine Progressive Web App und lässt sich über den Browser zum Startbildschirm hinzufügen – inklusive Offline-Unterstützung und Push-Benachrichtigungen."
+          },
+          "languages": {
+            "q": "In welchen Sprachen gibt es die App?",
+            "a": "Deutsch und Englisch. Am Desktop schaltest du die Sprache oben im Kopfbereich um, auf dem Smartphone und in der installierten App in den Einstellungen."
+          }
+        }
       }
     }
   },

--- a/messages/en.json
+++ b/messages/en.json
@@ -8,7 +8,8 @@
     "settings": "Settings"
   },
   "Footer": {
-    "featuresHeading": "Features"
+    "featuresHeading": "Features",
+    "faqHeading": "FAQ"
   },
   "Install": {
     "title": "Install the app",
@@ -56,6 +57,83 @@
       "languages": {
         "title": "Multilingual",
         "desc": "Fully available in German and English, switchable at any time."
+      }
+    }
+  },
+  "FAQ": {
+    "title": "Frequently Asked Questions",
+    "intro": "Everything you need to know about the prediction game at a glance.",
+    "sections": {
+      "rules": {
+        "heading": "Predicting & Rules",
+        "items": {
+          "howToTip": {
+            "q": "How do I submit a prediction?",
+            "a": "Open the dashboard, pick an upcoming match and enter your predicted goals for the home and away team. You submit exactly one prediction per match."
+          },
+          "deadline": {
+            "q": "Until when can I predict?",
+            "a": "Until kick-off. Before that you can change your prediction as often as you like – once the match starts it is locked."
+          },
+          "regularTimeOnly": {
+            "q": "Which part of the match counts for the prediction?",
+            "a": "Only regular time counts (90 minutes including stoppage time). In the knockout stage, extra time and penalty shoot-outs are not included."
+          },
+          "scoring": {
+            "q": "How are points awarded?",
+            "a": "5 points for the exact score, 3 points for the correct goal difference (not a draw), 2 points for the correct tendency or a correctly predicted draw, otherwise 0 points."
+          },
+          "winnerBonus": {
+            "q": "What does the tournament-winner pick give me?",
+            "a": "If the team you openly picked actually wins the World Cup, you earn 12 bonus points."
+          },
+          "secretWinner": {
+            "q": "What is the “secret winner”?",
+            "a": "A second, hidden winner pick that must differ from your open pick. If that team wins the World Cup, you get 6 bonus points."
+          }
+        }
+      },
+      "ranking": {
+        "heading": "Ranking & Departments",
+        "items": {
+          "howRanking": {
+            "q": "How does the ranking work?",
+            "a": "All points from completed matches plus your bonuses are added up. The ranking is sorted by total points."
+          },
+          "globalVsDepartment": {
+            "q": "What is the difference between the global and the department ranking?",
+            "a": "There is a global ranking across all participants and one ranking per department (Langenfeld, Mannheim, Mainz). Use the tabs to switch between the views."
+          },
+          "liveUpdate": {
+            "q": "When are my points updated?",
+            "a": "Live, while matches are in play – scores and points update automatically without you having to reload the page."
+          }
+        }
+      },
+      "account": {
+        "heading": "Account & Tech",
+        "items": {
+          "whoCanRegister": {
+            "q": "Who can register?",
+            "a": "Anyone with a valid valantic email address."
+          },
+          "passwordReset": {
+            "q": "I forgot my password – what now?",
+            "a": "On the login page, click “Forgot password?” and enter your email address. You will receive a link to set a new password."
+          },
+          "reminders": {
+            "q": "Will I be reminded about matches?",
+            "a": "Only if you enable it. In the settings, turn on at least one channel – push (in the browser or the installed app) and/or email. Then choose how long before kick-off you want to be reminded. Without an active channel, no reminders are sent."
+          },
+          "installApp": {
+            "q": "Can I install the app?",
+            "a": "Yes. The app is a Progressive Web App and can be added to your home screen from the browser – including offline support and push notifications."
+          },
+          "languages": {
+            "q": "Which languages does the app support?",
+            "a": "German and English. On desktop you switch the language at the top of the header; on mobile and in the installed app you change it in the settings."
+          }
+        }
       }
     }
   },

--- a/tests/unit/faq-content.test.ts
+++ b/tests/unit/faq-content.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import de from "@/messages/de.json";
+import en from "@/messages/en.json";
+import { FAQ_SECTIONS } from "@/lib/faq";
+
+const CATALOGS = [
+  ["de", de],
+  ["en", en],
+] as const;
+
+const TOTAL_QUESTIONS = 14;
+
+describe("FAQ content", () => {
+  it("config covers the expected number of questions", () => {
+    const count = FAQ_SECTIONS.reduce((sum, s) => sum + s.items.length, 0);
+    expect(count).toBe(TOTAL_QUESTIONS);
+  });
+
+  it("has no duplicate question keys across sections", () => {
+    const keys = FAQ_SECTIONS.flatMap((s) => s.items);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  for (const [label, catalog] of CATALOGS) {
+    describe(`${label} catalog`, () => {
+      const faq = (catalog as Record<string, unknown>).FAQ as
+        | Record<string, unknown>
+        | undefined;
+
+      it("has a title and intro", () => {
+        expect(faq).toBeDefined();
+        expect(typeof faq?.title).toBe("string");
+        expect(typeof faq?.intro).toBe("string");
+      });
+
+      it("states the bonus point values that mirror betting-api", () => {
+        const items = ((
+          faq?.sections as Record<
+            string,
+            { items?: Record<string, { a?: string }> }
+          >
+        )?.rules?.items ?? {}) as Record<string, { a?: string }>;
+        expect(items.winnerBonus?.a, `${label} winner bonus`).toContain("12");
+        expect(items.secretWinner?.a, `${label} secret winner bonus`).toContain(
+          "6",
+        );
+      });
+
+      it("provides a heading and a non-empty q/a for every configured item", () => {
+        const sections = faq?.sections as Record<string, unknown> | undefined;
+        expect(sections).toBeDefined();
+
+        for (const section of FAQ_SECTIONS) {
+          const node = sections?.[section.key] as
+            | { heading?: unknown; items?: Record<string, unknown> }
+            | undefined;
+          expect(node, `${label}.FAQ.sections.${section.key}`).toBeDefined();
+          expect(typeof node?.heading).toBe("string");
+
+          for (const item of section.items) {
+            const qa = node?.items?.[item] as
+              | { q?: unknown; a?: unknown }
+              | undefined;
+            const path = `${label}.FAQ.sections.${section.key}.items.${item}`;
+            expect(typeof qa?.q, `${path}.q`).toBe("string");
+            expect(typeof qa?.a, `${path}.a`).toBe("string");
+            expect((qa?.q as string).length, `${path}.q`).toBeGreaterThan(0);
+            expect((qa?.a as string).length, `${path}.a`).toBeGreaterThan(0);
+          }
+        }
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Background

The footer only linked the `/features` page; there was no single place that answered the common questions about the Tipspiel (how predicting works, scoring, bonuses, ranking, account/tech). This adds a dedicated FAQ page so users can self-serve these answers, in both German and English like the rest of the app.

## What this changes

- Adds a new `/faq` page reachable from the footer (next to "Funktionen"), under the authenticated app layout and using the same layout as `/features`.
- Presents 14 questions across three sections — Predicting & Rules, Ranking & Departments, Account & Tech — as a native `<details>` accordion with no client-side JavaScript.
- Adds full German and English copy. Rules content matches the backend scoring (exact 5 / goal-difference 3 / tendency 2 / 0, winner bonus +12, secret-winner bonus +6), clarifies that only regular 90-minute time counts (no extra time or penalties in the knockout stage), that reminders require enabling a push and/or email channel in settings first, and where the language switch lives (desktop header vs. mobile/PWA settings).
- Adds a unit test covering question-key coverage, German/English question/answer presence, and the bonus point values to guard against content drift.