### PR TITLE
XR-009: normalize seed team codes (GER not DEU) + guard

### DIFF
--- a/scripts/demo_data.ts
+++ b/scripts/demo_data.ts
@@ -1,16 +1,9 @@
 import Database from "better-sqlite3";
 import { Argon2id } from "oslo/password";
 import path from "node:path";
+import { USERS, type SeedUser } from "./seed-users";
 
 type TeamRef = { name: string; tla: string };
-
-type SeedUser = {
-  email: string;
-  username: string;
-  department: string;
-  winner: string;
-  secretWinner: string;
-};
 
 type SeedMatch = {
   id: number;
@@ -41,64 +34,6 @@ const TEAM = {
   CRO: { name: "Croatia", tla: "CRO" },
 } as const;
 
-const USERS: SeedUser[] = [
-  {
-    email: "ada.lovelace@local.dev",
-    username: "AdaLovelace",
-    department: "Mainz",
-    winner: "DEU",
-    secretWinner: "ESP",
-  },
-  {
-    email: "alan.turing@local.dev",
-    username: "AlanTuring",
-    department: "Mainz",
-    winner: "ENG",
-    secretWinner: "FRA",
-  },
-  {
-    email: "marie.curie@local.dev",
-    username: "MarieCurie",
-    department: "Mannheim",
-    winner: "FRA",
-    secretWinner: "DEU",
-  },
-  {
-    email: "nikola.tesla@local.dev",
-    username: "NikolaTesla",
-    department: "Mannheim",
-    winner: "HRV",
-    secretWinner: "ITA",
-  },
-  {
-    email: "rosa.parks@local.dev",
-    username: "RosaParks",
-    department: "Mannheim",
-    winner: "ESP",
-    secretWinner: "POR",
-  },
-  {
-    email: "test.user@local.dev",
-    username: "TestUser",
-    department: "Langenfeld",
-    winner: "DEU",
-    secretWinner: "NLD",
-  },
-  {
-    email: "albert.einstein@local.dev",
-    username: "AlbertEinstein",
-    department: "Langenfeld",
-    winner: "DEU",
-    secretWinner: "ITA",
-  },
-  {
-    email: "isaac.newton@local.dev",
-    username: "IsaacNewton",
-    department: "Langenfeld",
-    winner: "POR",
-    secretWinner: "ENG",
-  },
-];
 
 function buildMatches(now: number): SeedMatch[] {
   const HOUR = 3_600_000;

--- a/scripts/seed-users.ts
+++ b/scripts/seed-users.ts
@@ -1,0 +1,73 @@
+// Demo users for the seed. Extracted so a unit test can assert the
+// winner/secretWinner codes are valid signup team codes (see
+// tests/unit/seed-team-codes.test.ts) — a mismatch silently breaks the
+// tournament-winner bonus, since scoring compares the stored code against
+// TOURNAMENT_WINNER. Codes must be the football-data TLAs used by the signup
+// form in lib/data/teams.ts (e.g. Germany is "GER", not the ISO3 "DEU").
+
+export type SeedUser = {
+  email: string;
+  username: string;
+  department: string;
+  winner: string;
+  secretWinner: string;
+};
+
+export const USERS: SeedUser[] = [
+  {
+    email: "ada.lovelace@local.dev",
+    username: "AdaLovelace",
+    department: "Mainz",
+    winner: "GER",
+    secretWinner: "ESP",
+  },
+  {
+    email: "alan.turing@local.dev",
+    username: "AlanTuring",
+    department: "Mainz",
+    winner: "ENG",
+    secretWinner: "FRA",
+  },
+  {
+    email: "marie.curie@local.dev",
+    username: "MarieCurie",
+    department: "Mannheim",
+    winner: "FRA",
+    secretWinner: "GER",
+  },
+  {
+    email: "nikola.tesla@local.dev",
+    username: "NikolaTesla",
+    department: "Mannheim",
+    winner: "CRO",
+    secretWinner: "BRA",
+  },
+  {
+    email: "rosa.parks@local.dev",
+    username: "RosaParks",
+    department: "Mannheim",
+    winner: "ESP",
+    secretWinner: "POR",
+  },
+  {
+    email: "test.user@local.dev",
+    username: "TestUser",
+    department: "Langenfeld",
+    winner: "GER",
+    secretWinner: "NED",
+  },
+  {
+    email: "albert.einstein@local.dev",
+    username: "AlbertEinstein",
+    department: "Langenfeld",
+    winner: "GER",
+    secretWinner: "BRA",
+  },
+  {
+    email: "isaac.newton@local.dev",
+    username: "IsaacNewton",
+    department: "Langenfeld",
+    winner: "POR",
+    secretWinner: "ENG",
+  },
+];

--- a/tests/e2e/profile.spec.ts
+++ b/tests/e2e/profile.spec.ts
@@ -42,13 +42,13 @@ test.describe("profile page", () => {
   test("secretWinner is public on every profile", async ({ page }) => {
     await login(page);
 
-    // Own profile (user 6 = TestUser, secretWinner = NLD per FE-007 seed)
+    // Own profile (user 6 = TestUser, secretWinner = NED per seed)
     await page.goto("/user/6");
     const ownSecretCard = page
       .locator("div", { hasText: "SECRET WINNER" })
       .first();
     await expect(ownSecretCard).toBeVisible();
-    await expect(ownSecretCard).toContainText("NLD");
+    await expect(ownSecretCard).toContainText("NED");
 
     // Another user's profile (user 1 = AdaLovelace, secretWinner = ESP per FE-007 seed)
     await page.goto("/user/1");
@@ -58,8 +58,8 @@ test.describe("profile page", () => {
     await expect(otherSecretCard).toBeVisible();
     await expect(otherSecretCard).toContainText("ESP");
 
-    // Tournament Winner is also public — AdaLovelace.winner = DEU
+    // Tournament Winner is also public — AdaLovelace.winner = GER
     await expect(page.locator("body")).toContainText("TOURNAMENT WINNER");
-    await expect(page.locator("body")).toContainText("DEU");
+    await expect(page.locator("body")).toContainText("GER");
   });
 });

--- a/tests/unit/seed-team-codes.test.ts
+++ b/tests/unit/seed-team-codes.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { USERS } from "@/scripts/seed-users";
+import { TEAMS } from "@/lib/data/teams";
+
+// Guards the bug XR-009 fixed: a seeded winner/secretWinner that is not a code
+// the signup form offers (e.g. ISO3 "DEU" instead of the football-data TLA
+// "GER", or a team not in the tournament) silently breaks the tournament-winner
+// bonus, because scoring compares the stored code against TOURNAMENT_WINNER.
+describe("seed team codes", () => {
+  const validCodes = new Set<string>(TEAMS.map((t) => t.code));
+
+  it("every seeded winner/secretWinner is a code the signup form offers", () => {
+    for (const u of USERS) {
+      expect(validCodes.has(u.winner), `${u.username} winner=${u.winner}`).toBe(
+        true,
+      );
+      expect(
+        validCodes.has(u.secretWinner),
+        `${u.username} secretWinner=${u.secretWinner}`,
+      ).toBe(true);
+    }
+  });
+
+  it("winner and secretWinner differ for every seeded user", () => {
+    for (const u of USERS) {
+      expect(u.winner, u.username).not.toBe(u.secretWinner);
+    }
+  });
+});


### PR DESCRIPTION
## Background

A user who registers via the signup form stores their winner pick as the football-data team code (Germany = "GER"), while the demo seed used the ISO3 "DEU". Scoring compares the stored code against the configured tournament winner, so a form-registered Germany pick would never earn the bonus. Production was checked and already uses the football-data codes consistently, so this is a seed/test-data and guard fix only — no data migration.

## What this changes

- Normalizes the demo seed's winner/secret-winner codes to the codes the signup form offers (GER, CRO, NED, and a real tournament team in place of Italy), extracting the user list so it can be tested.
- Adds a unit guard that every seeded pick is a valid signup team code and that the two picks differ — this would have caught the original mismatch.
- Updates the affected profile end-to-end assertions to the new codes.