### PR TITLE
FE-096: E2E for password reset + email reminders

### DIFF
--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -1,9 +1,46 @@
 import { expect, type Page } from "@playwright/test";
+import Database from "better-sqlite3";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { generateResetToken, hashResetToken } from "@/lib/password-reset";
 
 // Mirrors playwright.config.ts so request-context specs can send a same-origin
 // CSRF `Origin` header that matches the dynamically-chosen frontend port.
 const FRONTEND_PORT = Number(process.env.E2E_FRONTEND_PORT ?? 3100);
 export const ORIGIN = `http://localhost:${FRONTEND_PORT}`;
+
+// Same shared test DB the global setup migrates + seeds (see setup.ts).
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const FRONTEND_ROOT = path.resolve(HERE, "../..");
+const TEST_DB = path.resolve(FRONTEND_ROOT, "../shared/db/test.db");
+
+/**
+ * Issue a valid password-reset token for a user straight into the DB and return
+ * the raw token. The raw token only ever lives in the email, so an E2E that
+ * drives /reset-password seeds it the same way the route would: store the hash,
+ * hand the caller the raw value. Mirrors lib/password-reset-store.
+ */
+export function seedResetToken(email: string): string {
+  const db = new Database(TEST_DB);
+  try {
+    const row = db
+      .prepare("SELECT id FROM user WHERE email = ?")
+      .get(email) as { id: number } | undefined;
+    if (!row) {
+      throw new Error(`seedResetToken: no user for ${email}`);
+    }
+    const token = generateResetToken();
+    const tokenHash = hashResetToken(token);
+    // expires_at is a Drizzle `timestamp` column → stored as unix seconds.
+    const expiresAt = Math.floor((Date.now() + 60 * 60 * 1000) / 1000);
+    db.prepare(
+      "INSERT INTO password_reset_token (user_id, token_hash, expires_at) VALUES (?, ?, ?)",
+    ).run(row.id, tokenHash, expiresAt);
+    return token;
+  } finally {
+    db.close();
+  }
+}
 
 // Canonical seeded accounts (see frontend/scripts/demo_data.ts). Every seeded
 // user shares the password below. TEST_USER is id 6 and is the account most

--- a/tests/e2e/password-reset.spec.ts
+++ b/tests/e2e/password-reset.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "@playwright/test";
+import { login, logout, signupNewUser, seedResetToken, PASSWORD } from "./helpers";
+
+test.describe("password reset", () => {
+  test("forgot-password shows the generic confirmation", async ({ page }) => {
+    await page.goto("/forgot-password");
+    await page.fill("#email", "whoever@e2e.local");
+    await page.click("button[type=submit]");
+
+    // Generic message regardless of whether the email exists (no enumeration).
+    await expect(
+      page.getByText("If that email is registered, we have sent a reset link."),
+    ).toBeVisible();
+  });
+
+  test("a reset token sets a new password; old password stops working", async ({
+    page,
+  }) => {
+    const account = await signupNewUser(page, "reset");
+    const token = seedResetToken(account.email);
+    const newPassword = "newpass-9876";
+
+    await page.goto(`/reset-password?token=${token}`);
+    await page.fill("#newPassword", newPassword);
+    await page.fill("#confirmPassword", newPassword);
+    await page.click("button[type=submit]");
+    await expect(
+      page.getByText("Your password has been updated. You can now sign in."),
+    ).toBeVisible();
+
+    // The new password signs in (login() waits for the dashboard).
+    await login(page, account.email, newPassword);
+    await logout(page);
+
+    // The old password is now rejected — stays on /login.
+    await page.goto("/login");
+    await page.fill("#email", account.email);
+    await page.fill("#password", PASSWORD);
+    await page.click("button[type=submit]");
+    await expect(page.getByText("Email or password incorrect.")).toBeVisible();
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test("an invalid reset token is rejected", async ({ page }) => {
+    await page.goto("/reset-password?token=not-a-real-token");
+    await page.fill("#newPassword", "whatever-9999");
+    await page.fill("#confirmPassword", "whatever-9999");
+    await page.click("button[type=submit]");
+
+    // No success message — the form surfaces an error and stays put.
+    await expect(
+      page.getByText("Your password has been updated. You can now sign in."),
+    ).toHaveCount(0);
+  });
+});

--- a/tests/e2e/reminders.spec.ts
+++ b/tests/e2e/reminders.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test, type Page } from "@playwright/test";
+import { login } from "./helpers";
+
+const emailToggle = (page: Page) =>
+  page.getByRole("checkbox", { name: "Email reminders" });
+
+const oneHourLead = (page: Page) =>
+  page.getByRole("checkbox", { name: "1 hour before" });
+
+test.describe("email reminders", () => {
+  test("lead-time selection persists; disabling channels locks the controls", async ({
+    page,
+  }) => {
+    await login(page); // TEST_USER — email reminders are on by default (FE-073)
+    await page.goto("/settings");
+
+    await expect(emailToggle(page)).toBeChecked();
+    // Email on => at least one channel active => lead-time controls usable.
+    await expect(oneHourLead(page)).toBeEnabled();
+
+    await oneHourLead(page).check();
+    await page.getByRole("button", { name: "Save reminders" }).click();
+    await expect(page.getByText("Reminders saved.")).toBeVisible();
+
+    // Persists across a reload.
+    await page.goto("/settings");
+    await expect(oneHourLead(page)).toBeChecked();
+    await expect(emailToggle(page)).toBeChecked();
+
+    // Turning the email channel off (push is off) locks the lead-time controls.
+    // The toggle persists via a fetch then flips state, so click + assert the
+    // resulting state rather than uncheck() (which checks the state eagerly).
+    await emailToggle(page).click();
+    await expect(emailToggle(page)).not.toBeChecked();
+    await expect(
+      page.getByText("Enable email or push to receive reminders."),
+    ).toBeVisible();
+    await expect(oneHourLead(page)).toBeDisabled();
+
+    // Leave the shared seeded user back in its default (email on) state.
+    await emailToggle(page).click();
+    await expect(emailToggle(page)).toBeChecked();
+    await expect(oneHourLead(page)).toBeEnabled();
+  });
+});


### PR DESCRIPTION
## Background

Two user-facing flows had store, route and unit coverage but no end-to-end test (a gap surfaced while adding E2E to CI in FE-095): completing a password reset, and the reminder settings. This adds the missing browser-level coverage; the mail-send and forgot-password route are already unit-tested, so nothing is duplicated.

## What this changes

- Adds an end-to-end test for password reset: the forgot-password page shows the generic confirmation, a valid reset link lets a newly registered user set a new password and sign in with it (the old password is then rejected), and an invalid link is refused. The reset token is issued straight into the test database the same way the email link would carry it, so no mail server is needed.
- Adds an end-to-end test for the email reminder settings: reminders are on by default, choosing a lead time and saving persists across a reload, and turning the email channel off (with push off) locks the lead-time controls and shows the prompt to enable a channel.
- Push reminders are intentionally out of scope (they need a service worker).