### PR TITLE
FE-098: Fühlingen org name + full email on profile

### DIFF
--- a/app/(app)/user/[id]/page.tsx
+++ b/app/(app)/user/[id]/page.tsx
@@ -12,6 +12,7 @@ import { PredictionHistory } from "@/components/profile/PredictionHistory";
 import { HistoryFilterProvider } from "@/components/profile/HistoryFilterContext";
 import { isTournamentLocked } from "@/lib/tournament";
 import { displayNameFromEmail } from "@/lib/user-name";
+import { getBrand } from "@/lib/brand";
 import { Avatar } from "@/components/Avatar";
 
 interface UserPageProps {
@@ -91,7 +92,11 @@ export default async function UserProfilePage({
                 />
                 <ProfileHeader
                   username={localUser.username}
-                  displayName={displayNameFromEmail(localUser.email)}
+                  displayName={
+                    getBrand().displayFullEmail
+                      ? localUser.email
+                      : displayNameFromEmail(localUser.email)
+                  }
                   position={position}
                   totalPoints={totalPoints}
                 />

--- a/lib/brand/brands/fuhlingen.ts
+++ b/lib/brand/brands/fuhlingen.ts
@@ -2,9 +2,10 @@ import type { Brand } from "@/lib/brand/types";
 
 export const fuhlingen: Brand = {
   id: "fuhlingen",
-  org: "fuhlingen",
+  org: "Fühlingen",
   departments: ["A-Jugend", "Herren", "Andere"],
   emailPolicy: "all",
+  displayFullEmail: true,
   githubUrl: "https://github.com/football-betting",
   assets: {
     icon192: "/brands/fuhlingen/icon-192.png",

--- a/lib/brand/brands/valantic.ts
+++ b/lib/brand/brands/valantic.ts
@@ -5,6 +5,7 @@ export const valantic: Brand = {
   org: "valantic",
   departments: ["Langenfeld", "Mannheim", "Mainz", "Siegen"],
   emailPolicy: { allowedDomains: ["valantic.com"] },
+  displayFullEmail: false,
   githubUrl: "https://github.com/football-betting",
   assets: {
     icon192: "/icon/icon-192.png",

--- a/lib/brand/types.ts
+++ b/lib/brand/types.ts
@@ -9,6 +9,8 @@ export interface Brand {
   departments: readonly [string, ...string[]];
   /** `"all"` allows any valid email; otherwise only the listed domains. */
   emailPolicy: EmailPolicy;
+  /** Profile page: show the full email address instead of a name derived from it. */
+  displayFullEmail: boolean;
   githubUrl: string;
   assets: {
     /** PWA manifest icons. */

--- a/tests/unit/brand.test.ts
+++ b/tests/unit/brand.test.ts
@@ -25,9 +25,10 @@ describe("getBrand", () => {
     process.env.NEXT_PUBLIC_BRAND = "fuhlingen";
     const brand = getBrand();
     expect(brand.id).toBe("fuhlingen");
-    expect(brand.org).toBe("fuhlingen");
+    expect(brand.org).toBe("Fühlingen");
     expect(brand.departments).toEqual(["A-Jugend", "Herren", "Andere"]);
     expect(brand.emailPolicy).toBe("all");
+    expect(brand.displayFullEmail).toBe(true);
   });
 
   it("falls back to valantic for an unknown brand", () => {


### PR DESCRIPTION
## Background
The second brand was registered under the lowercase placeholder "fuhlingen" and, on the profile page, a user's identity was shown as a name derived from their email (the part after @ was dropped). For this audience the full email should be visible, and the brand name should use its proper spelling.

## What this changes
The brand now presents itself as "Fühlingen" everywhere its name appears. On the profile page, the Fühlingen brand shows each user's full email address instead of a shortened, derived name, so members can be identified clearly. The valantic brand is unchanged in both respects.