### PR TITLE
FE-099: show live matches during halftime

### DIFF
--- a/lib/match.ts
+++ b/lib/match.ts
@@ -41,7 +41,10 @@ function rowToMatch(row: typeof match.$inferSelect): MatchRow | null {
 }
 
 export async function getLiveMatches(): Promise<MatchRow[]> {
-  const rows = await db.select().from(match).where(eq(match.status, "IN_PLAY"));
+  const rows = await db
+    .select()
+    .from(match)
+    .where(inArray(match.status, ["IN_PLAY", "PAUSED"]));
   return rows
     .map(rowToMatch)
     .filter((m): m is MatchRow => m !== null)

--- a/tests/integration/match.integration.test.ts
+++ b/tests/integration/match.integration.test.ts
@@ -1,7 +1,32 @@
 import { describe, expect, it } from "vitest";
-import { getLiveState, getMatchById, getUpcomingMatches } from "@/lib/match";
+import {
+  getLiveMatches,
+  getLiveState,
+  getMatchById,
+  getUpcomingMatches,
+} from "@/lib/match";
 import { isUpcomingStatus } from "@/lib/reminders";
+import { db } from "@/lib/db";
+import { match } from "@/db/schema";
 import { first } from "./helpers";
+
+const TEAM = { name: "Test FC", tla: "TST" };
+
+async function insertMatch(id: number, status: string, utcDate: Date) {
+  await db
+    .insert(match)
+    .values({
+      id,
+      homeTeam: TEAM,
+      awayTeam: { name: "Other FC", tla: "OTH" },
+      status,
+      utcDate,
+      score: null,
+      homeScore: null,
+      awayScore: null,
+    })
+    .onConflictDoUpdate({ target: match.id, set: { status } });
+}
 
 describe("match store (seeded demo data)", () => {
   it("returns upcoming matches: all future, SCHEDULED/TIMED, ascending", async () => {
@@ -31,5 +56,19 @@ describe("match store (seeded demo data)", () => {
   it("reports the next kickoff via getLiveState", async () => {
     const state = await getLiveState();
     expect(state.nextKickoff).not.toBeNull();
+  });
+
+  it("includes IN_PLAY and PAUSED (halftime) matches in the live block", async () => {
+    const inPlayId = -9001;
+    const pausedId = -9002;
+    await insertMatch(inPlayId, "IN_PLAY", new Date("2026-06-01T18:00:00Z"));
+    await insertMatch(pausedId, "PAUSED", new Date("2026-06-01T20:00:00Z"));
+
+    const liveIds = (await getLiveMatches()).map((m) => m.id);
+    expect(liveIds).toContain(inPlayId);
+    expect(liveIds).toContain(pausedId);
+
+    const upcomingIds = (await getUpcomingMatches()).map((m) => m.id);
+    expect(upcomingIds).not.toContain(pausedId);
   });
 });


### PR DESCRIPTION
## Background
A match that is genuinely live disappears from the dashboard's live block as
soon as it goes into halftime. Users see no live game even though one is in
progress — the auto-refresh keeps running and the match detail page still
shows it as live, but the dashboard's live section is empty. This undermines
live tracking exactly when people are watching.

## What this changes
The dashboard live block now keeps a match visible throughout halftime, in
line with how the rest of the app already treats a paused match as live. A
running game stays on the dashboard from kickoff until it is finished, with no
gap over the break.